### PR TITLE
Autonomized build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,22 @@
-/.gradle/
-/bin/
-/build/
-/eclipse/
-/lib/
-/.git/
-/.gradle/
-/.settings/
-/.classpath
-/.project
+# eclipse
+eclipse
+bin
+*.launch
+.settings
+.metadata
+.classpath
+.project
 
+# idea
+out
+*.ipr
+*.iws
+*.iml
+.idea
+
+# gradle
+build
+.gradle
+
+# other
+run

--- a/README.md
+++ b/README.md
@@ -4,39 +4,53 @@ https://minecraft.curseforge.com/projects/hbms-nuclear-tech-mod?gameCategorySlug
 
 For a 1.12 fork, check this link: https://github.com/Drillgon200/Hbm-s-Nuclear-Tech-GIT/releases
 
-## Installation Instructions
+## Building from source
 
 Tired of waiting until the next version comes out? Here is a tutorial on how to compile the very newest version yourself:
-1. Download minecraft forge 1.7.10 src
-2. Unpack it somewhere
-3. Download the source and insert it into the same folder. This will overwrite a couple of files, for example build.gradle
-4. Run `gradlew setupDecompWorkspace` on windows or `./gradlew setupDecompWorkspace` on linux (remember: do not take the name of root in vain). Running this command on a blank forge workspace will yield errors, so it's important you insert the mod's source in step 3. The source has corrected versions of guild.gradle and the gradle wrapper, if done correctly it should run just fine.
-5. The `build.gradle` file will reference these following files:
+Please note that these installation instructions are assuming you're running Microsoft Windows operating system. Linux users should know what to do by looking at the same guide.
+
+ 1. Make sure you have JDK8 installed. If not, download it from [adoptium.net](https://adoptium.net/?variant=openjdk8&jvmVariant=hotspot)
+ 2. If you don't have git installed, download&install it from [here](https://git-scm.com/downloads).
+ 3. Open up "Git Bash":
+    * Press Windows Button, type "Git Bash" and press ENTER
+ 4. Enter the directory where you would like the sources to be (advanced users can use any directory)
+ ```bash
+     cd $HOME/Downloads
+ ```
+ 5. Download the source code:
+ ```bash
+     git clone https://github.com/HbmMods/Hbm-s-Nuclear-Tech-GIT.git
+ ```
+ 4. Enter the source code directory
+ ```bash
+     cd Hbm-s-Nuclear-Tech-GIT
+ ```
+ 5. Build the mod
+ ```bash
+     ./gradlew build
+ ```
+ 6. Locate the mod file.
+    1. Open up your file explorer.
+    2. Navigate to the location where you downloaded the sources.
+       * If you exactly followed step 1, it should be `C:/Users/%USER%/Downloads`.
+    3. Enter the downloaded source tree.
+    4. Navigate to `build/libs`.
+    5. Grab the "HBM-NTM-<version>.jar" one.
+        * This is your mod file. You can install it like any other mod by putting it into your mods directory.
+
+## Contributing
+If you want to make some changes to the mod, follow this guide:
+1. Follow steps 1-4 from *Building from source* section
+2. Setup forge decompilation workspace
+```bash
+    ./gradlew setupDecompWorkspace
 ```
-compile files('lib/CodeChickenCore-1.7.10-1.0.4.29-dev.jar')
-compile files('lib/CodeChickenLib-1.7.10-1.1.3.140-dev.jar')
-compile files('lib/NotEnoughItems-1.7.10-1.0.3.74-dev.jar')
+3. (OPTIONAL, but needed if you use eclipse) Generate eclipse files
+```bash
+    ./gradlew eclipse
 ```
-which means you need to do one of the following things:
-1) Find these exact versions of the dependencies, download them and put them into a folder called `libs` in your project's root folder. You can download a zip containing all files here: https://bit.ly/3fBxMq0
-2) Find other versions, change the `build.gradle` file to reflect this difference and fix any potential errors this could cause (unlikely but not impossible)
-3) Remove these dependencies from `build.gradle` along with all the API code. Note that this will break NEI-integration.
-7. Open up the CMD in the root directory and run `gradlew build` on windows or `./gradlew build` on linux
-8. Head over to `build/libs` and get the jar (named modid.jar)
-9. Open the jar file with an archieve manager of your choice and insert the mod's asset folder into the jar's main directory
-
-If you want to do some changes in the code yourself, start here after 6. and continue with 7. once you are done:
-1) Get the IDE of your choice and prepare the workspace (for eclipse, it's `gradlew eclipse` or `./gradlew eclipse`, then use the eclipse folder as workspace directory in eclipse)
-2) Meddle with the code, you can always test the code in the IDE (eclipse has a convenient green play button)
-3) Save changes, close the IDE and continue with 7. of the previous list
-
-## Installation Instructions for a non-standard Workspace
-
-I cannot offer any help on compiling the mod in a GregTech-workspace as I never managed to get it to work myself, here's a rough guide on how it might be possible:
-1. Prepare the workspace
-2. Slap this mod's `src` into the project's root directory
-3. Pray
+4. Open up the project directory in eclipse using *Open existing project from file system*
+5. Code!
 
 # License
