### PR TITLE
Modified RBMK fuels, added effects for boron/foam on RBMK and ZIRNOX

### DIFF
--- a/src/main/java/com/hbm/blocks/generic/BlockLayering.java
+++ b/src/main/java/com/hbm/blocks/generic/BlockLayering.java
@@ -2,6 +2,7 @@ package com.hbm.blocks.generic;
 
 import java.util.Random;
 
+import com.hbm.blocks.machine.ZirnoxDestroyed;
 import com.hbm.blocks.machine.rbmk.RBMKDebris;
 
 import cpw.mods.fml.relauncher.Side;
@@ -55,7 +56,7 @@ public class BlockLayering extends Block {
 	public boolean canPlaceBlockAt(World world, int x, int y, int z) {
 		Block block = world.getBlock(x, y - 1, z);
 		
-		if(block instanceof RBMKDebris)
+		if(block instanceof RBMKDebris || block instanceof ZirnoxDestroyed)
 			return true;
 		
 		return block != Blocks.ice && block != Blocks.packed_ice ? (block.isLeaves(world, x, y - 1, z) ? true : (block == this && (world.getBlockMetadata(x, y - 1, z) & 7) == 7 ? true : block.isOpaqueCube() && block.getMaterial().blocksMovement())) : false;

--- a/src/main/java/com/hbm/blocks/machine/ZirnoxDestroyed.java
+++ b/src/main/java/com/hbm/blocks/machine/ZirnoxDestroyed.java
@@ -13,6 +13,7 @@ import com.hbm.tileentity.TileEntityProxyCombo;
 import com.hbm.tileentity.machine.TileEntityZirnoxDestroyed;
 
 import cpw.mods.fml.common.network.NetworkRegistry.TargetPoint;
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
@@ -47,13 +48,29 @@ public class ZirnoxDestroyed extends BlockDummyable {
 
 	@Override
 	public void updateTick(World world, int x, int y, int z, Random rand) {
-
-		ForgeDirection dir = ForgeDirection.getOrientation(rand.nextInt(6));
-
-		if(rand.nextInt(4) == 0 && world.getBlock(x + dir.offsetX, y + dir.offsetY + 1, z + dir.offsetZ) == Blocks.air) {
-			world.setBlock(x + dir.offsetX, y + dir.offsetY + 1, z + dir.offsetZ, ModBlocks.gas_meltdown);
+		
+		Block block = world.getBlock(x, y + 1, z);
+		
+		if(block == Blocks.air) {
+			if(rand.nextInt(10) == 0)
+				world.setBlock(x, y + 1, z, ModBlocks.gas_meltdown);
+			
+		} else if(block == ModBlocks.foam_layer || block == ModBlocks.block_foam) {
+			if(rand.nextInt(25) == 0) {
+				int pos[] = this.findCore(world, x, y, z);
+				
+				if(pos != null) {
+					TileEntity te = world.getTileEntity(pos[0], pos[1], pos[2]);
+					
+					if(te instanceof TileEntityZirnoxDestroyed)
+						((TileEntityZirnoxDestroyed)te).onFire = false;
+				}
+			}
 		}
-
+		
+		if(rand.nextInt(10) == 0 && world.getBlock(x, y + 1, z) == Blocks.air)
+			world.setBlock(x, y + 1, z, ModBlocks.gas_meltdown);
+		
 		super.updateTick(world, x, y, z, rand);
 	}
 

--- a/src/main/java/com/hbm/blocks/machine/rbmk/RBMKDebrisBurning.java
+++ b/src/main/java/com/hbm/blocks/machine/rbmk/RBMKDebrisBurning.java
@@ -43,8 +43,9 @@ public class RBMKDebrisBurning extends RBMKDebris {
 				world.setBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ, ModBlocks.gas_meltdown);
 			}
 			
-			//Foam helps stop the fire; 1.66% chance every 100-120 seconds for one side
-			int chance = block == ModBlocks.foam_layer || block == ModBlocks.block_foam ? 10 : 100;
+			//Foam helps stop the fire; Boron smothers it. 1.66% chance every 100-120 seconds for one side
+			int chance = block == ModBlocks.foam_layer || block == ModBlocks.block_foam ||
+					block == ModBlocks.sand_boron_layer || block == ModBlocks.sand_boron ? 10 : 100;
 			
 			if(rand.nextInt(chance) == 0) {
 				world.setBlock(x, y, z, ModBlocks.pribris);

--- a/src/main/java/com/hbm/blocks/machine/rbmk/RBMKDebrisBurning.java
+++ b/src/main/java/com/hbm/blocks/machine/rbmk/RBMKDebrisBurning.java
@@ -37,15 +37,14 @@ public class RBMKDebrisBurning extends RBMKDebris {
 			}
 			
 			ForgeDirection dir = ForgeDirection.getOrientation(rand.nextInt(6));
+			Block block = world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ);
 
-			if(rand.nextInt(10) == 0 && world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ) == Blocks.air) {
+			if(rand.nextInt(10) == 0 && block == Blocks.air) {
 				world.setBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ, ModBlocks.gas_meltdown);
 			}
 			
-			Block block = world.getBlock(x, y + 1, z);
-			
-			//Foam helps stop the fire.
-			int chance = block == ModBlocks.foam_layer || block == ModBlocks.block_foam ? 20 : 100;
+			//Foam helps stop the fire; ~5+ minutes to extinguish with one side exposed to foam.
+			int chance = block == ModBlocks.foam_layer || block == ModBlocks.block_foam ? 10 : 100;
 			
 			if(rand.nextInt(chance) == 0) {
 				world.setBlock(x, y, z, ModBlocks.pribris);

--- a/src/main/java/com/hbm/blocks/machine/rbmk/RBMKDebrisBurning.java
+++ b/src/main/java/com/hbm/blocks/machine/rbmk/RBMKDebrisBurning.java
@@ -8,6 +8,7 @@ import com.hbm.packet.AuxParticlePacketNT;
 import com.hbm.packet.PacketDispatcher;
 
 import cpw.mods.fml.common.network.NetworkRegistry.TargetPoint;
+import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
@@ -37,11 +38,16 @@ public class RBMKDebrisBurning extends RBMKDebris {
 			
 			ForgeDirection dir = ForgeDirection.getOrientation(rand.nextInt(6));
 
-			if(rand.nextInt(7) == 0 && world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ) == Blocks.air) {
+			if(rand.nextInt(10) == 0 && world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ) == Blocks.air) {
 				world.setBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ, ModBlocks.gas_meltdown);
 			}
 			
-			if(rand.nextInt(100) == 0) {
+			Block block = world.getBlock(x, y + 1, z);
+			
+			//Foam helps stop the fire.
+			int chance = block == ModBlocks.foam_layer || block == ModBlocks.block_foam ? 20 : 100;
+			
+			if(rand.nextInt(chance) == 0) {
 				world.setBlock(x, y, z, ModBlocks.pribris);
 			} else {
 				world.scheduleBlockUpdate(x, y, z, this, this.tickRate(world));

--- a/src/main/java/com/hbm/blocks/machine/rbmk/RBMKDebrisBurning.java
+++ b/src/main/java/com/hbm/blocks/machine/rbmk/RBMKDebrisBurning.java
@@ -43,7 +43,7 @@ public class RBMKDebrisBurning extends RBMKDebris {
 				world.setBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ, ModBlocks.gas_meltdown);
 			}
 			
-			//Foam helps stop the fire; ~5+ minutes to extinguish with one side exposed to foam.
+			//Foam helps stop the fire; 1.66% chance every 100-120 seconds for one side
 			int chance = block == ModBlocks.foam_layer || block == ModBlocks.block_foam ? 10 : 100;
 			
 			if(rand.nextInt(chance) == 0) {

--- a/src/main/java/com/hbm/blocks/machine/rbmk/RBMKDebrisRadiating.java
+++ b/src/main/java/com/hbm/blocks/machine/rbmk/RBMKDebrisRadiating.java
@@ -13,6 +13,7 @@ import com.hbm.util.ContaminationUtil.ContaminationType;
 import com.hbm.util.ContaminationUtil.HazardType;
 
 import cpw.mods.fml.common.network.NetworkRegistry.TargetPoint;
+import net.minecraft.block.Block;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
@@ -50,11 +51,16 @@ public class RBMKDebrisRadiating extends RBMKDebrisBurning {
 			
 			ForgeDirection dir = ForgeDirection.getOrientation(rand.nextInt(6));
 
-			if(rand.nextInt(5) == 0 && world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ) == Blocks.air) {
+			if(rand.nextInt(10) == 0 && world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ) == Blocks.air) {
 				world.setBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ, ModBlocks.gas_meltdown);
 			}
 			
-			if(rand.nextInt(1000) == 0) {
+			Block block = world.getBlock(x, y + 1, z);
+			
+			//Boron sand helps stop the fission reaction.
+			int chance = block == ModBlocks.sand_boron_layer || block == ModBlocks.sand_boron ? 50 : 1000;
+			
+			if(rand.nextInt(chance) == 0) {
 				
 				int meta = world.getBlockMetadata(x, y, z);
 				

--- a/src/main/java/com/hbm/blocks/machine/rbmk/RBMKDebrisRadiating.java
+++ b/src/main/java/com/hbm/blocks/machine/rbmk/RBMKDebrisRadiating.java
@@ -50,14 +50,13 @@ public class RBMKDebrisRadiating extends RBMKDebrisBurning {
 			}
 			
 			ForgeDirection dir = ForgeDirection.getOrientation(rand.nextInt(6));
-
-			if(rand.nextInt(10) == 0 && world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ) == Blocks.air) {
+			Block block = world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ);
+			
+			if(rand.nextInt(10) == 0 && block == Blocks.air) {
 				world.setBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ, ModBlocks.gas_meltdown);
 			}
 			
-			Block block = world.getBlock(x, y + 1, z);
-			
-			//Boron sand helps stop the fission reaction.
+			//Boron sand helps stop the fission reaction; ~5+ minutes to halt with one side exposed to boron sand.
 			int chance = block == ModBlocks.sand_boron_layer || block == ModBlocks.sand_boron ? 50 : 1000;
 			
 			if(rand.nextInt(chance) == 0) {

--- a/src/main/java/com/hbm/blocks/machine/rbmk/RBMKDebrisRadiating.java
+++ b/src/main/java/com/hbm/blocks/machine/rbmk/RBMKDebrisRadiating.java
@@ -56,8 +56,8 @@ public class RBMKDebrisRadiating extends RBMKDebrisBurning {
 				world.setBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ, ModBlocks.gas_meltdown);
 			}
 			
-			//Boron sand helps stop the fission reaction; ~5+ minutes to halt with one side exposed to boron sand.
-			int chance = block == ModBlocks.sand_boron_layer || block == ModBlocks.sand_boron ? 50 : 1000;
+			//Boron sand helps stop the fission reaction; 0.66% chance every 20-40 ticks for one side
+			int chance = block == ModBlocks.sand_boron_layer || block == ModBlocks.sand_boron ? 25 : 1000;
 			
 			if(rand.nextInt(chance) == 0) {
 				

--- a/src/main/java/com/hbm/entity/projectile/EntityRBMKDebris.java
+++ b/src/main/java/com/hbm/entity/projectile/EntityRBMKDebris.java
@@ -121,11 +121,12 @@ public class EntityRBMKDebris extends EntityDebrisBase {
 				}
 			}
 			
-			if(this.getType() == DebrisType.FUEL) {
-				List<EntityLivingBase> entities = worldObj.getEntitiesWithinAABB(EntityLivingBase.class, this.boundingBox.expand(10, 10, 10));
+			if(this.getType() == DebrisType.FUEL || this.getType() == DebrisType.GRAPHITE) {
+				List<EntityLivingBase> entities = worldObj.getEntitiesWithinAABB(EntityLivingBase.class, this.boundingBox.expand(2.5, 2.5, 2.5));
 				
+				int level = this.getType() == DebrisType.FUEL ? 9 : 4;
 				for(EntityLivingBase e : entities) {
-					e.addPotionEffect(new PotionEffect(HbmPotion.radiation.id, 60 * 20, 9));
+					e.addPotionEffect(new PotionEffect(HbmPotion.radiation.id, 60 * 20, level));
 				}
 			}
 			

--- a/src/main/java/com/hbm/entity/projectile/EntityZirnoxDebris.java
+++ b/src/main/java/com/hbm/entity/projectile/EntityZirnoxDebris.java
@@ -116,10 +116,11 @@ public class EntityZirnoxDebris extends EntityDebrisBase {
 			}
 
 			if(this.getType() == DebrisType.ELEMENT || this.getType() == DebrisType.GRAPHITE) {
-				List<EntityLivingBase> entities = worldObj.getEntitiesWithinAABB(EntityLivingBase.class, this.boundingBox.expand(10, 10, 10));
-
+				List<EntityLivingBase> entities = worldObj.getEntitiesWithinAABB(EntityLivingBase.class, this.boundingBox.expand(2.5, 2.5, 2.5));
+				
+				int level = this.getType() == DebrisType.ELEMENT ? 7 : 4;
 				for(EntityLivingBase e : entities) {
-					e.addPotionEffect(new PotionEffect(HbmPotion.radiation.id, 60 * 20, 4));
+					e.addPotionEffect(new PotionEffect(HbmPotion.radiation.id, 60 * 20, level));
 				}
 			}
 

--- a/src/main/java/com/hbm/inventory/recipes/SILEXRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/SILEXRecipes.java
@@ -277,8 +277,8 @@ public class SILEXRecipes {
 					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nugget_les), 90 - i * 20))			//Just bullshit something about "not enough np237 for extractable amounts of xe135"
 					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_long_tiny, 1, ItemWasteLong.WasteClass.NEPTUNIUM.ordinal()), 2 + 3 * i))
 					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_short_tiny, 1, ItemWasteShort.WasteClass.NEPTUNIUM.ordinal()), 2 + 5 * i))
