### PR TITLE
More uses for the heat system

### DIFF
--- a/src/main/java/com/hbm/blocks/machine/HeaterElectric.java
+++ b/src/main/java/com/hbm/blocks/machine/HeaterElectric.java
@@ -75,17 +75,25 @@ public class HeaterElectric extends BlockDummyable implements ILookOverlay, IToo
 		TileEntityHeaterElectric heater = (TileEntityHeaterElectric) te;
 
 		List<String> text = new ArrayList();
-		text.add(String.format("%,d", heater.heatEnergy) + " TU");
-		text.add(EnumChatFormatting.GREEN + "-> " + EnumChatFormatting.RESET + heater.getConsumption() + " HE/t");
-		text.add(EnumChatFormatting.RED + "<- " + EnumChatFormatting.RESET + heater.getHeatGen() + " TU/t");
-		
+        if(!heater.mode)
+		{
+			text.add(String.format("%,d", heater.heatEnergy) + " TU");
+			text.add(EnumChatFormatting.GREEN + "-> " + EnumChatFormatting.RESET + heater.getConsumption() + " HE/t");
+			text.add(EnumChatFormatting.RED + "<- " + EnumChatFormatting.RESET + heater.getHeatGen() + " TU/t");
+		}
+		else {
+			text.add( I18nUtil.resolveKey("info.hold_heat"));
+			text.add(String.format("%,d", heater.heatEnergy) + " TU");
+			text.add(I18nUtil.resolveKey("info.hold") + String.format("%,d", heater.holdheat) + " TU");
+			text.add(EnumChatFormatting.GREEN + "-> " + EnumChatFormatting.RESET + heater.getConsumption() + " HE/t");
+		}
 		ILookOverlay.printGeneric(event, I18nUtil.resolveKey(getUnlocalizedName() + ".name"), 0xffff00, 0x404000, text);
 	}
 
 	@Override
 	public boolean onScrew(World world, EntityPlayer player, int x, int y, int z, int side, float fX, float fY, float fZ, ToolType tool) {
 		
-		if(tool != ToolType.SCREWDRIVER)
+		if(tool != ToolType.SCREWDRIVER && tool != ToolType.HAND_DRILL)
 			return false;
 		
 		if(world.isRemote) return true;
@@ -99,8 +107,16 @@ public class HeaterElectric extends BlockDummyable implements ILookOverlay, IToo
 		if(!(te instanceof TileEntityHeaterElectric)) return false;
 		
 		TileEntityHeaterElectric tile = (TileEntityHeaterElectric) te;
-		tile.toggleSetting();
+		switch (tool) {
+			case SCREWDRIVER:
+                tile.toggleSetting();
+                break;
+            case HAND_DRILL:
+                tile.modeSetting();
+                break;
+		}
 		tile.markDirty();
+
 		
 		return true;
 	}

--- a/src/main/java/com/hbm/blocks/machine/MachineFractionTower.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineFractionTower.java
@@ -113,10 +113,11 @@ public class MachineFractionTower extends BlockDummyable implements ILookOverlay
 		TileEntityMachineFractionTower cracker = (TileEntityMachineFractionTower) te;
 		
 		List<String> text = new ArrayList();
-
+		text.add(cracker.heat + "TU");
+		text.add(EnumChatFormatting.YELLOW + I18nUtil.resolveKey("info.heating_pgain") + String.format("%.2f", cracker.pincrease)  );
 		for(int i = 0; i < cracker.tanks.length; i++)
 			text.add((i == 0 ? (EnumChatFormatting.GREEN + "-> ") : (EnumChatFormatting.RED + "<- ")) + EnumChatFormatting.RESET + I18nUtil.resolveKey("hbmfluid." + cracker.tanks[i].getTankType().getName().toLowerCase()) + ": " + cracker.tanks[i].getFill() + "/" + cracker.tanks[i].getMaxFill() + "mB");
-		
+
 		ILookOverlay.printGeneric(event, I18nUtil.resolveKey(getUnlocalizedName() + ".name"), 0xffff00, 0x404000, text);
 	}
 }

--- a/src/main/java/com/hbm/blocks/machine/MachineLiquefactor.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineLiquefactor.java
@@ -1,20 +1,27 @@
 package com.hbm.blocks.machine;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.hbm.blocks.BlockDummyable;
+import com.hbm.blocks.ILookOverlay;
 import com.hbm.blocks.ITooltipProvider;
+import com.hbm.inventory.UpgradeManager;
+import com.hbm.items.machine.ItemMachineUpgrade;
 import com.hbm.tileentity.TileEntityProxyCombo;
 import com.hbm.tileentity.machine.oil.TileEntityMachineLiquefactor;
