### PR TITLE
Extended OC Compatibility along with a minor bugfix

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKAbsorber.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKAbsorber.java
@@ -2,14 +2,8 @@ package com.hbm.tileentity.machine.rbmk;
 
 import com.hbm.entity.projectile.EntityRBMKDebris.DebrisType;
 import com.hbm.tileentity.machine.rbmk.TileEntityRBMKConsole.ColumnType;
-import cpw.mods.fml.common.Optional;
-import li.cil.oc.api.machine.Arguments;
-import li.cil.oc.api.machine.Callback;
-import li.cil.oc.api.machine.Context;
-import li.cil.oc.api.network.SimpleComponent;
 
-@Optional.InterfaceList({@Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers")})
-public class TileEntityRBMKAbsorber extends TileEntityRBMKBase implements SimpleComponent {
+public class TileEntityRBMKAbsorber extends TileEntityRBMKBase {
 	
 	@Override
 	public void onMelt(int reduce) {
@@ -21,24 +15,6 @@ public class TileEntityRBMKAbsorber extends TileEntityRBMKBase implements Simple
 		}
 		
 		super.onMelt(reduce);
-	}
-
-	@Override
-	public String getComponentName() {
-		return "rbmk_absorber_rod";
-	}
-
-	@Callback(direct = true, limit = 4)
-	@Optional.Method(modid = "OpenComputers")
-	public Object[] getHeat(Context context, Arguments args) {
-		return new Object[] {heat};
-	}
-
-
-	@Callback(direct = true, limit = 4)
-	@Optional.Method(modid = "OpenComputers")
-	public Object[] getCoordinates(Context context, Arguments args) {
-		return new Object[] {xCoord, yCoord, zCoord};
 	}
 
 	@Override

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKBoiler.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKBoiler.java
@@ -332,41 +332,41 @@ public class TileEntityRBMKBoiler extends TileEntityRBMKSlottedBase implements I
 		return "rbmk_boiler";
 	}
 	
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getHeat(Context context, Arguments args) {
 		return new Object[] {heat};
 	}
 	
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getSteam(Context context, Arguments args) {
 		return new Object[] {steam.getFill()};
 	}
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getSteamMax(Context context, Arguments args) {
 		return new Object[] {steam.getMaxFill()};
 	}
 	
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getWater(Context context, Arguments args) {
 		return new Object[] {feed.getFill()};
 	}
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getWaterMax(Context context, Arguments args) {
 		return new Object[] {feed.getMaxFill()};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getCoordinates(Context context, Arguments args) {
 		return new Object[] {xCoord, yCoord, zCoord};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getInfo(Context context, Arguments args) {
 		FluidType type = steam.getTankType();
@@ -379,7 +379,7 @@ public class TileEntityRBMKBoiler extends TileEntityRBMKSlottedBase implements I
 		return new Object[] {heat, steam.getFill(), steam.getMaxFill(), feed.getFill(), feed.getMaxFill(), type_1, xCoord, yCoord, zCoord};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getSteamType(Context context, Arguments args) {
 		FluidType type = steam.getTankType();
@@ -390,7 +390,7 @@ public class TileEntityRBMKBoiler extends TileEntityRBMKSlottedBase implements I
 		else {return new Object[] {"Unknown Error"};}
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] setSteamType(Context context, Arguments args) {
 		int type = args.checkInteger(0);

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKControl.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKControl.java
@@ -126,37 +126,37 @@ public abstract class TileEntityRBMKControl extends TileEntityRBMKSlottedBase im
 		return "rbmk_control_rod";
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getLevel(Context context, Arguments args) {
 		return new Object[] {getMult() * 100};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getTargetLevel(Context context, Arguments args) {
 		return new Object[] {targetLevel * 100};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getCoordinates(Context context, Arguments args) {
 		return new Object[] {xCoord, yCoord, zCoord};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getHeat(Context context, Arguments args) {
 		return new Object[] {heat};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getInfo(Context context, Arguments args) {
 		return new Object[] {heat, getMult() * 100, targetLevel * 100, xCoord, yCoord, zCoord};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] setLevel(Context context, Arguments args) {
 		double newLevel = args.checkDouble(0)/100.0;

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKControlManual.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKControlManual.java
@@ -133,7 +133,7 @@ public class TileEntityRBMKControlManual extends TileEntityRBMKControl implement
 		return data;
 	}
 	
-	@Callback
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getColor(Context context, Arguments args) {
 		return new Object[] {this.color};

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKCooler.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKCooler.java
@@ -149,31 +149,31 @@ public class TileEntityRBMKCooler extends TileEntityRBMKBase implements IFluidAc
 		return "rbmk_cooler";
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getHeat(Context context, Arguments args) {
 		return new Object[]{heat};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getCryo(Context context, Arguments args) {
 		return new Object[]{tank.getFill()};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getCryoMax(Context context, Arguments args) {
 		return new Object[]{tank.getMaxFill()};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getCoordinates(Context context, Arguments args) {
 		return new Object[] {xCoord, yCoord, zCoord};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getInfo(Context context, Arguments args) {
 		return new Object[]{heat, tank.getFill(), tank.getMaxFill(), xCoord, yCoord, zCoord};

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKHeater.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKHeater.java
@@ -280,54 +280,54 @@ public class TileEntityRBMKHeater extends TileEntityRBMKSlottedBase implements I
 		return "rbmk_heater";
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getHeat(Context context, Arguments args) {
 		return new Object[] {heat};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getFill(Context context, Arguments args) {
 		return new Object[] {feed.getFill()};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getFillMax(Context context, Arguments args) {
 		return new Object[] {feed.getMaxFill()};
 	}
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getExport(Context context, Arguments args) {
 		return new Object[] {steam.getFill()};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getExportMax(Context context, Arguments args) {
 		return new Object[] {steam.getMaxFill()};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getFillType(Context context, Arguments args) {
 		return new Object[] {feed.getTankType().getID()};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getExportType(Context context, Arguments args) {
 		return new Object[] {steam.getTankType().getID()};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getInfo(Context context, Arguments args) {
 		return new Object[] {heat, feed.getFill(), feed.getMaxFill(), steam.getFill(), steam.getMaxFill(), feed.getTankType().getID(), steam.getTankType().getID(), xCoord, yCoord, zCoord};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getCoordinates(Context context, Arguments args) {
 		return new Object[] {xCoord, yCoord, zCoord};

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKOutgasser.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKOutgasser.java
@@ -226,37 +226,37 @@ public class TileEntityRBMKOutgasser extends TileEntityRBMKSlottedBase implement
 		return "rbmk_outgasser";
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getGas(Context context, Arguments args) {
 		return new Object[] {gas.getFill()};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getGasMax(Context context, Arguments args) {
 		return new Object[] {gas.getMaxFill()};
 	}
 	
-		@Callback(direct = true, limit = 4)
+		@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getGasType(Context context, Arguments args) {
 		return new Object[] {gas.getTankType().getID()};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getProgress(Context context, Arguments args) {
 		return new Object[] {progress};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getCoordinates(Context context, Arguments args) {
 		return new Object[] {xCoord, yCoord, zCoord};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getInfo(Context context, Arguments args) {
 		return new Object[] {gas.getFill(), gas.getMaxFill(), progress, gas.getTankType().getID(), xCoord, yCoord, zCoord};

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKReflector.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKReflector.java
@@ -2,14 +2,8 @@ package com.hbm.tileentity.machine.rbmk;
 
 import com.hbm.entity.projectile.EntityRBMKDebris.DebrisType;
 import com.hbm.tileentity.machine.rbmk.TileEntityRBMKConsole.ColumnType;
-import cpw.mods.fml.common.Optional;
-import li.cil.oc.api.machine.Arguments;
-import li.cil.oc.api.machine.Callback;
-import li.cil.oc.api.machine.Context;
-import li.cil.oc.api.network.SimpleComponent;
 
-@Optional.InterfaceList({@Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers")})
-public class TileEntityRBMKReflector extends TileEntityRBMKBase implements SimpleComponent {
+public class TileEntityRBMKReflector extends TileEntityRBMKBase {
 	
 	@Override
 	public void onMelt(int reduce) {
@@ -21,22 +15,6 @@ public class TileEntityRBMKReflector extends TileEntityRBMKBase implements Simpl
 		}
 		
 		super.onMelt(reduce);
-	}
-	@Override
-	public String getComponentName() {
-		return "rbmk_reflector_rod";
-	}
-
-	@Callback(direct = true, limit = 4)
-	@Optional.Method(modid = "OpenComputers")
-	public Object[] getHeat(Context context, Arguments args) {
-		return new Object[] {heat};
-	}
-
-	@Callback(direct = true, limit = 4)
-	@Optional.Method(modid = "OpenComputers")
-	public Object[] getCoordinates(Context context, Arguments args) {
-		return new Object[] {xCoord, yCoord, zCoord};
 	}
 
 	@Override

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKRod.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKRod.java
@@ -384,25 +384,25 @@ public class TileEntityRBMKRod extends TileEntityRBMKSlottedBase implements IRBM
 		return "rbmk_fuel_rod";
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getHeat(Context context, Arguments args) {
 		return new Object[] {heat};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getFluxSlow(Context context, Arguments args) {
 		return new Object[] {fluxSlow};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getFluxFast(Context context, Arguments args) {
 		return new Object[] {fluxFast};
 	}
 	
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getDepletion(Context context, Arguments args) {
 		if(slots[0] != null && slots[0].getItem() instanceof ItemRBMKRod) {
@@ -411,7 +411,7 @@ public class TileEntityRBMKRod extends TileEntityRBMKSlottedBase implements IRBM
 		return new Object[] {"N/A"};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getXenonPoison(Context context, Arguments args) {
 		if(slots[0] != null && slots[0].getItem() instanceof ItemRBMKRod) {
@@ -420,7 +420,7 @@ public class TileEntityRBMKRod extends TileEntityRBMKSlottedBase implements IRBM
 		return new Object[] {"N/A"};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getCoreHeat(Context context, Arguments args) {
 		if(slots[0] != null && slots[0].getItem() instanceof ItemRBMKRod) {
@@ -429,7 +429,7 @@ public class TileEntityRBMKRod extends TileEntityRBMKSlottedBase implements IRBM
 		return new Object[] {"N/A"};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getSkinHeat(Context context, Arguments args) {
 		if(slots[0] != null && slots[0].getItem() instanceof ItemRBMKRod) {
@@ -438,7 +438,7 @@ public class TileEntityRBMKRod extends TileEntityRBMKSlottedBase implements IRBM
 		return new Object[] {"N/A"};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getInfo(Context context, Arguments args) {
 		Object OC_enrich_buf;
@@ -453,13 +453,13 @@ public class TileEntityRBMKRod extends TileEntityRBMKSlottedBase implements IRBM
 		return new Object[] {heat, ItemRBMKRod.getHullHeat(slots[0]), ItemRBMKRod.getCoreHeat(slots[0]), fluxSlow, fluxFast, OC_enrich_buf, OC_poison_buf, ((RBMKRod)this.getBlockType()).moderated, xCoord, yCoord, zCoord};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getModerated(Context context, Arguments args) {
 		return new Object[] {((RBMKRod)this.getBlockType()).moderated};
 	}
 
-	@Callback(direct = true, limit = 8)
+	@Callback(direct = true, limit = 16)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getCoordinates(Context context, Arguments args) {
 		return new Object[] {xCoord, yCoord, zCoord};

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKRod.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKRod.java
@@ -443,14 +443,20 @@ public class TileEntityRBMKRod extends TileEntityRBMKSlottedBase implements IRBM
 	public Object[] getInfo(Context context, Arguments args) {
 		Object OC_enrich_buf;
 		Object OC_poison_buf;
+		Object OC_hull_buf;
+		Object OC_core_buf;
 		if(slots[0] != null && slots[0].getItem() instanceof ItemRBMKRod) {
 			OC_enrich_buf = ItemRBMKRod.getEnrichment(slots[0]);
 			OC_poison_buf = ItemRBMKRod.getPoison(slots[0]);
+			OC_hull_buf = ItemRBMKRod.getHullHeat(slots[0]);
+			OC_core_buf = ItemRBMKRod.getCoreHeat(slots[0]);
 		} else {
 			OC_enrich_buf = "N/A";
 			OC_poison_buf = "N/A";
+			OC_hull_buf = "N/A";
+			OC_core_buf = "N/A";
 		}
-		return new Object[] {heat, ItemRBMKRod.getHullHeat(slots[0]), ItemRBMKRod.getCoreHeat(slots[0]), fluxSlow, fluxFast, OC_enrich_buf, OC_poison_buf, ((RBMKRod)this.getBlockType()).moderated, xCoord, yCoord, zCoord};
+		return new Object[] {heat, OC_hull_buf, OC_core_buf, fluxSlow, fluxFast, OC_enrich_buf, OC_poison_buf, ((RBMKRod)this.getBlockType()).moderated, xCoord, yCoord, zCoord};
 	}
 
 	@Callback(direct = true, limit = 16)

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKStorage.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKStorage.java
@@ -95,26 +95,26 @@ public class TileEntityRBMKStorage extends TileEntityRBMKSlottedBase implements 
 	public String getComponentName() {
 		return "rbmk_storage_rod";
 	}
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getCoordinates(Context context, Arguments args) {
 		return new Object[] {xCoord, yCoord, zCoord};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getHeat(Context context, Arguments args) {
 		return new Object[] {heat};
 	}
 
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getStored(Context context, Arguments args) {
 		return new Object[] {slots[0], slots[1], slots[2], slots[3], slots[4], slots[5], slots[6], slots[7], slots[8], slots[9], slots[10], slots[11]};
 	}
 
-	@Callback(direct = true, limit = 4)
+	@Callback(direct = true, limit = 8)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getInfo(Context context, Arguments args) {
 		return new Object[] {heat, slots[0], slots[1], slots[2], slots[3], slots[4], slots[5], slots[6], slots[7], slots[8], slots[9], slots[10], slots[11], xCoord, yCoord, zCoord};


### PR DESCRIPTION
Increased callback rates, as they are incredibly cheap on performance. Also added direct delay bypass to the `getColor` function of the manual control rod, as I had forgotten to do so originally.

Along with that, this commit fixes a large bug in the `getInfo` code for the RBMK fuel rods that causes it to always return nil and "unknown error", breaking most OC setups.