### PR TITLE
Improve crane I/O screwdriver logic

### DIFF
--- a/src/main/java/com/hbm/blocks/network/CraneExtractor.java
+++ b/src/main/java/com/hbm/blocks/network/CraneExtractor.java
@@ -43,11 +43,6 @@ public class CraneExtractor extends BlockCraneBase {
 	}
 
 	@Override
-	protected boolean hasReversedIO() {
-		return true;
-	}
-
-	@Override
 	public int getRotationFromSide(IBlockAccess world, int x, int y, int z, int side) {
 		int meta = world.getBlockMetadata(x, y, z);
 

--- a/src/main/java/com/hbm/blocks/network/CraneUnboxer.java
+++ b/src/main/java/com/hbm/blocks/network/CraneUnboxer.java
@@ -51,11 +51,6 @@ public class CraneUnboxer extends BlockCraneBase implements IEnterableBlock {
 	}
 
 	@Override
-	protected boolean hasReversedIO() {
-		return true;
-	}
-
-	@Override
 	public int getRotationFromSide(IBlockAccess world, int x, int y, int z, int side) {
 		int meta = world.getBlockMetadata(x, y, z);
 

--- a/src/main/java/com/hbm/tileentity/network/TileEntityCraneBase.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityCraneBase.java
@@ -46,18 +46,31 @@ public abstract class TileEntityCraneBase extends TileEntityMachineBase {
 		return outputOverride;
 	}
 
-	public ForgeDirection cycleOutputOverride() {
-		do {
-			outputOverride = ForgeDirection.getOrientation(Math.floorMod(outputOverride.ordinal() - 1, 7));
-		} while (outputOverride.ordinal() == getBlockMetadata());
+	public void setOutputOverride(ForgeDirection direction) {
+		ForgeDirection oldSide = getOutputSide();
+		if (oldSide == direction)
+			direction = direction.getOpposite();
 
-		onBlockChanged();
-		return outputOverride;
+		outputOverride = direction;
+
+		if (direction == getInputSide())
+			setInput(oldSide);
+		else
+			onBlockChanged();
 	}
 
-	public void ensureOutputOverrideValid() {
-		if (outputOverride.ordinal() == getBlockMetadata())
-			cycleOutputOverride();
+	public void setInput(ForgeDirection direction) {
+		outputOverride = getOutputSide(); // save the current output, if it isn't saved yet
+
+		ForgeDirection oldSide = getInputSide();
+		if (oldSide == direction)
+			direction = direction.getOpposite();
+
+		boolean needSwapOutput = direction == getOutputSide();
+		worldObj.setBlockMetadataWithNotify(xCoord, yCoord, zCoord, direction.ordinal(), needSwapOutput ? 4 : 3);
+
+		if (needSwapOutput)
+			setOutputOverride(oldSide);
 	}
 
 	protected void onBlockChanged() {


### PR DESCRIPTION
Instead of cycling through all directions, the side the player clicks on will be manipulated directly, and, if applicable, input will be swapped with output and vice versa.

Right-clicking normally changes the conveyor side, shift-right-clicking the machine side.

Clicking on a side twice will manipulate the opposite side.

Related to #1164.