### PR TITLE
Fixed rounding errors with large reactor

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineReactorLarge.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineReactorLarge.java
@@ -374,7 +374,7 @@ public class TileEntityMachineReactorLarge extends TileEntity
 	
 	private void generate() {
 		
-		int consumption = (maxFuel / cycleDuration) * rods / 100;
+		int consumption = (int) (((double)maxFuel / cycleDuration) * rods / 100);
 		
 		if(consumption > fuel)
 			consumption = fuel;
@@ -385,7 +385,7 @@ public class TileEntityMachineReactorLarge extends TileEntity
 		fuel -= consumption;
 		waste += consumption;
 		
-		int heat = (consumption / size) * type.heat / fuelMult;
+		int heat = (int) (((double)consumption / size) * type.heat / fuelMult);
 		
 		this.coreHeat += heat;
 		


### PR DESCRIPTION
Large reactor rods only affected heat produced (which in turn affects steam production) in increments of 10% (for example, 19% control rod level produced the same heat as 10%) while still consuming more fuel. This change fixes that error, assuming it wasn't intentional. (Yes, I suck at pull requests)