-
 This software is licensed under the GNU Public License version 3. In short: This software is free, you may run the software freely, create modified versions, distribute this software and distribute modified versions, as long as the modified software too has a free software license. You win this round, Stallman. The full license can be found in the `LICENSE` file.

--- a/build.gradle
+++ b/build.gradle
@@ -21,18 +21,25 @@ buildscript {
 apply plugin: 'forge'
 
 version = "1.0"
-group= "com.yourname.modid" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = "modid"
+group= "com.hbm" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+archivesBaseName = "HBM-NTM"
 
 minecraft {
     version = "1.7.10-10.13.4.1558-1.7.10"
     runDir = "eclipse"
 }
 
+repositories {
+	maven {
+		name = 'ModMaven'
+		url = 'https://modmaven.dev'
+	}
+}
+
 dependencies {
-compile files('lib/CodeChickenCore-1.7.10-1.0.4.29-dev.jar')
-compile files('lib/CodeChickenLib-1.7.10-1.1.3.140-dev.jar')
-compile files('lib/NotEnoughItems-1.7.10-1.0.3.74-dev.jar')
+	compile 'codechicken:CodeChickenCore:1.7.10-1.0.4.29:dev'
+	compile 'codechicken:CodeChickenLib:1.7.10-1.1.3.140:dev'
+	compile 'codechicken:NotEnoughItems:1.7.10-1.0.3.74:dev'
 }
 
 processResources

--- a/build.gradle
+++ b/build.gradle
@@ -1,32 +1,27 @@
 buildscript {
-    repositories {
-        mavenCentral()
-        maven {
-            name = "forge"
-            url = "https://files.minecraftforge.net/maven"
-        }
-        maven {
-            name = "sonatype"
-            url = "https://oss.sonatype.org/content/repositories/snapshots/"
-        }
-        maven {
-            url = "https://repo1.maven.org/maven2/"
-        }
-    }
-    dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
-    }
+	repositories {
+		maven { url = 'https://files.minecraftforge.net/maven' }
+		maven { url = 'https://plugins.gradle.org/m2' }
+		mavenCentral()
+	}
+	dependencies {
+		classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.10.0'
+		classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+	}
 }
 
+apply plugin: 'com.palantir.git-version'
 apply plugin: 'forge'
 
-version = "1.0"
-group= "com.hbm" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+version gitVersion()
+group = "com.hbm" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "HBM-NTM"
 
+sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8'
+
 minecraft {
-    version = "1.7.10-10.13.4.1558-1.7.10"
-    runDir = "eclipse"
+	version = "1.7.10-10.13.4.1558-1.7.10"
+	runDir = "eclipse"
 }
 
 repositories {
@@ -42,28 +37,27 @@ dependencies {
 	compile 'codechicken:NotEnoughItems:1.7.10-1.0.3.74:dev'
 }
 
-processResources
-{
-    // this will ensure that this task is redone when the versions change.
-    inputs.property "version", project.version
-    inputs.property "mcversion", project.minecraft.version
+processResources {
+	// this will ensure that this task is redone when the versions change.
+	inputs.property "version", project.version
+	inputs.property "mcversion", project.minecraft.version
 
-    // replace stuff in mcmod.info, nothing else
-    from(sourceSets.main.resources.srcDirs) {
-        include 'mcmod.info'
-                
-        // replace version and mcversion
-        expand 'version':project.version, 'mcversion':project.minecraft.version
-    }
-        
-    // copy everything else, thats not the mcmod.info
-    from(sourceSets.main.resources.srcDirs) {
-        exclude 'mcmod.info'
-    }
+	// replace stuff in mcmod.info, nothing else
+	from(sourceSets.main.resources.srcDirs) {
+		include 'mcmod.info'
+		
+		// replace version and mcversion
+		expand 'version':project.version, 'mcversion':project.minecraft.version
+	}
+		
+	// copy everything else, thats not the mcmod.info
+	from(sourceSets.main.resources.srcDirs) {
+		exclude 'mcmod.info'
+	}
 }
 
-apply plugin: 'java'
-compileJava {
-    sourceCompatibility = '1.8'
-    targetCompatibility = '1.8'
+task version {
+	doFirst {
+		println project.version
+	}
 }


### PR DESCRIPTION
The build system should now be fully autonomous. That means that the build should run just fine without any user intervention upon cloning the repository. Additionally, the README was updated with new instructions for building the mod and setting up modding workspace.

Notable changes:
 * Replaced local dependencies with maven ones (https://github.com/HbmMods/Hbm-s-Nuclear-Tech-GIT/commit/9a41ccc0ba8c51334bda9c8acc0a598f0511bf45)
 * Updated .gitignore (https://github.com/HbmMods/Hbm-s-Nuclear-Tech-GIT/commit/9a41ccc0ba8c51334bda9c8acc0a598f0511bf45)
 * Added updated building instructions (https://github.com/HbmMods/Hbm-s-Nuclear-Tech-GIT/commit/6c63313842f85f6e6c86e10214c2de910c4ff9d2)
 * Added automatic project versioning (https://github.com/HbmMods/Hbm-s-Nuclear-Tech-GIT/commit/4e641e8e7ce7a31b1a1e530971a8c81e68c4ec82)