### PR TITLE
Backport the faster fallout algorithm

### DIFF
--- a/src/main/java/com/hbm/config/BombConfig.java
+++ b/src/main/java/com/hbm/config/BombConfig.java
@@ -80,17 +80,13 @@ public class BombConfig {
 		Property propBlastSpeed = config.get(CATEGORY_NUKE, "6.01_blastSpeed", 1024);
 		propBlastSpeed.comment = "Base speed of MK3 system (old and schrabidium) detonations (Blocks / tick)";
 		blastSpeed = propBlastSpeed.getInt();
-		// fallout range
+		// new explosion speed
 		Property propFalloutRange = config.get(CATEGORY_NUKE, "6.02_blastSpeedNew", 1024);
 		propFalloutRange.comment = "Base speed of MK4 system (new) detonations (Blocks / tick)";
 		mk4 = propFalloutRange.getInt();
-		// fallout speed
+		// fallout range
 		Property falloutRangeProp = config.get(CATEGORY_NUKE, "6.03_falloutRange", 100);
 		falloutRangeProp.comment = "Radius of fallout area (base radius * value in percent)";
 		falloutRange = falloutRangeProp.getInt();
-		// new explosion speed
-		Property falloutSpeed = config.get(CATEGORY_NUKE, "6.04_falloutSpeed", 256);
-		falloutSpeed.comment = "Blocks processed per tick by the fallout rain";
-		fSpeed = falloutSpeed.getInt();
 	}
 }

--- a/src/main/java/com/hbm/config/BombConfig.java
+++ b/src/main/java/com/hbm/config/BombConfig.java
@@ -23,7 +23,7 @@ public class BombConfig {
 	public static int mk4 = 1024;
 	public static int blastSpeed = 1024;
 	public static int falloutRange = 100;
-	public static int fSpeed = 256;
+	public static int fDelay = 4;
 	public static int limitExplosionLifespan = 0;
 	
 	public static void loadFromConfig(Configuration config) {
@@ -88,5 +88,8 @@ public class BombConfig {
 		Property falloutRangeProp = config.get(CATEGORY_NUKE, "6.03_falloutRange", 100);
 		falloutRangeProp.comment = "Radius of fallout area (base radius * value in percent)";
 		falloutRange = falloutRangeProp.getInt();
+		Property falloutDelayProp = config.get(CATEGORY_NUKE, "6.04_falloutDelay", 4);
+		falloutDelayProp.comment = "How many ticks to wait for the next fallout chunk computation";
+		fDelay = falloutDelayProp.getInt();
 	}
 }

--- a/src/main/java/com/hbm/entity/effect/EntityFalloutRain.java
+++ b/src/main/java/com/hbm/entity/effect/EntityFalloutRain.java
@@ -76,14 +76,17 @@ public class EntityFalloutRain extends Entity {
 		Set<Long> chunks = new LinkedHashSet<>(); // LinkedHashSet preserves insertion order
 		Set<Long> outerChunks = new LinkedHashSet<>();
 		int outerRange = getScale();
-		for (int angle = 0; angle <= 720; angle++) { // TODO Make this adjust to the fallout's scale
+		// Basically defines something like the step size, but as indirect proportion. The actual angle used for rotation will always end up at 360° for angle == adjustedMaxAngle
+		// So yea, I mathematically worked out that 20 is a good value for this, with the minimum possible being 18 in order to reach all chunks
+		int adjustedMaxAngle = 20 * outerRange / 32; // step size = 20 * chunks / 2
+		for (int angle = 0; angle <= adjustedMaxAngle; angle++) {
 			Vec3 vector = Vec3.createVectorHelper(outerRange, 0, 0);
-			vector.rotateAroundY((float) (angle / 180.0 * Math.PI)); // Ugh, mutable data classes (also, ugh, radians; it uses degrees in 1.18; took me two hours to debug)
+			vector.rotateAroundY((float) (angle * Math.PI / 180.0 / (adjustedMaxAngle / 360.0))); // Ugh, mutable data classes (also, ugh, radians; it uses degrees in 1.18; took me two hours to debug)
 			outerChunks.add(ChunkCoordIntPair.chunkXZ2Int((int) (posX + vector.xCoord) >> 4, (int) (posZ + vector.zCoord) >> 4));
 		}
-		for (int distance = 0; distance <= outerRange; distance += 8) for (int angle = 0; angle <= 720; angle++) {
+		for (int distance = 0; distance <= outerRange; distance += 8) for (int angle = 0; angle <= adjustedMaxAngle; angle++) {
 			Vec3 vector = Vec3.createVectorHelper(distance, 0, 0);
-			vector.rotateAroundY((float) (angle / 180.0 * Math.PI));
+			vector.rotateAroundY((float) (angle * Math.PI / 180.0 / (adjustedMaxAngle / 360.0)));
 			long chunkCoord = ChunkCoordIntPair.chunkXZ2Int((int) (posX + vector.xCoord) >> 4, (int) (posZ + vector.zCoord) >> 4);
 			if (!outerChunks.contains(chunkCoord)) chunks.add(chunkCoord);
 		}
@@ -93,7 +96,7 @@ public class EntityFalloutRain extends Entity {
 		Collections.reverse(chunksToProcess); // So it starts nicely from the middle
 		Collections.reverse(outerChunksToProcess);
 	}
-    
+
     private void stomp(int x, int z, double dist) {
     	
     	int depth = 0;


### PR DESCRIPTION
No redundant fallout calculations anymore. Block transformation chances still need to be adjusted though. You can either do that by pushing to this branch or giving me the task. For now, this will be a draft.
There is also a TODO in EntityFalloutRain that calls for self-adjusting fallout chunk precision.