-					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_long_tiny, 1, ItemWasteLong.WasteClass.SCHRABIDIUM.ordinal()), 1 + 1 * i))
-					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_short_tiny, 1, ItemWasteShort.WasteClass.SCHRABIDIUM.ordinal()), 1 + 3 * i))
+					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_long_tiny, 1, ItemWasteLong.WasteClass.SCHRABIDIUM.ordinal()), 1 + 2 * i))
+					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_short_tiny, 1, ItemWasteShort.WasteClass.SCHRABIDIUM.ordinal()), 1 + 2 * i))
 					.addOut(new WeightedRandomObject(new ItemStack(ModItems.powder_coal_tiny), 4 + 8 * i)) ); 
 						
 			// MES //
@@ -286,18 +286,18 @@ public class SILEXRecipes {
 					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nugget_schrabidium_fuel), 90 - i * 20))
 					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_long_tiny, 1, ItemWasteLong.WasteClass.NEPTUNIUM.ordinal()), 1 + 3 * i))
 					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_short_tiny, 1, ItemWasteShort.WasteClass.NEPTUNIUM.ordinal()), 2 + 4 * i))
-					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_long_tiny, 1, ItemWasteLong.WasteClass.SCHRABIDIUM.ordinal()), 1 + 2 * i))
+					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_long_tiny, 1, ItemWasteLong.WasteClass.SCHRABIDIUM.ordinal()), 1 + 3 * i))
 					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_short_tiny, 1, ItemWasteShort.WasteClass.SCHRABIDIUM.ordinal()), 2 + 4 * i))
