### PR TITLE
Modifications to the Nuclear Blast Algorithm

### DIFF
--- a/com/hbm/blocks/ModBlocks.java
+++ b/com/hbm/blocks/ModBlocks.java
@@ -20,6 +20,7 @@ import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.material.MaterialLiquid;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.init.Blocks;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 
@@ -532,25 +533,24 @@ public class ModBlocks {
 		gravel_obsidian = new BlockFalling(Material.iron).setBlockName("gravel_obsidian").setCreativeTab(MainRegistry.tabBlock).setStepSound(Block.soundTypeGravel).setHardness(5.0F).setResistance(600.0F).setBlockTextureName(RefStrings.MODID + ":gravel_obsidian");
 		asphalt = new BlockGeneric(Material.rock).setBlockName("asphalt").setCreativeTab(MainRegistry.tabBlock).setLightOpacity(15).setHardness(15.0F).setResistance(100.0F).setBlockTextureName(RefStrings.MODID + ":asphalt");
 
-		reinforced_brick = new BlockGeneric(Material.rock).setBlockName("reinforced_brick").setCreativeTab(MainRegistry.tabBlock).setLightOpacity(15).setHardness(15.0F).setResistance(6000.0F).setBlockTextureName(RefStrings.MODID + ":reinforced_brick");
-		reinforced_glass = new ReinforcedBlock(Material.glass).setBlockName("reinforced_glass").setCreativeTab(MainRegistry.tabBlock).setLightOpacity(0).setHardness(15.0F).setResistance(6000.0F).setBlockTextureName(RefStrings.MODID + ":reinforced_glass");
-		reinforced_light = new ReinforcedBlock(Material.rock).setBlockName("reinforced_light").setCreativeTab(MainRegistry.tabBlock).setLightOpacity(15).setLightLevel(1.0F).setHardness(15.0F).setResistance(6000.0F).setBlockTextureName(RefStrings.MODID + ":reinforced_light");
-		reinforced_sand = new BlockGeneric(Material.rock).setBlockName("reinforced_sand").setCreativeTab(MainRegistry.tabBlock).setLightOpacity(15).setHardness(15.0F).setResistance(6000.0F).setBlockTextureName(RefStrings.MODID + ":reinforced_sand");
-		reinforced_lamp_off = new ReinforcedLamp(Material.rock, false).setBlockName("reinforced_lamp_off").setCreativeTab(MainRegistry.tabBlock).setHardness(15.0F).setResistance(6000.0F).setBlockTextureName(RefStrings.MODID + ":reinforced_lamp_off");
-		reinforced_lamp_on = new ReinforcedLamp(Material.rock, true).setBlockName("reinforced_lamp_on").setHardness(15.0F).setResistance(6000.0F).setBlockTextureName(RefStrings.MODID + ":reinforced_lamp_on");
+		reinforced_brick = new BlockGeneric(Material.rock).setBlockName("reinforced_brick").setCreativeTab(MainRegistry.tabBlock).setLightOpacity(15).setHardness(15.0F).setResistance(1000.0F).setBlockTextureName(RefStrings.MODID + ":reinforced_brick");
+		reinforced_glass = new ReinforcedBlock(Material.glass).setBlockName("reinforced_glass").setCreativeTab(MainRegistry.tabBlock).setLightOpacity(0).setHardness(15.0F).setResistance(3000.0F).setBlockTextureName(RefStrings.MODID + ":reinforced_glass");
+		reinforced_light = new ReinforcedBlock(Material.rock).setBlockName("reinforced_light").setCreativeTab(MainRegistry.tabBlock).setLightOpacity(15).setLightLevel(1.0F).setHardness(15.0F).setResistance(1000.0F).setBlockTextureName(RefStrings.MODID + ":reinforced_light");
+		reinforced_sand = new BlockGeneric(Material.rock).setBlockName("reinforced_sand").setCreativeTab(MainRegistry.tabBlock).setLightOpacity(15).setHardness(15.0F).setResistance(4000.0F).setBlockTextureName(RefStrings.MODID + ":reinforced_sand");
+		reinforced_lamp_off = new ReinforcedLamp(Material.rock, false).setBlockName("reinforced_lamp_off").setCreativeTab(MainRegistry.tabBlock).setHardness(15.0F).setResistance(1000.0F).setBlockTextureName(RefStrings.MODID + ":reinforced_lamp_off");
+		reinforced_lamp_on = new ReinforcedLamp(Material.rock, true).setBlockName("reinforced_lamp_on").setHardness(15.0F).setResistance(1000.0F).setBlockTextureName(RefStrings.MODID + ":reinforced_lamp_on");
 
-		brick_concrete = new BlockGeneric(Material.rock).setBlockName("brick_concrete").setCreativeTab(MainRegistry.tabBlock).setLightOpacity(15).setHardness(15.0F).setResistance(6000.0F).setBlockTextureName(RefStrings.MODID + ":brick_concrete");
+		brick_concrete = new BlockGeneric(Material.rock).setBlockName("brick_concrete").setCreativeTab(MainRegistry.tabBlock).setLightOpacity(15).setHardness(15.0F).setResistance(4000.0F).setBlockTextureName(RefStrings.MODID + ":brick_concrete");
 		brick_obsidian = new BlockGeneric(Material.rock).setBlockName("brick_obsidian").setCreativeTab(MainRegistry.tabBlock).setLightOpacity(15).setHardness(15.0F).setResistance(6000.0F).setBlockTextureName(RefStrings.MODID + ":brick_obsidian");
-		brick_light = new BlockGeneric(Material.rock).setBlockName("brick_light").setCreativeTab(MainRegistry.tabBlock).setLightOpacity(15).setHardness(15.0F).setResistance(60.0F).setBlockTextureName(RefStrings.MODID + ":brick_light");
-
+		brick_light = new BlockGeneric(Material.rock).setBlockName("brick_light").setCreativeTab(MainRegistry.tabBlock).setLightOpacity(15).setHardness(15.0F).setResistance(1000.0F).setBlockTextureName(RefStrings.MODID + ":brick_light");
 		cmb_brick = new BlockGeneric(Material.rock).setBlockName("cmb_brick").setCreativeTab(MainRegistry.tabBlock).setHardness(25.0F).setResistance(6000.0F).setBlockTextureName(RefStrings.MODID + ":cmb_brick");
 		cmb_brick_reinforced = new BlockGeneric(Material.rock).setBlockName("cmb_brick_reinforced").setCreativeTab(MainRegistry.tabBlock).setHardness(25.0F).setResistance(60000.0F).setBlockTextureName(RefStrings.MODID + ":cmb_brick_reinforced");
 
-		block_meteor = new BlockOre(Material.rock).setBlockName("block_meteor").setCreativeTab(MainRegistry.tabBlock).setHardness(15.0F).setResistance(6000.0F).setBlockTextureName(RefStrings.MODID + ":block_meteor");
-		block_meteor_cobble = new BlockOre(Material.rock).setBlockName("block_meteor_cobble").setCreativeTab(MainRegistry.tabBlock).setHardness(15.0F).setResistance(6000.0F).setBlockTextureName(RefStrings.MODID + ":block_meteor_cobble");
-		block_meteor_broken = new BlockOre(Material.rock).setBlockName("block_meteor_broken").setCreativeTab(MainRegistry.tabBlock).setHardness(15.0F).setResistance(6000.0F).setBlockTextureName(RefStrings.MODID + ":block_meteor_broken");
-		block_meteor_molten = new BlockOre(Material.rock).setBlockName("block_meteor_molten").setLightLevel(0.75F).setCreativeTab(MainRegistry.tabBlock).setHardness(15.0F).setResistance(6000.0F).setBlockTextureName(RefStrings.MODID + ":block_meteor_molten");
-		block_meteor_treasure = new BlockOre(Material.rock).setBlockName("block_meteor_treasure").setCreativeTab(MainRegistry.tabBlock).setHardness(15.0F).setResistance(6000.0F).setBlockTextureName(RefStrings.MODID + ":block_meteor_treasure");
+		block_meteor = new BlockOre(Material.rock).setBlockName("block_meteor").setCreativeTab(MainRegistry.tabBlock).setHardness(15.0F).setResistance(900.0F).setBlockTextureName(RefStrings.MODID + ":block_meteor");
+		block_meteor_cobble = new BlockOre(Material.rock).setBlockName("block_meteor_cobble").setCreativeTab(MainRegistry.tabBlock).setHardness(15.0F).setResistance(900.0F).setBlockTextureName(RefStrings.MODID + ":block_meteor_cobble");
+		block_meteor_broken = new BlockOre(Material.rock).setBlockName("block_meteor_broken").setCreativeTab(MainRegistry.tabBlock).setHardness(15.0F).setResistance(900.0F).setBlockTextureName(RefStrings.MODID + ":block_meteor_broken");
+		block_meteor_molten = new BlockOre(Material.rock).setBlockName("block_meteor_molten").setLightLevel(0.75F).setCreativeTab(MainRegistry.tabBlock).setHardness(15.0F).setResistance(900.0F).setBlockTextureName(RefStrings.MODID + ":block_meteor_molten");
+		block_meteor_treasure = new BlockOre(Material.rock).setBlockName("block_meteor_treasure").setCreativeTab(MainRegistry.tabBlock).setHardness(15.0F).setResistance(900.0F).setBlockTextureName(RefStrings.MODID + ":block_meteor_treasure");
 		
 		tape_recorder = new DecoTapeRecorder(Material.rock).setBlockName("tape_recorder").setCreativeTab(MainRegistry.tabBlock).setHardness(15.0F).setResistance(15.0F).setBlockTextureName(RefStrings.MODID + ":deco_tape_recorder");
 		steel_poles = new DecoSteelPoles(Material.rock).setBlockName("steel_poles").setCreativeTab(MainRegistry.tabBlock).setHardness(15.0F).setResistance(15.0F).setBlockTextureName(RefStrings.MODID + ":deco_steel_poles");
@@ -570,7 +570,7 @@ public class ModBlocks {
 		waste_mycelium = new WasteEarth(Material.ground).setBlockName("waste_mycelium").setStepSound(Block.soundTypeGrass).setLightLevel(1F).setCreativeTab(MainRegistry.tabBlock).setHardness(0.5F).setResistance(1.0F).setBlockTextureName(RefStrings.MODID + ":waste_mycelium_side");
 		waste_trinitite = new BlockOre(Material.sand).setBlockName("waste_trinitite").setStepSound(Block.soundTypeSand).setCreativeTab(MainRegistry.tabBlock).setHardness(0.5F).setResistance(2.5F).setBlockTextureName(RefStrings.MODID + ":waste_trinitite");
 		waste_trinitite_red = new BlockOre(Material.sand).setBlockName("waste_trinitite_red").setStepSound(Block.soundTypeSand).setCreativeTab(MainRegistry.tabBlock).setHardness(0.5F).setResistance(2.5F).setBlockTextureName(RefStrings.MODID + ":waste_trinitite_red");
-		waste_log = new WasteLog(Material.wood).setBlockName("waste_log").setStepSound(Block.soundTypeWood).setCreativeTab(MainRegistry.tabBlock).setHardness(5.0F).setResistance(0.5F);
+		waste_log = new WasteLog(Material.wood).setBlockName("waste_log").setStepSound(Block.soundTypeWood).setCreativeTab(MainRegistry.tabBlock).setHardness(5.0F).setResistance(2.5F);
 		waste_planks = new BlockOre(Material.wood).setBlockName("waste_planks").setStepSound(Block.soundTypeWood).setCreativeTab(MainRegistry.tabBlock).setHardness(0.5F).setResistance(2.5F).setBlockTextureName(RefStrings.MODID + ":waste_planks");
 		frozen_dirt = new BlockOre(Material.wood).setBlockName("frozen_dirt").setStepSound(Block.soundTypeGlass).setCreativeTab(MainRegistry.tabBlock).setHardness(0.5F).setResistance(2.5F).setBlockTextureName(RefStrings.MODID + ":frozen_dirt");
 		frozen_grass = new WasteEarth(Material.wood).setBlockName("frozen_grass").setStepSound(Block.soundTypeGlass).setCreativeTab(MainRegistry.tabBlock).setHardness(0.5F).setResistance(2.5F);

--- a/com/hbm/blocks/bomb/NukeBoy.java
+++ b/com/hbm/blocks/bomb/NukeBoy.java
@@ -115,7 +115,7 @@ public class NukeBoy extends BlockContainer implements IBomb {
 	public void onNeighborBlockChange(World p_149695_1_, int x, int y, int z, Block p_149695_5_) {
 		TileEntityNukeBoy entity = (TileEntityNukeBoy) p_149695_1_.getTileEntity(x, y, z);
 		if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z)) {
-			if (entity.isReady()) {
+			if (entity.isReady() && p_149695_1_.isRemote) {
 				this.onBlockDestroyedByPlayer(p_149695_1_, x, y, z, 1);
 				entity.clearSlots();
 				p_149695_1_.setBlockToAir(x, y, z);
@@ -151,7 +151,7 @@ public class NukeBoy extends BlockContainer implements IBomb {
 			entity.posY = y;
 			entity.posZ = z;
 			entity.destructionRange = MainRegistry.boyRadius;
-			entity.speed = 25;
+			entity.speed = MainRegistry.blastSpeed;
 			entity.coefficient = 10.0F;
 			world.spawnEntityInWorld(entity);
 
@@ -164,7 +164,7 @@ public class NukeBoy extends BlockContainer implements IBomb {
 				entity2.posZ = z;
 				world.spawnEntityInWorld(entity2);
 			} else {
-				EntityNukeCloudSmall entity2 = new EntityNukeCloudNoShroom(world, 1000);
+				EntityNukeCloudSmall entity2 = new EntityNukeCloudNoShroom(world, 3000);
 				entity2.posX = x;
 				entity2.posY = y - 11;
 				entity2.posZ = z;

--- a/com/hbm/blocks/bomb/NukeCustom.java
+++ b/com/hbm/blocks/bomb/NukeCustom.java
@@ -121,7 +121,7 @@ public class NukeCustom extends BlockContainer implements IBomb {
 	@Override
 	public void onNeighborBlockChange(World p_149695_1_, int x, int y, int z, Block p_149695_5_) {
 		TileEntityNukeCustom entity = (TileEntityNukeCustom) p_149695_1_.getTileEntity(x, y, z);
-		if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z)) {
+		if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z) && p_149695_1_.isRemote) {
 			if (entity.isReady()) {
 				float[] f = entity.returnAllValues();
 				this.onBlockDestroyedByPlayer(p_149695_1_, x, y, z, 1);
@@ -167,7 +167,7 @@ public class NukeCustom extends BlockContainer implements IBomb {
 				entity.posY = y + 0.5;
 				entity.posZ = z + 0.5;
 				entity.destructionRange = (int)schrab;
-				entity.speed = 25;
+				entity.speed = MainRegistry.blastSpeed;
 				entity.coefficient = 1.0F;
 				entity.waste = false;
 

--- a/com/hbm/blocks/bomb/NukeFleija.java
+++ b/com/hbm/blocks/bomb/NukeFleija.java
@@ -123,7 +123,7 @@ public class NukeFleija extends BlockContainer implements IBomb {
 	public void onNeighborBlockChange(World p_149695_1_, int x, int y, int z, Block p_149695_5_)
     {
     	TileEntityNukeFleija entity = (TileEntityNukeFleija) p_149695_1_.getTileEntity(x, y, z);
-        if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z))
+        if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z)&& p_149695_1_.isRemote)
         {
         	if(entity.isReady())
         	{
@@ -148,7 +148,7 @@ public class NukeFleija extends BlockContainer implements IBomb {
     		entity.posY = y;
     		entity.posZ = z;
     		entity.destructionRange = r;
-    		entity.speed = 25;
+    		entity.speed = MainRegistry.blastSpeed;
     		entity.coefficient = 1.0F;
     		entity.waste = false;
     	

--- a/com/hbm/blocks/bomb/NukeGadget.java
+++ b/com/hbm/blocks/bomb/NukeGadget.java
@@ -119,7 +119,7 @@ public class NukeGadget extends BlockContainer implements IBomb {
 	@Override
 	public void onNeighborBlockChange(World p_149695_1_, int x, int y, int z, Block p_149695_5_) {
 		TileEntityNukeGadget entity = (TileEntityNukeGadget) p_149695_1_.getTileEntity(x, y, z);
-		if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z)) {
+		if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z)&& p_149695_1_.isRemote) {
 			if (entity.isReady()) {
 				this.onBlockDestroyedByPlayer(p_149695_1_, x, y, z, 1);
 				entity.clearSlots();
@@ -164,7 +164,7 @@ public class NukeGadget extends BlockContainer implements IBomb {
 			entity.posY = y;
 			entity.posZ = z;
 			entity.destructionRange = MainRegistry.gadgetRadius;
-			entity.speed = 25;
+			entity.speed = MainRegistry.blastSpeed;
 			entity.coefficient = 10.0F;
 
 			world.spawnEntityInWorld(entity);

--- a/com/hbm/blocks/bomb/NukeMan.java
+++ b/com/hbm/blocks/bomb/NukeMan.java
@@ -125,7 +125,7 @@ public class NukeMan extends BlockContainer implements IBomb {
 	public void onNeighborBlockChange(World p_149695_1_, int x, int y, int z, Block p_149695_5_)
     {
     	TileEntityNukeMan entity = (TileEntityNukeMan) p_149695_1_.getTileEntity(x, y, z);
-        if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z))
+        if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z)&& p_149695_1_.isRemote)
         {
         	if(entity.isReady())
         	{
@@ -178,7 +178,7 @@ public class NukeMan extends BlockContainer implements IBomb {
     	entity.posY = y;
     	entity.posZ = z;
     	entity.destructionRange = MainRegistry.manRadius;
-    	entity.speed = 25;
+    	entity.speed = MainRegistry.blastSpeed;
     	entity.coefficient = 10.0F;
     	
     	world.spawnEntityInWorld(entity);

--- a/com/hbm/blocks/bomb/NukeMike.java
+++ b/com/hbm/blocks/bomb/NukeMike.java
@@ -118,7 +118,7 @@ public class NukeMike extends BlockContainer implements IBomb {
 	@Override
 	public void onNeighborBlockChange(World p_149695_1_, int x, int y, int z, Block p_149695_5_) {
 		TileEntityNukeMike entity = (TileEntityNukeMike) p_149695_1_.getTileEntity(x, y, z);
-		if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z)) {
+		if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z)&& p_149695_1_.isRemote) {
 			if (entity.isReady() && !entity.isFilled()) {
 				this.onBlockDestroyedByPlayer(p_149695_1_, x, y, z, 1);
 				entity.clearSlots();
@@ -146,7 +146,7 @@ public class NukeMike extends BlockContainer implements IBomb {
 			entity.posY = y;
 			entity.posZ = z;
 			entity.destructionRange = r;
-			entity.speed = 25;
+			entity.speed = MainRegistry.blastSpeed;
 			entity.coefficient = 10.0F;
 
 			world.spawnEntityInWorld(entity);

--- a/com/hbm/blocks/bomb/NukePrototype.java
+++ b/com/hbm/blocks/bomb/NukePrototype.java
@@ -134,7 +134,7 @@ public class NukePrototype extends BlockContainer implements IBomb {
 	public void onNeighborBlockChange(World p_149695_1_, int x, int y, int z, Block p_149695_5_)
     {
     	TileEntityNukePrototype entity = (TileEntityNukePrototype) p_149695_1_.getTileEntity(x, y, z);
-        if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z))
+        if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z)&& p_149695_1_.isRemote)
         {
         	if(entity.isReady())
         	{
@@ -159,7 +159,7 @@ public class NukePrototype extends BlockContainer implements IBomb {
     		entity.posY = y;
     		entity.posZ = z;
     		entity.destructionRange = r;
-    		entity.speed = 25;
+    		entity.speed = MainRegistry.blastSpeed;
     		entity.coefficient = 1.0F;
     		entity.waste = false;
     	

--- a/com/hbm/blocks/bomb/NukeTsar.java
+++ b/com/hbm/blocks/bomb/NukeTsar.java
@@ -122,7 +122,7 @@ public class NukeTsar extends BlockContainer implements IBomb {
 	public void onNeighborBlockChange(World p_149695_1_, int x, int y, int z, Block p_149695_5_)
     {
     	TileEntityNukeTsar entity = (TileEntityNukeTsar) p_149695_1_.getTileEntity(x, y, z);
-        if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z))
+        if (p_149695_1_.isBlockIndirectlyGettingPowered(x, y, z)&& p_149695_1_.isRemote)
         {
         	if(entity.isReady() && !entity.isFilled())
         	{
@@ -155,7 +155,7 @@ public class NukeTsar extends BlockContainer implements IBomb {
     		entity.posY = y;
     		entity.posZ = z;
     		entity.destructionRange = r;
-    		entity.speed = 25;
+    		entity.speed = MainRegistry.blastSpeed;
     		entity.coefficient = 10.0F;
     	
     		world.spawnEntityInWorld(entity);

--- a/com/hbm/entity/effect/EntityNukeCloudSmall.java
+++ b/com/hbm/entity/effect/EntityNukeCloudSmall.java
@@ -57,14 +57,14 @@ public class EntityNukeCloudSmall extends Entity {
     		this.age = 0;
         	this.setDead();
         }
-    	ring += 0.1F;
+    	ring += 0.03F;
     	
         if(age < 150)
         {
         	height = -60F + ((age - 100) * 60 / 50);
         	if(scale < 1.5)
         	{
-        		scale += 0.02;
+        		scale += 0.006f;
         	}
         }
         

--- a/com/hbm/entity/logic/EntityNukeExplosionMK3.java
+++ b/com/hbm/entity/logic/EntityNukeExplosionMK3.java
@@ -4,6 +4,7 @@ import com.hbm.entity.effect.EntityFalloutRain;
 import com.hbm.explosion.ExplosionFleija;
 import com.hbm.explosion.ExplosionNukeAdvanced;
 import com.hbm.explosion.ExplosionNukeGeneric;
+import com.hbm.main.MainRegistry;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NBTTagCompound;
@@ -96,7 +97,7 @@ public class EntityNukeExplosionMK3 extends Entity {
         	this.did = true;
         }
         
-        speed = 100;
+        speed += 1;	//increase speed to keep up with expansion
         
         boolean flag = false;
         boolean flag2 = false;
@@ -132,6 +133,7 @@ public class EntityNukeExplosionMK3 extends Entity {
 				fallout.setScale((int)(this.destructionRange * 1.8));
 
 				this.worldObj.spawnEntityInWorld(fallout);
+				//this.worldObj.getWorldInfo().setRaining(true);
 				
 				did2 = true;
         	}

--- a/com/hbm/entity/missile/EntityMissileMirv.java
+++ b/com/hbm/entity/missile/EntityMissileMirv.java
@@ -28,7 +28,7 @@ public class EntityMissileMirv extends EntityMissileBaseAdvanced {
     	entity.posY = this.posY;
     	entity.posZ = this.posZ;
     	entity.destructionRange = MainRegistry.missileRadius;
-    	entity.speed = 25;
+    	entity.speed = MainRegistry.blastSpeed;
     	entity.coefficient = 10.0F;
     	
     	this.worldObj.spawnEntityInWorld(entity);

--- a/com/hbm/entity/missile/EntityMissileNuclear.java
+++ b/com/hbm/entity/missile/EntityMissileNuclear.java
@@ -26,7 +26,7 @@ public class EntityMissileNuclear extends EntityMissileBaseAdvanced {
     	entity.posY = this.posY;
     	entity.posZ = this.posZ;
     	entity.destructionRange = MainRegistry.missileRadius;
-    	entity.speed = 25;
+    	entity.speed = MainRegistry.blastSpeed;
     	entity.coefficient = 10.0F;
     	
     	this.worldObj.spawnEntityInWorld(entity);

--- a/com/hbm/entity/projectile/EntityMiniMIRV.java
+++ b/com/hbm/entity/projectile/EntityMiniMIRV.java
@@ -255,7 +255,7 @@ public class EntityMiniMIRV extends Entity implements IProjectile
         	    entity0.posY = this.posY;
         	    entity0.posZ = this.posZ;
         	    entity0.destructionRange = MainRegistry.fatmanRadius;
-        	    entity0.speed = 25;
+        	    entity0.speed = MainRegistry.blastSpeed;
         	    entity0.coefficient = 10.0F;
         	    	
         	    this.worldObj.spawnEntityInWorld(entity0);

--- a/com/hbm/entity/projectile/EntityMiniNuke.java
+++ b/com/hbm/entity/projectile/EntityMiniNuke.java
@@ -242,11 +242,11 @@ public class EntityMiniNuke extends Entity implements IProjectile
         	    entity0.posY = this.posY;
         	    entity0.posZ = this.posZ;
         	    entity0.destructionRange = MainRegistry.fatmanRadius;
-        	    entity0.speed = 25;
+        	    entity0.speed = MainRegistry.blastSpeed;
         	    entity0.coefficient = 10.0F;
         	    	
         	    this.worldObj.spawnEntityInWorld(entity0);
-            	if(rand.nextInt(100) == 0)
+            	if(rand.nextInt(100) >= 0)	//edited
             	{
             		ExplosionParticleB.spawnMush(this.worldObj, (int)this.posX, (int)this.posY - 3, (int)this.posZ);
             	} else {

--- a/com/hbm/explosion/ExplosionNukeAdvanced.java
+++ b/com/hbm/explosion/ExplosionNukeAdvanced.java
@@ -65,8 +65,8 @@ public class ExplosionNukeAdvanced
 		
 		this.radius = rad;
 		this.radius2 = this.radius * this.radius;
-		
-		this.explosionCoefficient = coefficient;
+
+		this.explosionCoefficient = Math.min(Math.max((rad + coefficient * (y - 60))/(coefficient*rad), 1/coefficient),1.0f);	//scale the coefficient depending on detonation height
 		this.type = typ;
 		
 		this.nlimit = this.radius2 * 4; //How many total columns should be broken (radius ^ 2 is one quadrant, there are 4 quadrants)
@@ -99,11 +99,13 @@ public class ExplosionNukeAdvanced
 		if (dist > 0) //check if any blocks have to be broken here
 		{
 			dist = (int) Math.sqrt(dist); //calculate sphere height at this (x,z) coordinate
-			for (int y = dist; y > -dist / this.explosionCoefficient; y--) //go from top to bottom to favor light updates
+			for (int y = dist; y > -dist * this.explosionCoefficient; y--) //go from top to bottom to favor light updates
 			{
-				//this.worldObj.setBlock(this.posX+x, this.posY+y, this.posZ+z, Blocks.air); //set block to air relative to epicenter
-				
-				ExplosionNukeGeneric.destruction(this.worldObj, this.posX + x, this.posY + y, this.posZ + z);
+				if(y<8){//only spare blocks that are mostly below epicenter
+					y-= ExplosionNukeGeneric.destruction(this.worldObj, this.posX + x, this.posY + y, this.posZ + z);//spare blocks below
+				}else{//don't spare blocks above epicenter
+					ExplosionNukeGeneric.destruction(this.worldObj, this.posX + x, this.posY + y, this.posZ + z);
+				}
 			}
 		}
 	}
@@ -114,10 +116,18 @@ public class ExplosionNukeAdvanced
 		if (dist > 0)
 		{
 			dist = (int) Math.sqrt(dist);
-			for (int y = dist; y > -dist; y--)
+			//int dist0 = (int)Math.sqrt(this.radius2*0.15f - (x * x + z * z));
+			for (int y = dist; y > -dist * this.explosionCoefficient; y--)
 			{
-				
-				ExplosionNukeGeneric.vaporDest(this.worldObj, this.posX + x, this.posY + y, this.posZ + z);
+				y-=ExplosionNukeGeneric.vaporDest(this.worldObj, this.posX + x, this.posY + y, this.posZ + z);
+				/*
+				if(dist0>0){//skip blocks already in the destruction zone: we will 
+					if(y>=dist0 || y<=-dist0*this.explosionCoefficient){
+						y-=ExplosionNukeGeneric.vaporDest(this.worldObj, this.posX + x, this.posY + y, this.posZ + z);
+					}
+				}else{
+					y-=ExplosionNukeGeneric.vaporDest(this.worldObj, this.posX + x, this.posY + y, this.posZ + z);
+				}*/
 			}
 		}
 	}
@@ -128,7 +138,7 @@ public class ExplosionNukeAdvanced
 		if (dist > 0)
 		{
 			dist = (int) Math.sqrt(dist);
-			for (int y = dist; y > -dist; y--)
+			for (int y = dist; y > -dist * this.explosionCoefficient; y--)
 			{
 				if(radius >= 95)
 					ExplosionNukeGeneric.wasteDest(this.worldObj, this.posX + x, this.posY + y, this.posZ + z);

--- a/com/hbm/explosion/ExplosionNukeGeneric.java
+++ b/com/hbm/explosion/ExplosionNukeGeneric.java
@@ -4,6 +4,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockLiquid;
+import net.minecraft.block.BlockSlab;
+import net.minecraft.block.BlockStairs;
+import net.minecraft.block.material.Material;
 import net.minecraft.enchantment.EnchantmentProtection;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -316,73 +321,70 @@ public class ExplosionNukeGeneric {
 		}
 	}
 
-	public static void destruction(World world, int x, int y, int z) {
+	public static int destruction(World world, int x, int y, int z) {
 		int rand;
 		if (!world.isRemote) {
-			if (world.getBlock(x, y, z) != Blocks.bedrock && world.getBlock(x, y, z) != ModBlocks.reinforced_brick
-					&& world.getBlock(x, y, z) != ModBlocks.reinforced_glass
-					&& world.getBlock(x, y, z) != ModBlocks.reinforced_light
-					&& world.getBlock(x, y, z) != ModBlocks.reinforced_sand
-					&& world.getBlock(x, y, z) != ModBlocks.reinforced_lamp_off
-					&& world.getBlock(x, y, z) != ModBlocks.reinforced_lamp_on
-					&& world.getBlock(x, y, z) != ModBlocks.cmb_brick
-					&& world.getBlock(x, y, z) != ModBlocks.crystal_virus
-					&& world.getBlock(x, y, z) != ModBlocks.crystal_hardened
-					&& world.getBlock(x, y, z) != ModBlocks.crystal_pulsar
-					&& world.getBlock(x, y, z) != ModBlocks.cmb_brick_reinforced
-					&& !(world.getBlock(x, y, z) instanceof DecoBlockAlt)) {
-				if (world.getBlock(x, y, z) == ModBlocks.brick_concrete) {
+			Block b = world.getBlock(x,y,z);
+			if (b.getExplosionResistance(null)>=200f) {	//500 is the resistance of liquids
+				//blocks to be spared
+				int protection = (int)(b.getExplosionResistance(null)/300f);
+				if (b == ModBlocks.brick_concrete) {
 					rand = field_149933_a.nextInt(8);
 					if (rand == 0) {
 						world.setBlock(x, y, z, Blocks.gravel, 0, 3);
+						return 0;
 					}
-				} else if (world.getBlock(x, y, z) == ModBlocks.brick_light) {
-					rand = field_149933_a.nextInt(2);
+				} else if (b == ModBlocks.brick_light) {
+					rand = field_149933_a.nextInt(3);
 					if (rand == 0) {
 						world.setBlock(x, y, z, ModBlocks.waste_planks, 0, 3);
+						return 0;
+					}else if (rand == 1){
+						world.setBlock(x,y,z,ModBlocks.block_scrap,0,3);
+						return 0;
 					}
-				} else if (world.getBlock(x, y, z) == ModBlocks.brick_obsidian) {
+				} else if (b == ModBlocks.brick_obsidian) {
 					rand = field_149933_a.nextInt(20);
 					if (rand == 0) {
 						world.setBlock(x, y, z, Blocks.obsidian, 0, 3);
 					}
-				} else if (world.getBlock(x, y, z) == Blocks.obsidian) {
+				} else if (b == Blocks.obsidian) {
 					world.setBlock(x, y, z, ModBlocks.gravel_obsidian, 0, 3);
-				} else {
-					world.setBlock(x, y, z, Blocks.air, 0, 3);
+					return 0;
+				} else if(field_149933_a.nextInt(protection+3)==0){
+					world.setBlock(x, y, z, ModBlocks.block_scrap,0,3);
 				}
+				return protection;
+			}else{//otherwise, kill the block!
+				world.setBlock(x, y, z, Blocks.air,0, 2);
 			}
 		}
+		return 0;
 	}
 
-	public static void vaporDest(World world, int x, int y, int z) {
+	public static int vaporDest(World world, int x, int y, int z) {
 		if (!world.isRemote) {
-			if (world.getBlock(x, y, z) == Blocks.water || world.getBlock(x, y, z) == Blocks.flowing_water
-					|| world.getBlock(x, y, z) == Blocks.tallgrass || world.getBlock(x, y, z) == Blocks.leaves
-					|| world.getBlock(x, y, z) == Blocks.leaves2 || world.getBlock(x, y, z) == Blocks.double_plant
-					|| world.getBlock(x, y, z) == Blocks.cactus || world.getBlock(x, y, z) == Blocks.snow_layer
-					|| world.getBlock(x, y, z) == Blocks.reeds || world.getBlock(x, y, z) == Blocks.glass_pane
-					|| world.getBlock(x, y, z) == Blocks.stained_glass_pane || world.getBlock(x, y, z) == Blocks.carrots
-					|| world.getBlock(x, y, z) == Blocks.potatoes || world.getBlock(x, y, z) == Blocks.wheat
-					|| world.getBlock(x, y, z) == Blocks.ladder || world.getBlock(x, y, z) == Blocks.torch
-					|| world.getBlock(x, y, z) == Blocks.redstone_torch
-					|| world.getBlock(x, y, z) == Blocks.unlit_redstone_torch
-					|| world.getBlock(x, y, z) == Blocks.redstone_wire
-					|| world.getBlock(x, y, z) == Blocks.unpowered_repeater
-					|| world.getBlock(x, y, z) == Blocks.powered_repeater
-					|| world.getBlock(x, y, z) == Blocks.wooden_pressure_plate
-					|| world.getBlock(x, y, z) == Blocks.stone_pressure_plate
-					|| world.getBlock(x, y, z) == Blocks.wooden_button || world.getBlock(x, y, z) == Blocks.stone_button
-					|| world.getBlock(x, y, z) == Blocks.lever || world.getBlock(x, y, z) == Blocks.deadbush
-					|| world.getBlock(x, y, z) == ModBlocks.red_cable) {
-				world.setBlock(x, y, z, Blocks.air);
+			Block b = world.getBlock(x,y,z);
+			if (b.getExplosionResistance(null)<0.5f //most light things
+					|| b == Blocks.web || b == ModBlocks.red_cable
+					|| b instanceof BlockLiquid) {
+				world.setBlock(x, y, z, Blocks.air,0, 2);
+				return 0;
+			} else if (b.getExplosionResistance(null)<=3.0f && !b.isOpaqueCube()){
+				if(b != Blocks.chest && b != Blocks.farmland){
+					//destroy all medium resistance blocks that aren't chests or farmland
+					world.setBlock(x, y, z, Blocks.air,0,2);
+					return 0;
+				}
 			}
-
-			if (world.getBlock(x, y, z).isFlammable(world, x, y, z, ForgeDirection.UP)
+			
+			if (b.isFlammable(world, x, y, z, ForgeDirection.UP)
 					&& world.getBlock(x, y + 1, z) == Blocks.air) {
-				world.setBlock(x, y + 1, z, Blocks.fire);
+				world.setBlock(x, y + 1, z, Blocks.fire,0,2);
 			}
+			return (int)( b.getExplosionResistance(null)/300f);
 		}
+		return 0;
 	}
 
 	public static void waste(World world, int x, int y, int z, int radius) {
@@ -410,21 +412,20 @@ public class ExplosionNukeGeneric {
 	public static void wasteDest(World world, int x, int y, int z) {
 		if (!world.isRemote) {
 			int rand;
-
-			if (world.getBlock(x, y, z) == Blocks.glass || world.getBlock(x, y, z) == Blocks.stained_glass
-					|| world.getBlock(x, y, z) == Blocks.wooden_door || world.getBlock(x, y, z) == Blocks.iron_door) {
-				world.setBlock(x, y, z, Blocks.air);
+			Block b = world.getBlock(x,y,z);
+			if (b == Blocks.wooden_door || b == Blocks.iron_door) {
+				world.setBlock(x, y, z, Blocks.air,0,2);
 			}
 
-			else if (world.getBlock(x, y, z) == Blocks.grass) {
+			else if (b == Blocks.grass) {
 				world.setBlock(x, y, z, ModBlocks.waste_earth);
 			}
 
-			else if (world.getBlock(x, y, z) == Blocks.mycelium) {
+			else if (b == Blocks.mycelium) {
 				world.setBlock(x, y, z, ModBlocks.waste_mycelium);
 			}
 
-			else if (world.getBlock(x, y, z) == Blocks.sand) {
+			else if (b == Blocks.sand) {
 				rand = field_149933_a.nextInt(20);
 				if (rand == 1 && world.getBlockMetadata(x, y, z) == 0) {
 					world.setBlock(x, y, z, ModBlocks.waste_trinitite);
@@ -434,15 +435,15 @@ public class ExplosionNukeGeneric {
 				}
 			}
 
-			else if (world.getBlock(x, y, z) == Blocks.clay) {
+			else if (b == Blocks.clay) {
 				world.setBlock(x, y, z, Blocks.hardened_clay);
 			}
 
-			else if (world.getBlock(x, y, z) == Blocks.mossy_cobblestone) {
+			else if (b == Blocks.mossy_cobblestone) {
 				world.setBlock(x, y, z, Blocks.coal_ore);
 			}
 
-			else if (world.getBlock(x, y, z) == Blocks.coal_ore) {
+			else if (b == Blocks.coal_ore) {
 				rand = field_149933_a.nextInt(10);
 				if (rand == 1 || rand == 2 || rand == 3) {
 					world.setBlock(x, y, z, Blocks.diamond_ore);
@@ -452,43 +453,44 @@ public class ExplosionNukeGeneric {
 				}
 			}
 
-			else if (world.getBlock(x, y, z) == Blocks.log || world.getBlock(x, y, z) == Blocks.log2) {
+			else if (b == Blocks.log || b == Blocks.log2) {
 				world.setBlock(x, y, z, ModBlocks.waste_log);
 			}
 
-			else if (world.getBlock(x, y, z) == Blocks.planks) {
+			else if (b == Blocks.brown_mushroom_block) {
+				if (world.getBlockMetadata(x, y, z) == 10) {
+					world.setBlock(x, y, z, ModBlocks.waste_log);
+				} else {
+					world.setBlock(x, y, z, Blocks.air,0,2);
+				}
+			}
+
+			else if (b == Blocks.red_mushroom_block) {
+				if (world.getBlockMetadata(x, y, z) == 10) {
+					world.setBlock(x, y, z, ModBlocks.waste_log);
+				} else {
+					world.setBlock(x, y, z, Blocks.air,0,2);
+				}
+			}
+			
+			else if (b.getMaterial() == Material.wood && b.isOpaqueCube() && b != ModBlocks.waste_log) {
 				world.setBlock(x, y, z, ModBlocks.waste_planks);
 			}
 
-			else if (world.getBlock(x, y, z) == ModBlocks.ore_uranium) {
+			else if (b == ModBlocks.ore_uranium) {
 				rand = field_149933_a.nextInt(30);
 				if (rand == 1) {
 					world.setBlock(x, y, z, ModBlocks.ore_schrabidium);
 				}
 			}
 
-			else if (world.getBlock(x, y, z) == ModBlocks.ore_nether_uranium) {
+			else if (b == ModBlocks.ore_nether_uranium) {
 				rand = field_149933_a.nextInt(30);
 				if (rand == 1) {
 					world.setBlock(x, y, z, ModBlocks.ore_nether_schrabidium);
 				}
 			}
 
-			else if (world.getBlock(x, y, z) == Blocks.brown_mushroom_block) {
-				if (world.getBlockMetadata(x, y, z) == 10) {
-					world.setBlock(x, y, z, ModBlocks.waste_log);
-				} else {
-					world.setBlock(x, y, z, Blocks.air);
-				}
-			}
-
-			else if (world.getBlock(x, y, z) == Blocks.red_mushroom_block) {
-				if (world.getBlockMetadata(x, y, z) == 10) {
-					world.setBlock(x, y, z, ModBlocks.waste_log);
-				} else {
-					world.setBlock(x, y, z, Blocks.air);
-				}
-			}
 		}
 	}
 
@@ -572,7 +574,7 @@ public class ExplosionNukeGeneric {
 				if (world.getBlockMetadata(x, y, z) == 10) {
 					world.setBlock(x, y, z, ModBlocks.waste_log);
 				} else {
-					world.setBlock(x, y, z, Blocks.air);
+					world.setBlock(x, y, z, Blocks.air,0,2);
 				}
 			}
 
@@ -580,7 +582,7 @@ public class ExplosionNukeGeneric {
 				if (world.getBlockMetadata(x, y, z) == 10) {
 					world.setBlock(x, y, z, ModBlocks.waste_log);
 				} else {
-					world.setBlock(x, y, z, Blocks.air);
+					world.setBlock(x, y, z, Blocks.air,0,2);
 				}
 			}
 		}
@@ -588,53 +590,54 @@ public class ExplosionNukeGeneric {
 
 	public static void emp(World world, int x, int y, int z) {
 		if (!world.isRemote) {
-
+			
+			Block b = world.getBlock(x,y,z);
 			if (world.getTileEntity(x, y, z) != null && (world.getTileEntity(x, y, z) instanceof ISource
 					|| world.getTileEntity(x, y, z) instanceof IConsumer
 					|| world.getTileEntity(x, y, z) instanceof TileEntityDummy)) {
-				world.setBlock(x, y, z, ModBlocks.block_electrical_scrap);
+				world.setBlock(x, y, z, ModBlocks.block_electrical_scrap,0,2);
 			}
 
-			else if (world.getBlock(x, y, z) == ModBlocks.red_wire_coated || 
-					world.getBlock(x, y, z) == ModBlocks.factory_titanium_furnace || 
-					world.getBlock(x, y, z) == ModBlocks.factory_titanium_conductor || 
-					world.getBlock(x, y, z) == ModBlocks.factory_advanced_furnace || 
-					world.getBlock(x, y, z) == ModBlocks.factory_advanced_conductor || 
-					world.getBlock(x, y, z) == ModBlocks.reactor_conductor || 
-					world.getBlock(x, y, z) == ModBlocks.fusion_conductor || 
-					world.getBlock(x, y, z) == ModBlocks.fusion_center || 
-					world.getBlock(x, y, z) == ModBlocks.fusion_motor || 
-					world.getBlock(x, y, z) == ModBlocks.watz_conductor || 
-					world.getBlock(x, y, z) == ModBlocks.fwatz_conductor || 
-					world.getBlock(x, y, z) == ModBlocks.fwatz_hatch || 
-					world.getBlock(x, y, z) == ModBlocks.fwatz_computer) {
-				world.setBlock(x, y, z, ModBlocks.block_electrical_scrap);
+			else if (b == ModBlocks.red_wire_coated || 
+					b == ModBlocks.factory_titanium_furnace || 
+					b == ModBlocks.factory_titanium_conductor || 
+					b == ModBlocks.factory_advanced_furnace || 
+					b == ModBlocks.factory_advanced_conductor || 
+					b == ModBlocks.reactor_conductor || 
+					b == ModBlocks.fusion_conductor || 
+					b == ModBlocks.fusion_center || 
+					b == ModBlocks.fusion_motor || 
+					b == ModBlocks.watz_conductor || 
+					b == ModBlocks.fwatz_conductor || 
+					b == ModBlocks.fwatz_hatch || 
+					b == ModBlocks.fwatz_computer) {
+				world.setBlock(x, y, z, ModBlocks.block_electrical_scrap,0,2);
 			}
 
-			else if (world.getBlock(x, y, z) == ModBlocks.red_cable || 
-					world.getBlock(x, y, z) == Blocks.redstone_wire || 
-					world.getBlock(x, y, z) == Blocks.powered_repeater || 
-					world.getBlock(x, y, z) == Blocks.unpowered_repeater || 
-					world.getBlock(x, y, z) == Blocks.activator_rail || 
-					world.getBlock(x, y, z) == Blocks.detector_rail || 
-					world.getBlock(x, y, z) == Blocks.golden_rail || 
-					world.getBlock(x, y, z) == Blocks.redstone_block || 
-					world.getBlock(x, y, z) == Blocks.redstone_lamp || 
-					world.getBlock(x, y, z) == Blocks.redstone_ore || 
-					world.getBlock(x, y, z) == Blocks.redstone_torch || 
-					world.getBlock(x, y, z) == Blocks.unlit_redstone_torch || 
-					world.getBlock(x, y, z) == Blocks.powered_comparator || 
-					world.getBlock(x, y, z) == Blocks.unpowered_comparator) {
-				world.setBlock(x, y, z, Blocks.air);
+			else if (b == ModBlocks.red_cable || 
+					b == Blocks.redstone_wire || 
+					b == Blocks.powered_repeater || 
+					b == Blocks.unpowered_repeater || 
+					b == Blocks.activator_rail || 
+					b == Blocks.detector_rail || 
+					b == Blocks.golden_rail || 
+					b == Blocks.redstone_block || 
+					b == Blocks.redstone_lamp || 
+					b == Blocks.redstone_ore || 
+					b == Blocks.redstone_torch || 
+					b == Blocks.unlit_redstone_torch || 
+					b == Blocks.powered_comparator || 
+					b == Blocks.unpowered_comparator) {
+				world.setBlock(x, y, z, Blocks.air,0,2);
 			}
 
-			else if (world.getBlock(x, y, z) == Blocks.dispenser || 
-					world.getBlock(x, y, z) == Blocks.dropper || 
-					world.getBlock(x, y, z) == Blocks.piston || 
-					world.getBlock(x, y, z) == Blocks.piston_extension || 
-					world.getBlock(x, y, z) == Blocks.piston_head || 
-					world.getBlock(x, y, z) == Blocks.sticky_piston) {
-				world.setBlock(x, y, z, Blocks.gravel);
+			else if (b == Blocks.dispenser || 
+					b == Blocks.dropper || 
+					b == Blocks.piston || 
+					b == Blocks.piston_extension || 
+					b == Blocks.piston_head || 
+					b == Blocks.sticky_piston) {
+				world.setBlock(x, y, z, Blocks.gravel,0,2);
 			}
 		}
 		//world.setBlock(x, y, z, Blocks.air);

--- a/com/hbm/main/MainRegistry.java
+++ b/com/hbm/main/MainRegistry.java
@@ -366,6 +366,7 @@ public class MainRegistry
 	public static int fatmanRadius = 35;
 	public static int nukaRadius = 25;
 	public static int aSchrabRadius = 20;
+	public static int blastSpeed = 1024;
 	public static int radioStructure = 500;
 	public static int antennaStructure = 250;
 	public static int atomStructure = 500;
@@ -1032,6 +1033,10 @@ public class MainRegistry
         Property propASchrab = config.get(Configuration.CATEGORY_GENERAL, "3.11_aSchrabRadius", 20);
         propASchrab.comment = "Radius of dropped anti schrabidium";
         aSchrabRadius = propASchrab.getInt();
+        //add blast speed as config
+        Property propBlastSpeed = config.get(Configuration.CATEGORY_GENERAL, "Blast Speed", 1024);
+        propBlastSpeed.comment = "Base speed of all detonations (Blocks / tick)";
+        blastSpeed = propBlastSpeed.getInt();
 
         Property propRadio = config.get(Configuration.CATEGORY_GENERAL, "4.00_radioSpawn", 500);
         propRadio.comment = "Spawn radio station on every nTH chunk";


### PR DESCRIPTION
First- really big fan of the mod!

I've proposed several changes to the way the nuclear blast algorithm works. Some of the things that I thought could be improved included:
-the slow spread speed of the destruction
-the limited interaction with other mod's blocks
-the fixed nature of the explosion shape
-the fact that blocks would be destroyed even if surrounded by blast resistant blocks

So I've made some changes for your consideration!
**First, the blast shape.** 

(Somewhat) realistically, you expect a blast in the air to have a spherical shape, while a blast on the surface would have the bottom radius reduced by the material below.
Here is the previous explosion shape:
![image](https://user-images.githubusercontent.com/3060565/33521801-c721d426-d7a1-11e7-9e2b-eba27316f471.png)
The central area, called by `destruction()` shows this behavior, but the `waste()` and `vapor()` areas are simply spheres, leading to a disproportionate level of destruction below ground (and a good number of extra block calls).

With the changes, at the time when the explosion entity is created, the bottom radii of all 3 zones are determined based on the blast height, as shown below (ideally, the top radii would attenuate the farther below ground the blast is, but given how thin the crust is anyways, this isn't noticeable enough to implement).
![image](https://user-images.githubusercontent.com/3060565/33521852-b606a7d2-d7a3-11e7-8416-4f697a503666.png)

This results in the following picture: when the blast is detonated far below ground, the lower half of the sphere is compressed (much like the previous code). _(note: explosion radius reduced to 70 to make effect more visible )_
![image](https://user-images.githubusercontent.com/3060565/33521867-28a6add2-d7a4-11e7-9e36-2dfc2eb4f4ed.png)
If we detonate at the surface, the shape is still the same:
![image](https://user-images.githubusercontent.com/3060565/33521871-4be0edc6-d7a4-11e7-81e0-93b6eb8e53a0.png)
But if we detonate the blast in the air, the shape starts to shift to a full sphere:
![image](https://user-images.githubusercontent.com/3060565/33521877-6858779e-d7a4-11e7-8c1c-95aa5de7e277.png)
![image](https://user-images.githubusercontent.com/3060565/33521878-706eec74-d7a4-11e7-8306-c697bcd8dc45.png)
This means aerial blasts are destructive too! (much like IRL)

**Second, the blast code itself**
Specifically `destruction()`, `vaporDest()` and `wasteDest()`. Instead of a long if statement that checks for specific block instances, we cache the block, then check its blast resistance to decide whether to destroy it or not. 

`Block b = world.getBlock(x,y,z);`
`if (b.getExplosionResistance(null)>=200f) {	//500 is the resistance of liquids`
`	...`

This means the explosion won't destroy other mods' blast resistant blocks (compatibility woo!), but I've had to up the blast resistance of `waste_log` and `waste_planks`.  The cutoff is set to a blast resistance of 1000f _(note: getExplosionResistance() returns 1/5 of the value for some reason)_, which is well above liquid blocks, but includes things like obsidian, end portals, etc. If the block is not one of the blast bricks from the mod, there is a chance for the block to be turned into `Block_scrap` (the higher the resistance, the lower the chance).

The `vaporDest()` function is modified in a similar way. We remove the following: 
-Blocks with resistance below 2.5 (dirt is 2.5)
-ALL Liquids
-Non-solid blocks below 15, excluding chests and farmland
This gives roughly the same functionality as before, but destroys more things that are usually destroyed!

The `wasteDest()` function is mostly the same, with the only addition being that solid, wooden blocks are turned into `waste_planks`.

Also, all the `SetBlock()` calls are switched to not trigger the neighors, in order to minimize ticking.

**Finally, a crude attempt to model Blast Shielding**
In an ideal world, we'd use some sort of raytracing to model the blast attenuation, which would be slowed down by a blast resistant block. But given the enormous nature of these explosions, this would be CPU-meltingly impossible! So I've implemented a compromise:
-Assume blast proof structures are roughly cubical
-If we hit a block below the epicenter thats not destroyed/broken by the blast:
-Skip the next few blocks below it
The higher the block's explosion resistance, the more blocks we skip. This results in a crude model of blast attenuation! Less floating structures once the blast is done, and paintings/beds/flowerpots inside bunkers will stay untouched! (Wood is still charred, because why not).

I'm running all this on a potato, but it looks like most of these changes have improved the total time from start to end of an explosion (for example, a full Littleboy blast finished in less than a minute, compared to several minutes before). And most importantly, the blast speed is now a setting in the config file, so beastly setups can run the detonations faster!

Thank you for the consideration, and good luck with development!