### PR TITLE
Bomber Fixes

### DIFF
--- a/src/main/java/com/hbm/items/tool/ItemBombCaller.java
+++ b/src/main/java/com/hbm/items/tool/ItemBombCaller.java
@@ -7,6 +7,7 @@ import com.hbm.lib.Library;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import com.hbm.world.WorldUtil;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
@@ -23,26 +24,38 @@ public class ItemBombCaller extends Item {
 	}
 	
 	@Override
-	public void addInformation(ItemStack itemstack, EntityPlayer player, List list, boolean bool)
+	public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean bool)
 	{
 		list.add("Aim & click to call an airstrike!");
 
-        if(itemstack.getItemDamage() == 0)
-    		list.add("Type: Carpet bombing");
-        if(itemstack.getItemDamage() == 1)
-    		list.add("Type: Napalm");
-        if(itemstack.getItemDamage() == 2)
-    		list.add("Type: Poison gas");
-        if(itemstack.getItemDamage() == 3)
-    		list.add("Type: Agent orange");
-        if(itemstack.getItemDamage() == 4)
-    		list.add("Type: Atomic bomb");
-        if(itemstack.getItemDamage() == 5)
-    		list.add("Type: VT stinger rockets");
-        if(itemstack.getItemDamage() == 6)
-    		list.add("Type: PIP OH GOD");
-        if(itemstack.getItemDamage() == 7)
-    		list.add("Type: Cloud the cloud oh god the cloud");
+        switch (stack.getItemDamage()) {
+
+			case 1:
+				list.add("Type: Napalm");
+				break;
+			case 2:
+				list.add("Type: Poison gas");
+				break;
+			case 3:
+				list.add("Type: Agent orange");
+				break;
+			case 4:
+				list.add("Type: Atomic bomb");
+				break;
+			case 5:
+				list.add("Type: VT stinger rockets");
+				break;
+			case 6:
+				list.add("Type: PIP OH GOD");
+				break;
+			case 7:
+				list.add("Type: Cloud the cloud oh god the cloud");
+				break;
+			default:
+				list.add("Type: Carpet bombing");
+
+		}
+
 	}
 	
 	@Override
@@ -53,45 +66,40 @@ public class ItemBombCaller extends Item {
 		int y = pos.blockY;
 		int z = pos.blockZ;
 		
-		boolean b = false;
-		
 	    if(!world.isRemote)
 		{
+            switch(stack.getItemDamage()) {
+				case 1:
+					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacNapalm(world, x, y, z));
+					break;
+				case 2:
+					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacChlorine(world, x, y, z));
+					break;
+				case 3:
+					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacOrange(world, x, y, z));
+					break;
+				case 4:
+					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacABomb(world, x, y, z));
+					break;
+				case 5:
+					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacStinger(world, x, y, z));
+					break;
+				case 6:
+					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacBoxcar(world, x, y, z));
+					break;
+				case 7:
+					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacPC(world, x, y, z));
 
-	        if(stack.getItemDamage() == 0)
-	        	if(world.spawnEntityInWorld(EntityBomber.statFacCarpet(world, x, y, z)))
-	        		b = true;
-	        if(stack.getItemDamage() == 1)
-	        	if(world.spawnEntityInWorld(EntityBomber.statFacNapalm(world, x, y, z)))
-	        		b = true;
-	        if(stack.getItemDamage() == 2)
-	        	if(world.spawnEntityInWorld(EntityBomber.statFacChlorine(world, x, y, z)))
-	        		b = true;
-	        if(stack.getItemDamage() == 3)
-	        	if(world.spawnEntityInWorld(EntityBomber.statFacOrange(world, x, y, z)))
-	        		b = true;
-	        if(stack.getItemDamage() == 4)
-	        	if(world.spawnEntityInWorld(EntityBomber.statFacABomb(world, x, y, z)))
-	        		b = true;
-	        if(stack.getItemDamage() == 5)
-	        	if(world.spawnEntityInWorld(EntityBomber.statFacStinger(world, x, y, z)))
-	        		b = true;
-	        if(stack.getItemDamage() == 6)
-	        	if(world.spawnEntityInWorld(EntityBomber.statFacBoxcar(world, x, y, z)))
-	        		b = true;
-	        if(stack.getItemDamage() == 7)
-	        	if(world.spawnEntityInWorld(EntityBomber.statFacPC(world, x, y, z)))
-	        		b = true;
-	        
-	        if(b) {
-		    	player.addChatMessage(new ChatComponentText("Called in airstrike!"));
-		        world.playSoundAtEntity(player, "hbm:item.techBleep", 1.0F, 1.0F);
-	        } else {
-		        world.playSoundAtEntity(player, "hbm:item.techBoop", 1.0F, 1.0F);
-	        }
+				default:
+					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacCarpet(world, x, y, z));
+			}
+
+			player.addChatMessage(new ChatComponentText("Called in airstrike!"));
+			world.playSoundAtEntity(player, "hbm:item.techBleep", 1.0F, 1.0F);
+
 		}
 	    