+import com.hbm.util.I18nUtil;
 
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
+import net.minecraftforge.client.event.RenderGameOverlayEvent.Pre;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class MachineLiquefactor extends BlockDummyable implements ITooltipProvider {
+public class MachineLiquefactor extends BlockDummyable implements ILookOverlay, ITooltipProvider {
 
 	public MachineLiquefactor() {
 		super(Material.iron);
@@ -65,5 +72,30 @@ public class MachineLiquefactor extends BlockDummyable implements ITooltipProvid
 	@Override
 	public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean ext) {
 		this.addStandardInfo(stack, player, list, ext);
+	}
+
+	@Override
+	public void printHook(Pre event, World world, int x, int y, int z) {
+		
+		int[] pos = this.findCore(world, x, y, z);
+		
+		if(pos == null)
+			return;
+		
+		TileEntity te = world.getTileEntity(pos[0], pos[1], pos[2]);
+		
+		if(!(te instanceof TileEntityMachineLiquefactor))
+			return;
+		
+			TileEntityMachineLiquefactor heater = (TileEntityMachineLiquefactor) te;
+        int gain=100*(heater.processTimeBase-heater.processTime)/heater.processTimeBase;
+		if(gain<0){
+			gain=0;
+		}
+		List<String> text = new ArrayList();
+		text.add(heater.heat + "TU");
+		text.add(EnumChatFormatting.GREEN + I18nUtil.resolveKey("info.heating_gain") + String.format("%,d", gain) +"%"  );
+		text.add(EnumChatFormatting.YELLOW + I18nUtil.resolveKey("info.heating_pgain") + String.format("%.2f", heater.pincrease)  );
+		ILookOverlay.printGeneric(event, I18nUtil.resolveKey(getUnlocalizedName() + ".name"), 0xffff00, 0x404000, text);
 	}
 }

--- a/src/main/java/com/hbm/blocks/machine/MachineRefinery.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineRefinery.java
@@ -161,5 +161,22 @@ public class MachineRefinery extends BlockDummyable implements IPersistentInfoPr
 	@SideOnly(Side.CLIENT)
 	public void printHook(Pre event, World world, int x, int y, int z) {
 		IRepairable.addGenericOverlay(event, world, x, y, z, this);
+		int[] pos = this.findCore(world, x, y, z);
+
+		if(pos == null)
+			return;
+
+		TileEntity te = world.getTileEntity(pos[0], pos[1], pos[2]);
+
+		if(!(te instanceof TileEntityMachineRefinery))
+			return;
+
+		TileEntityMachineRefinery heater = (TileEntityMachineRefinery) te;
+		List<String> text = new ArrayList();
+		text.add(heater.heat + "TU");
+		text.add(EnumChatFormatting.YELLOW + I18nUtil.resolveKey("info.heating_pgain") + String.format("%.2f", heater.pincrease)  );
+		ILookOverlay.printGeneric(event, I18nUtil.resolveKey(getUnlocalizedName() + ".name"), 0xffff00, 0x404000, text);
 	}
+
+
 }

--- a/src/main/java/com/hbm/blocks/machine/MachineVacuumDistill.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineVacuumDistill.java
@@ -1,16 +1,23 @@
 package com.hbm.blocks.machine;
 
 import com.hbm.blocks.BlockDummyable;
+import com.hbm.blocks.ILookOverlay;
 import com.hbm.tileentity.TileEntityProxyCombo;
 import com.hbm.tileentity.machine.oil.TileEntityMachineVacuumDistill;
 
+import com.hbm.util.I18nUtil;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class MachineVacuumDistill extends BlockDummyable {
+import java.util.ArrayList;
+import java.util.List;
+
+public class MachineVacuumDistill extends BlockDummyable implements ILookOverlay{
 
 	public MachineVacuumDistill(Material mat) {
 		super(mat);
@@ -46,5 +53,23 @@ public class MachineVacuumDistill extends BlockDummyable {
 	@Override
 	public int getOffset() {
 		return 1;
+	}
+	public void printHook(RenderGameOverlayEvent.Pre event, World world, int x, int y, int z) {
+
+		int[] pos = this.findCore(world, x, y, z);
+
+		if(pos == null)
+			return;
+
+		TileEntity te = world.getTileEntity(pos[0], pos[1], pos[2]);
+
+		if(!(te instanceof TileEntityMachineVacuumDistill))
+			return;
+
+		TileEntityMachineVacuumDistill heater = (TileEntityMachineVacuumDistill) te;
+		List<String> text = new ArrayList();
+		text.add(heater.heat + "TU");
+		text.add(EnumChatFormatting.YELLOW + I18nUtil.resolveKey("info.heating_pgain") + String.format("%.2f", heater.pincrease)  );
+		ILookOverlay.printGeneric(event, I18nUtil.resolveKey(getUnlocalizedName() + ".name"), 0xffff00, 0x404000, text);
 	}
 }

--- a/src/main/resources/assets/hbm/lang/en_US.lang
+++ b/src/main/resources/assets/hbm/lang/en_US.lang
@@ -1380,6 +1380,10 @@ info.template_out=Output:
 info.template_out_p=Outputs:
 info.template_seconds=seconds
 info.template_time=Production Time:
+info.heating_gain=Improved production efficiency:
+info.heating_pgain=Yield increase rate:
+info.hold_heat=Hold heat mode
+info.hold=Hold:
 
 item.acetylene_torch.name=Acetylene Welding Torch
 item.ajr_boots.name=Steel Ranger Boots


### PR DESCRIPTION
Add heat gain mechanism for liquefactor,vacuum distill,refinery and fraction tower. Now these machines can get heat to obtain different gains. Players can also now use electric heater to control the heat of the machine.They have to determine the heat at the highest machine efficiency by observing the displayed data.(ps:I am not sure that whether the gain function is balanced and players can not use the electric heater to finely control the heat of the machine.)