### PR TITLE
Small fixes

### DIFF
--- a/src/main/java/com/hbm/items/machine/ItemRBMKRod.java
+++ b/src/main/java/com/hbm/items/machine/ItemRBMKRod.java
@@ -205,7 +205,7 @@ public class ItemRBMKRod extends Item {
 			double avg = (heat + hullHeat + coreHeat) / 3D;
 			this.setCoreHeat(stack, avg);
 			this.setHullHeat(stack, avg);
-			return avg;
+			return avg - heat;
 		}
 		
 		if(hullHeat <= heat)

--- a/src/main/java/com/hbm/tileentity/machine/oil/TileEntityOilDrillBase.java
+++ b/src/main/java/com/hbm/tileentity/machine/oil/TileEntityOilDrillBase.java
@@ -199,7 +199,7 @@ public abstract class TileEntityOilDrillBase extends TileEntityMachineBase imple
 	
 	public int getDelayEff() {
 		int delay = getDelay();
-		return Math.max((delay - (delay / 4 * this.speedLevel) + (delay / 10 * this.energyLevel) / this.overLevel), 1);
+		return Math.max((delay - (delay / 4 * this.speedLevel) + (delay / 10 * this.energyLevel)) / this.overLevel, 1);
 	}
 	
 	public abstract int getPowerReq();


### PR DESCRIPTION
1. Oil wells now actually benefit from using the overdrive upgrade (The old behavior meant that overdrive only affected the speed decrease from power-savings upgrades, and using overdrive + power-savings was still slower than not using either upgrade to begin with while also consuming as much, if not more, power)
2. RBMK fuel items that exceed their max temperature no longer cause reactor temperatures to skyrocket exponentially when DisableMeltdowns is enabled. (Old behavior meant that RBMK rods would have their temperature increased by the average heat instead of being made equal to the average heat of the three components)