-	    stack.stackSize -= b ? 1 : 0;
+	    stack.stackSize -= 1;
 	    
         return stack;
     }

--- a/src/main/java/com/hbm/items/tool/ItemBombCaller.java
+++ b/src/main/java/com/hbm/items/tool/ItemBombCaller.java
@@ -17,108 +17,81 @@ import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
 public class ItemBombCaller extends Item {
-	
+
 	public ItemBombCaller() {
 		super();
-        this.setHasSubtypes(true);
+		this.setHasSubtypes(true);
 	}
-	
+
 	@Override
 	public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean bool)
 	{
 		list.add("Aim & click to call an airstrike!");
 
-        switch (stack.getItemDamage()) {
-
-			case 1:
-				list.add("Type: Napalm");
-				break;
-			case 2:
-				list.add("Type: Poison gas");
-				break;
-			case 3:
-				list.add("Type: Agent orange");
-				break;
-			case 4:
-				list.add("Type: Atomic bomb");
-				break;
-			case 5:
-				list.add("Type: VT stinger rockets");
-				break;
-			case 6:
-				list.add("Type: PIP OH GOD");
-				break;
-			case 7:
-				list.add("Type: Cloud the cloud oh god the cloud");
-				break;
-			default:
-				list.add("Type: Carpet bombing");
+		switch (stack.getItemDamage()) {
+			case 0: list.add("Type: Carpet bombing"); break;
+			case 1: list.add("Type: Napalm"); break;
+			case 2: list.add("Type: Poison gas"); break;
+			case 3: list.add("Type: Agent orange"); break;
+			case 4: list.add("Type: Atomic bomb"); break;
+			case 5: list.add("Type: VT stinger rockets"); break;
+			case 6: list.add("Type: PIP OH GOD"); break;
+			case 7: list.add("Type: Cloud the cloud oh god the cloud"); break;
+			default: list.add("Type: INVALID, Report it to mod creator");
 
 		}
 
 	}
-	
+
 	@Override
-    public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player)
-    {
+	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player)
+	{
 		MovingObjectPosition pos = Library.rayTrace(player, 500, 1);
 		int x = pos.blockX;
 		int y = pos.blockY;
 		int z = pos.blockZ;
-		
-	    if(!world.isRemote)
+
+		if(!world.isRemote)
 		{
-            switch(stack.getItemDamage()) {
-				case 1:
-					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacNapalm(world, x, y, z));
-					break;
-				case 2:
-					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacChlorine(world, x, y, z));
-					break;
-				case 3:
-					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacOrange(world, x, y, z));
-					break;
-				case 4:
-					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacABomb(world, x, y, z));
-					break;
-				case 5:
-					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacStinger(world, x, y, z));
-					break;
-				case 6:
-					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacBoxcar(world, x, y, z));
-					break;
-				case 7:
-					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacPC(world, x, y, z));
+			EntityBomber bomber;
+			switch(stack.getItemDamage()) {
 
-				default:
-					WorldUtil.loadAndSpawnEntityInWorld(EntityBomber.statFacCarpet(world, x, y, z));
+				case 1: bomber = EntityBomber.statFacNapalm(world, x, y, z); break;
+				case 2: bomber = EntityBomber.statFacChlorine(world, x, y, z); break;
+				case 3: bomber = EntityBomber.statFacOrange(world, x, y, z); break;
+				case 4: bomber = EntityBomber.statFacABomb(world, x, y, z); break;
+				case 5: bomber = EntityBomber.statFacStinger(world, x, y, z); break;
+				case 6: bomber = EntityBomber.statFacBoxcar(world, x, y, z); break;
+				case 7: bomber = EntityBomber.statFacPC(world, x, y, z); break;
+				default: bomber = EntityBomber.statFacCarpet(world, x, y, z);
+
 			}
-
+			WorldUtil.loadAndSpawnEntityInWorld(bomber);
 			player.addChatMessage(new ChatComponentText("Called in airstrike!"));
 			world.playSoundAtEntity(player, "hbm:item.techBleep", 1.0F, 1.0F);
 
 		}
-	    
-	    stack.stackSize -= 1;
-	    
-        return stack;
-    }
-    
-    @Override
-	@SideOnly(Side.CLIENT)
-    public void getSubItems(Item p_150895_1_, CreativeTabs p_150895_2_, List p_150895_3_)
-    {
-        p_150895_3_.add(new ItemStack(p_150895_1_, 1, 0));
-        p_150895_3_.add(new ItemStack(p_150895_1_, 1, 1));
-        p_150895_3_.add(new ItemStack(p_150895_1_, 1, 2));
-        p_150895_3_.add(new ItemStack(p_150895_1_, 1, 3));
-        p_150895_3_.add(new ItemStack(p_150895_1_, 1, 4));
-    }
 
