### PR TITLE
Some more changes with OpenComputers integration

### DIFF
--- a/src/main/java/com/hbm/tileentity/bomb/TileEntityLaunchPad.java
+++ b/src/main/java/com/hbm/tileentity/bomb/TileEntityLaunchPad.java
@@ -33,7 +33,6 @@ import com.hbm.blocks.bomb.LaunchPad;
 @Optional.InterfaceList({@Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers")})
 public class TileEntityLaunchPad extends TileEntityLoadedBase implements ISidedInventory, IEnergyUser, SimpleComponent {
 
-	public LaunchPad launchpadBlock = (LaunchPad) ModBlocks.launch_pad;
 	public ItemStack slots[];
 	
 	public long power;
@@ -318,7 +317,7 @@ public class TileEntityLaunchPad extends TileEntityLoadedBase implements ISidedI
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] launch(Context context, Arguments args) {
 		//worldObj.getBlock(xCoord, yCoord, zCoord).explode(worldObj, xCoord, yCoord, zCoord);	
-		launchpadBlock.explode(worldObj, xCoord, yCoord, zCoord);
+		((LaunchPad) ModBlocks.launch_pad).explode(worldObj, xCoord, yCoord, zCoord);
 		return new Object[] {};
 	}
 }

--- a/src/main/java/com/hbm/tileentity/bomb/TileEntityLaunchPad.java
+++ b/src/main/java/com/hbm/tileentity/bomb/TileEntityLaunchPad.java
@@ -19,8 +19,21 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class TileEntityLaunchPad extends TileEntityLoadedBase implements ISidedInventory, IEnergyUser {
+import cpw.mods.fml.common.Optional;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.SimpleComponent;
 
+import api.hbm.item.IDesignatorItem;
+import net.minecraft.block.Block;
+import com.hbm.blocks.ModBlocks;
+import com.hbm.blocks.bomb.LaunchPad;
+
+@Optional.InterfaceList({@Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers")})
+public class TileEntityLaunchPad extends TileEntityLoadedBase implements ISidedInventory, IEnergyUser, SimpleComponent {
+
+	public LaunchPad launchpadBlock = (LaunchPad) ModBlocks.launch_pad;
 	public ItemStack slots[];
 	
 	public long power;
@@ -30,7 +43,6 @@ public class TileEntityLaunchPad extends TileEntityLoadedBase implements ISidedI
 	private static final int[] slots_bottom = new int[] { 0, 1, 2};
 	private static final int[] slots_side = new int[] {0};
 	public int state = 0;
-	
 	private String customName;
 	
 	public TileEntityLaunchPad() {
@@ -255,5 +267,58 @@ public class TileEntityLaunchPad extends TileEntityLoadedBase implements ISidedI
 	public double getMaxRenderDistanceSquared()
 	{
 		return 65536.0D;
+	}
+	
+	// do some opencomputer stuff
+	@Override
+	public String getComponentName() {
+		return "launch_pad";
+	}
+	
+	@Callback
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getEnergyStored(Context context, Arguments args) {
+		return new Object[] {getPower()};
+	}
+	@Callback
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getMaxEnergy(Context context, Arguments args) {
+		return new Object[] {getMaxPower()};
+	}
+	
+	@Callback
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getCoords(Context context, Arguments args) {
+		if (slots[1] != null && slots[1].getItem() instanceof IDesignatorItem) {
+			int xCoord2 = slots[1].stackTagCompound.getInteger("xCoord");
+			int zCoord2 = slots[1].stackTagCompound.getInteger("zCoord");
+
+			// Not sure if i should have this
+			if(xCoord2 == xCoord && zCoord2 == zCoord) {
+				xCoord2 += 1;
+			}
+			
+			return new Object[] {xCoord2, zCoord2};
+		}
+		return new Object[] {"Designator not found"};
+	}
+	@Callback
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] setCoords(Context context, Arguments args) {
+		if (slots[1] != null && slots[1].getItem() instanceof IDesignatorItem) {
+			slots[1].stackTagCompound.setInteger("xCoord", args.checkInteger(0));
+			slots[1].stackTagCompound.setInteger("zCoord", args.checkInteger(1));
+			
+			return new Object[] {"Success"};
+		}
+		return new Object[] {"Designator not found"};
+	}
+	
+	@Callback
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] launch(Context context, Arguments args) {
+		//worldObj.getBlock(xCoord, yCoord, zCoord).explode(worldObj, xCoord, yCoord, zCoord);	
+		launchpadBlock.explode(worldObj, xCoord, yCoord, zCoord);
+		return new Object[] {};
 	}
 }

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityCoreEmitter.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityCoreEmitter.java
@@ -339,16 +339,18 @@ public class TileEntityCoreEmitter extends TileEntityMachineBase implements IEne
 	@Callback
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] setActive(Context context, Arguments args) {
-		isOn = Boolean.parseBoolean(args.checkString(0));
+		isOn = args.checkBoolean(0);
 		return new Object[] {};
 	}
 
 	@Callback
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] setInput(Context context, Arguments args) {
-		int newOutput = Integer.parseInt(args.checkString(0));
+		int newOutput = args.checkInteger(0);
 		if (newOutput > 100) {
 			newOutput = 100;
+		} else if (newOutput < 0) {
+			newOutput = 0;
 		}
 		watts = newOutput;
 		return new Object[] {};

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityCoreStabilizer.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityCoreStabilizer.java
@@ -197,9 +197,11 @@ public class TileEntityCoreStabilizer extends TileEntityMachineBase implements I
 	@Callback
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] setInput(Context context, Arguments args) {
-		int newOutput = Integer.parseInt(args.checkString(0));
+		int newOutput = args.checkInteger(0);
 		if (newOutput > 100) {
 			newOutput = 100;
+		} else if (newOutput < 0) {
+			newOutput = 0;
 		}
 		watts = newOutput;
 		return new Object[] {};

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityReactorResearch.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityReactorResearch.java
@@ -413,9 +413,11 @@ public class TileEntityReactorResearch extends TileEntityMachineBase implements 
 	@Callback
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] setLevel(Context context, Arguments args) {
-		double newLevel = Double.parseDouble(args.checkString(0))/100.0;
-		if (newLevel > 1) { // check if its above 100 so the control rod wont do funny things
-			newLevel = 1;
+		double newLevel = args.checkDouble(0)/100.0;
+		if (newLevel > 1.0) {
+			newLevel = 1.0;
+		} else if (newLevel < 0.0) {
+			newLevel = 0.0;
 		}
 		targetLevel = newLevel;
 		return new Object[] {};

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityReactorZirnox.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityReactorZirnox.java
@@ -578,7 +578,7 @@ public class TileEntityReactorZirnox extends TileEntityMachineBase implements IF
 	@Callback
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] setActive(Context context, Arguments args) {
-		isOn = Boolean.parseBoolean(args.checkString(0));
+		isOn = args.checkBoolean(0);
 		return new Object[] {};
 	}
 }

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKBoiler.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKBoiler.java
@@ -23,7 +23,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.Vec3;
 
-public class TileEntityRBMKBoiler extends TileEntityRBMKSlottedBase implements IFluidAcceptor, IFluidSource, IControlReceiver, IFluidStandardTransceiver {
+import cpw.mods.fml.common.Optional;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.SimpleComponent;
+
+@Optional.InterfaceList({@Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers")})
+public class TileEntityRBMKBoiler extends TileEntityRBMKSlottedBase implements IFluidAcceptor, IFluidSource, IControlReceiver, IFluidStandardTransceiver, SimpleComponent {
 	
 	public FluidTank feed;
 	public FluidTank steam;
@@ -313,5 +320,39 @@ public class TileEntityRBMKBoiler extends TileEntityRBMKSlottedBase implements I
 	@Override
 	public FluidTank[] getReceivingTanks() {
 		return new FluidTank[] {feed};
+	}
+	
+	// do some opencomputer stuff
+	@Override
+	public String getComponentName() {
+		return "rbmk_boiler";
+	}
+	
+	@Callback
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getHeat(Context context, Arguments args) {
+		return new Object[] {heat};
+	}
+	
+	@Callback
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getSteam(Context context, Arguments args) {
+		return new Object[] {steam.getFill()};
+	}
+	@Callback
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getSteamMax(Context context, Arguments args) {
+		return new Object[] {steam.getMaxFill()};
+	}
+	
+	@Callback
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getWater(Context context, Arguments args) {
+		return new Object[] {feed.getFill()};
+	}
+	@Callback
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getWaterMax(Context context, Arguments args) {
+		return new Object[] {feed.getMaxFill()};
 	}
 }

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKControl.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKControl.java
@@ -131,13 +131,13 @@ public abstract class TileEntityRBMKControl extends TileEntityRBMKSlottedBase im
 	@Callback
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getLevel(Context context, Arguments args) {
-		return new Object[] {getMult()};
+		return new Object[] {getMult() * 100};
 	}
 
 	@Callback
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getTargetLevel(Context context, Arguments args) {
-		return new Object[] {targetLevel};
+		return new Object[] {targetLevel * 100};
 	}
 
 

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKControl.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKControl.java
@@ -150,10 +150,12 @@ public abstract class TileEntityRBMKControl extends TileEntityRBMKSlottedBase im
 	@Callback
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] setLevel(Context context, Arguments args) {
-		double newLevel = Double.parseDouble(args.checkString(0))/100.0;
-		if (newLevel > 1) { // check if its above 100 so the control rod wont do funny things
-			newLevel = 1;
-		}
+		double newLevel = args.checkDouble(0)/100.0;
+		if (newLevel > 1.0) {
+			newLevel = 1.0;
+		} else if (newLevel < 0.0) {
+			newLevel = 0.0;
+		}	
 		targetLevel = newLevel;
 		return new Object[] {};
 	}


### PR DESCRIPTION
changes:
- fixed OpenComputers functions that use numbers/booleans for the args
- fixed TileEntityRBMKControl setLevel function being able to go negative, allowing players to easily cheese progression
- fixed TileEntityReactorResearch setLevel function for the same reason above
- fixed TileEntityCoreEmitter setInput function being able to go negative
- fixed TileEntityCoreStabilizer setInput function for the same reason above
- added compat for TileEntityRBMKBoiler
- added compat for TileEntityLaunchPad