-					.addOut(new WeightedRandomObject(new ItemStack(ModItems.powder_coal_tiny), 4 + 7 * i)) );
+					.addOut(new WeightedRandomObject(new ItemStack(ModItems.powder_coal_tiny), 4 + 6 * i)) );
 				    
 			//TODO: Readd xenon processing if/when the NEI handler can display more than 6 outputs properly
 			recipes.put(new ComparableStack(ModItems.rbmk_pellet_mes, 1, i + 5), new SILEXRecipe(600, 100, 2)
 					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nugget_schrabidium_fuel), 90 - i * 20)) //ditto
-					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_long_tiny, 1, ItemWasteLong.WasteClass.NEPTUNIUM.ordinal()), 1 + 2 * i))
+					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_long_tiny, 1, ItemWasteLong.WasteClass.NEPTUNIUM.ordinal()), 1 + 3 * i))
 					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_short_tiny, 1, ItemWasteShort.WasteClass.NEPTUNIUM.ordinal()), 2 + 4 * i))
 					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_long_tiny, 1, ItemWasteLong.WasteClass.SCHRABIDIUM.ordinal()), 1 + 3 * i))
 					.addOut(new WeightedRandomObject(new ItemStack(ModItems.nuclear_waste_short_tiny, 1, ItemWasteShort.WasteClass.SCHRABIDIUM.ordinal()), 2 + 4 * i))