-    @Override
+		stack.stackSize -= 1;
+
+		return stack;
+	}
+
+	@Override
 	@SideOnly(Side.CLIENT)
-    public boolean hasEffect(ItemStack p_77636_1_)
-    {
-        return p_77636_1_.getItemDamage() >= 4;
-    }
+	public void getSubItems(Item p_150895_1_, CreativeTabs p_150895_2_, List p_150895_3_)
+	{
+		p_150895_3_.add(new ItemStack(p_150895_1_, 1, 0));
+		p_150895_3_.add(new ItemStack(p_150895_1_, 1, 1));
+		p_150895_3_.add(new ItemStack(p_150895_1_, 1, 2));
+		p_150895_3_.add(new ItemStack(p_150895_1_, 1, 3));
+		p_150895_3_.add(new ItemStack(p_150895_1_, 1, 4));
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public boolean hasEffect(ItemStack p_77636_1_)
+	{
+		return p_77636_1_.getItemDamage() >= 4;
+	}
 }

--- a/src/main/java/com/hbm/world/WorldUtil.java
+++ b/src/main/java/com/hbm/world/WorldUtil.java
@@ -40,8 +40,8 @@ public class WorldUtil {
 	/*fun fact: this is based off of joinEntityInSurroundings in World
 	  however, since mojang is staffed by field mice, that function is client side only and half-baked
 	 */
-	public static void loadAndSpawnEntityInWorld(Entity entity)
-	{
+	public static void loadAndSpawnEntityInWorld(Entity entity) {
+
 		World world = entity.worldObj;
 		int chunkX = MathHelper.floor_double(entity.posX / 16.0D);
 		int chunkZ = MathHelper.floor_double(entity.posZ / 16.0D);

--- a/src/main/java/com/hbm/world/WorldUtil.java
+++ b/src/main/java/com/hbm/world/WorldUtil.java
@@ -2,12 +2,15 @@ package com.hbm.world;
 
 import com.hbm.packet.BiomeSyncPacket;
 import com.hbm.packet.PacketDispatcher;
-
 import cpw.mods.fml.common.network.NetworkRegistry.TargetPoint;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.MathHelper;
 import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.chunk.Chunk;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 
 public class WorldUtil {
 
@@ -29,6 +32,38 @@ public class WorldUtil {
 		/* this sucks ass */
 		ChunkCoordIntPair coord = chunk.getChunkCoordIntPair();
 		PacketDispatcher.wrapper.sendToAllAround(new BiomeSyncPacket(coord.chunkXPos, coord.chunkZPos, chunk.getBiomeArray()), new TargetPoint(world.provider.dimensionId, coord.getCenterXPos(), 128, coord.getCenterZPosition() /* who named you? */, 1024D));
+	}
+
+    /**Chunkloads the chunk the entity is going to spawn in and then spawns it
+	 * @param entity The entity to be spawned**/
+
+	/*fun fact: this is based off of joinEntityInSurroundings in World
+	  however, since mojang is staffed by field mice, that function is client side only and half-baked
+	 */
+	public static void loadAndSpawnEntityInWorld(Entity entity)
+	{
+		World world = entity.worldObj;
+		int chunkX = MathHelper.floor_double(entity.posX / 16.0D);
+		int chunkZ = MathHelper.floor_double(entity.posZ / 16.0D);
+		byte loadRadius = 2;
+
+		for (int k = chunkX - loadRadius; k <= chunkX + loadRadius; ++k)
+		{
+			for (int l = chunkZ - loadRadius; l <= chunkZ + loadRadius; ++l)
+			{
+				world.getChunkFromChunkCoords(k, l);
+			}
+		}
+
+		if (!world.loadedEntityList.contains(entity))
+		{
+			if (!MinecraftForge.EVENT_BUS.post(new EntityJoinWorldEvent(entity, world)))
+			{
+				world.getChunkFromChunkCoords(chunkX, chunkZ).addEntity(entity);
+				world.loadedEntityList.add(entity);
+				world.onEntityAdded(entity);
+			}
+		}
 	}
 
 	public static void syncBiomeChange(World world, int x, int z) {


### PR DESCRIPTION
**Added**
New logic to the airstrike designator that fixes the long standing issue of bombers not loading properly

- It uses a fixed version of a mojank function to chunkload the chunk the bomber is going to spawn in, can also be used for similar issues

Turned the rancid if chains within designator into switches