### PR TITLE
Fix inverted door redstone functionality

### DIFF
--- a/src/main/java/com/hbm/tileentity/TileEntityDoorGeneric.java
+++ b/src/main/java/com/hbm/tileentity/TileEntityDoorGeneric.java
@@ -142,9 +142,9 @@ public class TileEntityDoorGeneric extends TileEntityLockableBase implements IAn
 			}
 			PacketDispatcher.wrapper.sendToAllAround(new TEDoorAnimationPacket(xCoord, yCoord, zCoord, state, skinIndex, (byte)(shouldUseBB ? 1 : 0)), new TargetPoint(worldObj.provider.dimensionId, xCoord, yCoord, zCoord, 100));
 			
-			if(redstonePower == -1 && state == 0){
+			if(redstonePower == -1 && state == 1){
 				tryToggle(-1);
-			} else if(redstonePower > 0 && state == 1){
+			} else if(redstonePower > 0 && state == 0){
 				tryToggle(-1);
 			}
 			if(redstonePower == -1){


### PR DESCRIPTION
a small pr. is there anything else i need to explain?

changes:
- NTM doors now have redstone functionality just like vanilla doors. (i did not add any functionality, i wrote this when i was tired)
	- why? stuff like pressure plates or motion sensors (from some mod) when activated will just close the door instead when it should do the opposite