-					.addOut(new WeightedRandomObject(new ItemStack(ModItems.powder_coal_tiny), 4 + 7 * i)) );
+					.addOut(new WeightedRandomObject(new ItemStack(ModItems.powder_coal_tiny), 4 + 6 * i)) );
 				    
 			// HES //
 			recipes.put(new ComparableStack(ModItems.rbmk_pellet_hes, 1, i), new SILEXRecipe(600, 100, 2)

--- a/src/main/java/com/hbm/inventory/recipes/ShredderRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/ShredderRecipes.java
@@ -339,6 +339,7 @@ public class ShredderRecipes {
 		ShredderRecipes.setRecipe(ModItems.debris_exchanger, new ItemStack(ModItems.powder_steel, 3));
 		ShredderRecipes.setRecipe(ModItems.debris_element, new ItemStack(ModItems.scrap_nuclear, 4));
 		ShredderRecipes.setRecipe(ModItems.debris_metal, new ItemStack(ModItems.powder_steel_tiny, 3));
+		ShredderRecipes.setRecipe(ModItems.debris_graphite, new ItemStack(ModItems.powder_coal, 1));
 		
 		/*
 		 * GC COMPAT

--- a/src/main/java/com/hbm/inventory/recipes/anvil/AnvilRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/anvil/AnvilRecipes.java
@@ -696,10 +696,9 @@ public class AnvilRecipes {
 
 		constructionRecipes.add(new AnvilConstructionRecipe(
 				new ComparableStack(ModBlocks.machine_turbine), new AnvilOutput[] {
-						new AnvilOutput(new ItemStack(ModItems.turbine_titanium, 2)),
-						new AnvilOutput(new ItemStack(ModItems.motor, 1)),
-						new AnvilOutput(new ItemStack(ModItems.tank_steel, 2)),
-						new AnvilOutput(new ItemStack(ModItems.plate_titanium, 4))
+						new AnvilOutput(new ItemStack(ModItems.turbine_titanium, 1)),
+						new AnvilOutput(new ItemStack(ModItems.coil_copper, 2)),
+						new AnvilOutput(new ItemStack(ModItems.ingot_steel, 6))
 						}).setTier(3));
 		
 		constructionRecipes.add(new AnvilConstructionRecipe(

--- a/src/main/java/com/hbm/items/ModItems.java
+++ b/src/main/java/com/hbm/items/ModItems.java
@@ -3671,7 +3671,7 @@ public class ModItems {
 				.setStats(15)
 				.setFunction(EnumBurnFunc.LOG_TEN)
 				.setDepletionFunction(EnumDepleteFunc.RAISING_SLOPE)
-				.setHeat(0.5)
+				.setHeat(0.65) //0.5 is too much of a nerf in heat; pu239 buildup justifies it being on par with MEU ig
 				.setMeltingPoint(2865)
 				.setUnlocalizedName("rbmk_fuel_ueu").setTextureName(RefStrings.MODID + ":rbmk_fuel_ueu");
 		rbmk_fuel_meu = (ItemRBMKRod) new ItemRBMKRod(rbmk_pellet_meu)
@@ -3679,7 +3679,7 @@ public class ModItems {
 				.setStats(20)
 				.setFunction(EnumBurnFunc.LOG_TEN)
 				.setDepletionFunction(EnumDepleteFunc.RAISING_SLOPE)
-				.setHeat(0.65) //0.75 was a bit too much
+				.setHeat(0.65) //0.75 was a bit too much...
 				.setMeltingPoint(2865)
 				.setUnlocalizedName("rbmk_fuel_meu").setTextureName(RefStrings.MODID + ":rbmk_fuel_meu");
 		rbmk_fuel_heu233 = (ItemRBMKRod) new ItemRBMKRod(rbmk_pellet_heu233)

--- a/src/main/java/com/hbm/items/ModItems.java
+++ b/src/main/java/com/hbm/items/ModItems.java
@@ -3684,14 +3684,14 @@ public class ModItems {
 				.setUnlocalizedName("rbmk_fuel_meu").setTextureName(RefStrings.MODID + ":rbmk_fuel_meu");
 		rbmk_fuel_heu233 = (ItemRBMKRod) new ItemRBMKRod(rbmk_pellet_heu233)
 				.setYield(100000000D)
-				.setStats(50)
-				.setFunction(EnumBurnFunc.SQUARE_ROOT)
+				.setStats(27.5D)
+				.setFunction(EnumBurnFunc.LINEAR)
 				.setHeat(1.25D)
 				.setMeltingPoint(2865)
 				.setUnlocalizedName("rbmk_fuel_heu233").setTextureName(RefStrings.MODID + ":rbmk_fuel_heu233");
 		rbmk_fuel_heu235 = (ItemRBMKRod) new ItemRBMKRod(rbmk_pellet_heu235)
 				.setYield(100000000D)
-				.setStats(40)
+				.setStats(50) //Consistency with HEN; its critical mass is too high to justify a linear function
 				.setFunction(EnumBurnFunc.SQUARE_ROOT)
 				.setMeltingPoint(2865)
 				.setUnlocalizedName("rbmk_fuel_heu235").setTextureName(RefStrings.MODID + ":rbmk_fuel_heu235");
@@ -3768,7 +3768,7 @@ public class ModItems {
 				.setDepletionFunction(EnumDepleteFunc.RAISING_SLOPE)
 				.setHeat(0.75)
 				.setMeltingPoint(2800)
-				.setNeutronTypes(NType.FAST, NType.FAST)
+				.setNeutronTypes(NType.ANY, NType.FAST) //Build-up of Pu-239 leads to both speeds of neutrons grooving
 				.setUnlocalizedName("rbmk_fuel_men").setTextureName(RefStrings.MODID + ":rbmk_fuel_men");
 		rbmk_fuel_hen = (ItemRBMKRod) new ItemRBMKRod(rbmk_pellet_hen)
 				.setYield(100000000D)
@@ -3788,9 +3788,9 @@ public class ModItems {
 				.setYield(100000000D)
 				.setStats(50)
 				.setFunction(EnumBurnFunc.SQUARE_ROOT)
-				.setDepletionFunction(EnumDepleteFunc.RAISING_SLOPE)
 				.setHeat(1.25D)
 				.setMeltingPoint(2500)
+				.setNeutronTypes(NType.SLOW, NType.SLOW) //Beryllium Moderation
 				.setUnlocalizedName("rbmk_fuel_les").setTextureName(RefStrings.MODID + ":rbmk_fuel_les");
 		rbmk_fuel_mes = (ItemRBMKRod) new ItemRBMKRod(rbmk_pellet_mes)
 				.setYield(100000000D)
@@ -3824,13 +3824,14 @@ public class ModItems {
 				.setMeltingPoint(5211).setUnlocalizedName("rbmk_fuel_heaus").setTextureName(RefStrings.MODID + ":rbmk_fuel_heaus");
 		rbmk_fuel_po210be = (ItemRBMKRod) new ItemRBMKRod(rbmk_pellet_po210be)
 				.setYield(25000000D)
-				.setStats(15, 40)
-				.setFunction(EnumBurnFunc.SQUARE_ROOT)
+				.setStats(0D, 50)
+				.setFunction(EnumBurnFunc.PASSIVE)
 				.setDepletionFunction(EnumDepleteFunc.LINEAR)
 				.setXenon(0.0D, 50D)
 				.setHeat(0.1D)
 				.setDiffusion(0.05D)
 				.setMeltingPoint(1287)
+				.setNeutronTypes(NType.SLOW, NType.SLOW) //Beryllium Moderation
 				.setUnlocalizedName("rbmk_fuel_po210be").setTextureName(RefStrings.MODID + ":rbmk_fuel_po210be");
 		rbmk_fuel_ra226be = (ItemRBMKRod) new ItemRBMKRod(rbmk_pellet_ra226be)
 				.setYield(100000000D)
@@ -3841,14 +3842,16 @@ public class ModItems {
 				.setHeat(0.035D)
 				.setDiffusion(0.5D)
 				.setMeltingPoint(700)
+				.setNeutronTypes(NType.SLOW, NType.SLOW) //Beryllium Moderation
 				.setUnlocalizedName("rbmk_fuel_ra226be").setTextureName(RefStrings.MODID + ":rbmk_fuel_ra226be");
 		rbmk_fuel_pu238be = (ItemRBMKRod) new ItemRBMKRod(rbmk_pellet_pu238be)
 				.setYield(50000000D)
-				.setStats(10, 50)
+				.setStats(40, 40)
 				.setFunction(EnumBurnFunc.SQUARE_ROOT)
 				.setHeat(0.1D)
 				.setDiffusion(0.05D)
 				.setMeltingPoint(1287)
+				.setNeutronTypes(NType.SLOW, NType.SLOW) //Beryllium Moderation
 				.setUnlocalizedName("rbmk_fuel_pu238be").setTextureName(RefStrings.MODID + ":rbmk_fuel_pu238be");
 		rbmk_fuel_balefire_gold = (ItemRBMKRod) new ItemRBMKRod(rbmk_pellet_balefire_gold)
 				.setYield(100000000D)

--- a/src/main/java/com/hbm/items/machine/ItemRBMKRod.java
+++ b/src/main/java/com/hbm/items/machine/ItemRBMKRod.java
@@ -219,7 +219,7 @@ public class ItemRBMKRod extends Item {
 		PASSIVE(EnumChatFormatting.DARK_GREEN + "SAFE / PASSIVE"),			//const, no reactivity
 		LOG_TEN(EnumChatFormatting.YELLOW + "MEDIUM / LOGARITHMIC"),		//log10(x + 1) * reactivity * 50
 		PLATEU(EnumChatFormatting.GREEN + "SAFE / EULER"),					//(1 - e^(-x/25)) * reactivity * 100
-		ARCH(EnumChatFormatting.YELLOW + "MEDIUM / NEGATIVE-QUADRATIC"),	//x-(x²/1000) * reactivity
+		ARCH(EnumChatFormatting.RED + "DANGEROUS / NEGATIVE-QUADRATIC"),	//x-(x²/1000) * reactivity
 		SIGMOID(EnumChatFormatting.GREEN + "SAFE / SIGMOID"),				//100 / (1 + e^(-(x - 50) / 10)) <- tiny amount of reactivity at x=0 !
 		SQUARE_ROOT(EnumChatFormatting.YELLOW + "MEDIUM / SQUARE ROOT"),	//sqrt(x) * 10 * reactivity
 		LINEAR(EnumChatFormatting.RED + "DANGEROUS / LINEAR"),				//x * reactivity

--- a/src/main/java/com/hbm/items/tool/ItemDyatlov.java
+++ b/src/main/java/com/hbm/items/tool/ItemDyatlov.java
@@ -1,8 +1,11 @@
 package com.hbm.items.tool;
 
+import com.hbm.blocks.machine.ReactorZirnox;
 import com.hbm.blocks.machine.rbmk.RBMKBase;
+import com.hbm.tileentity.machine.TileEntityReactorZirnox;
 import com.hbm.tileentity.machine.rbmk.TileEntityRBMKBase;
 
+import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -15,9 +18,11 @@ public class ItemDyatlov extends Item {
 		
 		if(!world.isRemote) {
 			
-			if(world.getBlock(x, y, z) instanceof RBMKBase) {
+			Block block = world.getBlock(x, y, z);
+			
+			if(block instanceof RBMKBase) {
 				
-				RBMKBase rbmk = (RBMKBase)world.getBlock(x, y, z);
+				RBMKBase rbmk = (RBMKBase)block;
 				
 				int[] pos = rbmk.findCore(world, x, y, z);
 				
@@ -29,6 +34,22 @@ public class ItemDyatlov extends Item {
 
 						((TileEntityRBMKBase)te).meltdown();
 						//((TileEntityRBMKBase)te).heat = 100000;
+					}
+				}
+			}
+			
+			if(block instanceof ReactorZirnox) {
+				
+				ReactorZirnox zirnox = (ReactorZirnox)block;
+				
+				int[] pos = zirnox.findCore(world, x, y, z);
+				
+				if(pos != null) {
+					
+					TileEntity te = world.getTileEntity(pos[0], pos[1], pos[2]);
+					
+					if(te instanceof TileEntityReactorZirnox) {
+						((TileEntityReactorZirnox)te).heat = 200000;
 					}
 				}
 			}

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityZirnoxDestroyed.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityZirnoxDestroyed.java
@@ -21,13 +21,30 @@ import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
 public class TileEntityZirnoxDestroyed extends TileEntity {
-
+	
+	public boolean onFire = true;
+	
+	@Override
+	public void readFromNBT(NBTTagCompound nbt) {
+		super.readFromNBT(nbt);
+		onFire = nbt.getBoolean("fire");
+	}
+	
+	@Override
+	public void writeToNBT(NBTTagCompound nbt) {
+		super.writeToNBT(nbt);
+		nbt.setBoolean("onFire", onFire);
+	}
+	
 	@Override
 	public void updateEntity() {
 		if(!worldObj.isRemote) {
 			radiate(worldObj, this.xCoord, this.yCoord, this.zCoord);
 			
-			if(this.worldObj.getTotalWorldTime() % 50 == 0) {
+			if(this.worldObj.rand.nextInt(5000) == 0)
+				onFire = false;
+			
+			if(onFire && this.worldObj.getTotalWorldTime() % 50 == 0) {
 				NBTTagCompound data = new NBTTagCompound();
 				data.setString("type", "rbmkflame");
 				data.setInteger("maxAge", 90);
@@ -40,7 +57,7 @@ public class TileEntityZirnoxDestroyed extends TileEntity {
 
 	private void radiate(World world, int x, int y, int z) {
 
-		float rads = 500000F;
+		float rads = onFire ? 500000F : 75000F;
 		double range = 100D;
 
 		List<EntityLivingBase> entities = world.getEntitiesWithinAABB(EntityLivingBase.class, AxisAlignedBB.getBoundingBox(x + 0.5, y + 0.5, z + 0.5, x + 0.5, y + 0.5, z + 0.5).expand(range, range, range));
@@ -71,7 +88,7 @@ public class TileEntityZirnoxDestroyed extends TileEntity {
 
 			ContaminationUtil.contaminate(e, HazardType.RADIATION, ContaminationType.CREATIVE, eRads);
 
-			if(len < 5) {
+			if(onFire && len < 5) {
 				e.attackEntityFrom(DamageSource.onFire, 2);
 			}
 		}

--- a/src/main/java/com/hbm/world/worldgen/ComponentNTMFeatures.java
+++ b/src/main/java/com/hbm/world/worldgen/ComponentNTMFeatures.java
@@ -1024,7 +1024,7 @@ public class ComponentNTMFeatures {
 			this.fillWithBlocks(world, box, featureSizeX, 0, 5, featureSizeX, 1, 5, ModBlocks.concrete_pillar, Blocks.air, false); //Back Wall Pt. 2
 			this.fillWithRandomizedBlocks(world, box, 6, 0, 5, featureSizeX - 1, 0, 5, false, rand, RandomConcreteBricks);
 			this.fillWithRandomizedBlocks(world, box, 6, 1, 5, 6, 1, 5, false, rand, RandomConcreteBricks);
-			this.fillWithRandomizedBlocks(world, box, featureSizeX - 1, 1, 5, featureSizeX + 1, 1, 5, false, rand, RandomConcreteBricks);
+			this.fillWithRandomizedBlocks(world, box, featureSizeX - 1, 1, 5, featureSizeX - 1, 1, 5, false, rand, RandomConcreteBricks);
 			this.fillWithBlocks(world, box, featureSizeX, 0, featureSizeZ, featureSizeX, 1, featureSizeZ, ModBlocks.concrete_pillar, Blocks.air, false); //Right Wall Pt. 2
 			this.fillWithRandomizedBlocks(world, box, featureSizeX, 0, 6, featureSizeX, 0, featureSizeZ - 1, false, rand, RandomConcreteBricks);
 			this.fillWithRandomizedBlocks(world, box, featureSizeX, 1, 6, featureSizeX, 1, featureSizeZ - 3, false, rand, RandomConcreteBricks);


### PR DESCRIPTION
CoC:

- Boron sand and foam effects on, along with changes to, destroyed reactors
  - BlockLayering can now be placed on the destroyed ZIRNOX
    - Using foam over the entire area will extinguish it much quicker than naturally, reducing the radiation output massively and preventing fire damage when close
    - Lowered chance of meltdown gas spawning
  - RBMK Debris
    - Lowered chance of meltdown gas spawning for both
    - Using boron sand on smoldering RBMK debris will help stop the fission reaction/cool down the debris much quicker than naturally
    - Using foam on burning RBMK debris will extinguish the flames much quicker than naturally
  - Reduced the BB size for certain debris types to apply contamination (no idea why it was *10*). Added RBMK graphite to the contaminating type, with the RBMK rod and ZIRNOX element types applying higher levels of contamination. Also, shredding for graphite.
- Dyatlov Meltdown Applicator can now be used on the ZIRNOX by shift-clicking
- Changed the localization for Negative-quadratic to dangerous, to more accurately reflect the level of caution necessary
- RBMK fuel stat changes
  - Neutron sources, LES now split into slow neutrons, due to the concentration of beryllium moderating fast neutrons
  - Pu238be and Po210be stats/functions changed respectively to make them actually useful
  - HEU233 and HEU235 changed to linear function/50 reactivity respectively, in order to respect their highly-enriched status
    - HEU235 is still square root in order to be consistent with HEN, which possesses a similar critical mass
  - MEN now splits with any neutrons; this is due to the build-up of Pu-239 from U-238 breeding, allowing both types of neutrons to jive with the Np-237/Pu-239 respectively
  - UEU heat changed to 0.65; I did not really like this change, since I wanted to keep the heat outputs dependent on enrichment, but for a low-power fuel like UEU, 0.5 is too much of a nerf. Either way, MEU will always have a higher heat output due to its higher flux function, so it works out.
- Fixed #620 by changing the recipe to match
- Fixed a little error in one of the NTM Ruins