### PR TITLE
Curseforge publishing improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,8 @@
+import org.gradle.plugins.ide.eclipse.model.internal.FileReferenceFactory
+
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
 
 buildscript {
 	repositories {
@@ -53,7 +56,7 @@ eclipse.classpath.file.whenMerged { cp ->
 	}
 	
 	// Create file reference factory
-	def fileref = new org.gradle.plugins.ide.eclipse.model.internal.FileReferenceFactory()
+	def fileref = new FileReferenceFactory()
 	
 	// Find all codechicken development jars
 	cp.entries.findAll { entry -> entry.path.contains("codechicken") && entry.path.endsWith("-dev.jar") }.forEach { entry ->
@@ -132,12 +135,20 @@ if(Files.exists(Paths.get("curseforge.properties"))) {
 		projectId = cfprops.project_id
 		releaseType = "release"
 
+		displayName = "Hbm's Nuclear Tech Mod " + version_name.replace("_", "") + " for Minecraft 1.7.10"
+
+		gameVersions.addAll([
+				"Forge",
+				"Java 8",
+				"Client", "Server"
+		])
+
 		if (Files.exists(Paths.get("changelog"))) {
 			changelog = String.join("\r\n", Files.readAllLines(Paths.get("changelog")))
 
 			// Perform a backup of the changelog and create a new file for next changes
 			doLast {
-				Files.move(Paths.get("changelog"), Paths.get("changelog.bak"))
+				Files.move(Paths.get("changelog"), Paths.get("changelog.bak"), StandardCopyOption.REPLACE_EXISTING)
 				Files.createFile(Paths.get("changelog"))
 			}
 		}

--- a/curseforge.properties.example
+++ b/curseforge.properties.example
@@ -1,0 +1,5 @@
+# CurseForge API token (obtainable from https://legacy.curseforge.com/account/api-tokens)
+api_key=
+
+# CurseForge project ID
+project_id=

--- a/src/main/java/com/hbm/potion/HbmPotion.java
+++ b/src/main/java/com/hbm/potion/HbmPotion.java
@@ -47,10 +47,10 @@ public class HbmPotion extends Potion {
 	}
 
 	public static void init() {
-		taint = registerPotion(PotionConfig.taintID, true, 8388736, "potion.hbm_taint", 0, 0);
-		radiation = registerPotion(PotionConfig.radiationID, true, 8700200, "potion.hbm_radiation", 1, 0);
-		bang = registerPotion(PotionConfig.bangID, true, 1118481, "potion.hbm_bang", 3, 0);
-		mutation = registerPotion(PotionConfig.mutationID, false, 8388736, "potion.hbm_mutation", 2, 0);
+		taint = registerPotion(PotionConfig.taintID, true, 0x800080, "potion.hbm_taint", 0, 0);
+		radiation = registerPotion(PotionConfig.radiationID, true, 0x84C128, "potion.hbm_radiation", 1, 0);
+		bang = registerPotion(PotionConfig.bangID, true, 0x111111, "potion.hbm_bang", 3, 0);
+		mutation = registerPotion(PotionConfig.mutationID, false, 0x800080, "potion.hbm_mutation", 2, 0);
 		radx = registerPotion(PotionConfig.radxID, false, 0xBB4B00, "potion.hbm_radx", 5, 0);
 		lead = registerPotion(PotionConfig.leadID, true, 0x767682, "potion.hbm_lead", 6, 0);
 		radaway = registerPotion(PotionConfig.radawayID, false, 0xBB4B00, "potion.hbm_radaway", 7, 0);
@@ -58,7 +58,7 @@ public class HbmPotion extends Potion {
 		phosphorus = registerPotion(PotionConfig.phosphorusID, true, 0xFFFF00, "potion.hbm_phosphorus", 1, 1);
 		stability = registerPotion(PotionConfig.stabilityID, false, 0xD0D0D0, "potion.hbm_stability", 2, 1);
 		potionsickness = registerPotion(PotionConfig.potionsicknessID, false, 0xff8080, "potion.hbm_potionsickness", 3, 1);
-		death = registerPotion(PotionConfig.deathID, false, 1118481, "potion.hbm_death", 4, 1);
+		death = registerPotion(PotionConfig.deathID, false, 0x111111, "potion.hbm_death", 4, 1);
 	}
 
 	public static HbmPotion registerPotion(int id, boolean isBad, int color, String name, int x, int y) {


### PR DESCRIPTION
This PR improves metadata sent while publishing the mod on CurseForge. Display name is customized and differs from the filename, dependencies to Forge, Java 8 are added. The mod is also marked as client and server side.

The CurseForge configuration sample is also brought back as it is nicer to have a commented sample file than trying to get required fields from code.

There's also a fix for the changelog backup file not being replaced, generating an exception.

Also a smol improvement in potion code replacing decimal numbers to hexadecimal for more readable colors.