### PR TITLE
Ported the 1.12.2 RBMK console OC compat to 1.7.10 and also more PWR compat

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityPWRController.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityPWRController.java
@@ -528,6 +528,8 @@ public class TileEntityPWRController extends TileEntityMachineBase implements IG
 	}
 
 
+	// do some opencomputer stuff
+	@Override
 	public String getComponentName() {
 		return "ntm_pwr_control";
 	}
@@ -547,13 +549,25 @@ public class TileEntityPWRController extends TileEntityMachineBase implements IG
 	@Callback(direct = true)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getLevel(Context context, Arguments args) {
-		return new Object[] {rodTarget};
+		return new Object[] {rodTarget, rodLevel};
+	}
+	
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getCoolantInfo(Context context, Arguments args) {
+		return new Object[] {tanks[0].getFill(), tanks[0].getMaxFill(), tanks[1].getFill(), tanks[1].getMaxFill()};
+	}
+	
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getFuelInfo(Context context, Arguments args) {
+		return new Object[] {amountLoaded, progress, processTime};
 	}
 
 	@Callback(direct = true)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] getInfo(Context context, Arguments args) {
-		return new Object[] {coreHeat, hullHeat, flux, rodTarget};
+		return new Object[] {coreHeat, hullHeat, flux, rodTarget, rodLevel, amountLoaded, progress, processTime, tanks[0].getFill(), tanks[0].getMaxFill(), tanks[1].getFill(), tanks[1].getMaxFill()};
 	}
 
 	@Callback(direct = true, limit = 4)


### PR DESCRIPTION
Title.

changes:
- The RBMK console now has the same compat as the compat from 1.12.2 ([coming from this pr](https://github.com/Alcatergit/Hbm-s-Nuclear-Tech-GIT/pull/39))
	- This compat now may make the current compat of the separate fuel rods useless, but this just seems a lot more easier to work with
	- all functions are identical so scripts using this compat should work. some return values were changed to null or absolutely nothing so some scripts may require modifications to work in 1.7.10
- Added extra PWR compat:
	- ``getFuelInfo`` function that returns fuel type, fuel amount, depletion, fuel yield
	- ``getCoolantInfo`` function that returns coolant's current fill and coolant's max fill, hot coolant's current fill and hot coolant's max fill
	- ``getLevel`` returns both ``rodTarget`` and ``rodLevel``
	- ``getInfo`` also returns ``rodLevel``, coolant fill, and hot coolant fill
