### PR TITLE
Glyphid tweaks

### DIFF
--- a/src/main/java/com/hbm/config/MobConfig.java
+++ b/src/main/java/com/hbm/config/MobConfig.java
@@ -58,7 +58,7 @@ public class MobConfig {
 
 	public static boolean rampantMode = false;
 	public static boolean rampantNaturalScoutSpawn = false;
-	public static double rampantScoutSpawnThresh = 20;
+	public static double rampantScoutSpawnThresh = 14;
 	public static int rampantScoutSpawnChance = 600;
 	public static boolean scoutInitialSpawn = false;
 	public static boolean rampantExtendedTargetting = false;
@@ -101,7 +101,7 @@ public class MobConfig {
 		spawnMax = CommonConfig.createConfigDouble(config, CATEGORY, "12.G07_spawnMax", "Maximum amount of glyphids being able to exist at once through natural spawning", 50);
 		targetingThreshold = CommonConfig.createConfigDouble(config, CATEGORY, "12.G08_targetingThreshold", "Minimum amount of soot required for glyphids' extended targeting range to activate", 1D);
 
-		scoutSwarmSpawnChance = CommonConfig.createConfigInt(config, CATEGORY,"12.G10_scoutSwarmSpawn", "How likely are scouts to spawn in swarms, 1 in x chance format", 2);
+		scoutSwarmSpawnChance = CommonConfig.createConfigInt(config, CATEGORY,"12.G10_scoutSwarmSpawn", "How likely are scouts to spawn in swarms, 1 in x chance format", 3);
 
 		largeHiveChance = CommonConfig.createConfigInt(config, CATEGORY,"12.G11_largeHiveChance", "The chance for a large hive to spawn, formula: 1/x", 5);
 		largeHiveThreshold = CommonConfig.createConfigInt(config, CATEGORY,"12.G12_largeHiveThreshold", "The soot threshold for a large hive to spawn", 20);

--- a/src/main/java/com/hbm/entity/mob/EntityGlyphid.java
+++ b/src/main/java/com/hbm/entity/mob/EntityGlyphid.java
@@ -315,7 +315,7 @@ public class EntityGlyphid extends EntityMob {
 		if(source.isFireDamage()) {
 			amount *= 0.7F;
 		} else if(source.getDamageType().equals("player")) {
-			amount *= 1.5F;
+			amount *= getScale() < 1.25 ? 1.5 : getScale() < 1.3 ? 0.8 : 0.5;
 		} else if(source == ModDamageSource.acid || source.equals(new DamageSource(ModDamageSource.s_acid))){
 			amount = 0;
 		} else if(source == DamageSource.inWall) {

--- a/src/main/java/com/hbm/entity/mob/EntityGlyphid.java
+++ b/src/main/java/com/hbm/entity/mob/EntityGlyphid.java
@@ -176,8 +176,7 @@ public class EntityGlyphid extends EntityMob {
 	protected Entity findPlayerToAttack() {
 		if(this.isPotionActive(Potion.blindness)) return null;
 
-		EntityPlayer entityplayer = this.worldObj.getClosestVulnerablePlayerToEntity(this, useExtendedTargeting() ? 128D : 16D);
-		return entityplayer;
+		return this.worldObj.getClosestVulnerablePlayerToEntity(this, useExtendedTargeting() ? 128D : 16D);
 	}
 
 	@Override

--- a/src/main/java/com/hbm/entity/mob/EntityGlyphidBlaster.java
+++ b/src/main/java/com/hbm/entity/mob/EntityGlyphidBlaster.java
@@ -60,7 +60,7 @@ public class EntityGlyphidBlaster extends EntityGlyphidBombardier {
 
 	@Override
 	public float getBombDamage() {
-		return 10F;
+			return 15F;
 	}
 
 	@Override

--- a/src/main/java/com/hbm/entity/mob/EntityGlyphidBombardier.java
+++ b/src/main/java/com/hbm/entity/mob/EntityGlyphidBombardier.java
@@ -46,7 +46,7 @@ public class EntityGlyphidBombardier extends EntityGlyphid {
 			
 			if(this.ticksExisted % 60 == 1) {
 				
-				boolean topAttack = rand.nextBoolean();
+				boolean topAttack = false;
 
 				double velX = e.posX - lastX;
 				double velY = e.posY - lastY;
@@ -55,7 +55,11 @@ public class EntityGlyphidBombardier extends EntityGlyphid {
 				if(this.lastTarget != e || Vec3.createVectorHelper(velX, velY, velZ).lengthVector() > 30) {
 					velX = velY = velZ = 0;
 				}
-				
+
+				if (this.getDistanceToEntity(e) > 20) {
+					topAttack = true;
+				}
+
 				int prediction = topAttack ? 60 : 20;
 				Vec3 delta = Vec3.createVectorHelper(e.posX - posX + velX * prediction, (e.posY + e.height / 2) - (posY + 1) + velY * prediction, e.posZ - posZ + velZ * prediction);
 				double len = delta.lengthVector();
@@ -91,7 +95,7 @@ public class EntityGlyphidBombardier extends EntityGlyphid {
 	}
 	
 	public float getBombDamage() {
-		return 1.5F;
+		return 5F;
 	}
 	
 	public int getBombCount() {

--- a/src/main/java/com/hbm/entity/mob/EntityGlyphidDigger.java
+++ b/src/main/java/com/hbm/entity/mob/EntityGlyphidDigger.java
@@ -64,7 +64,7 @@ public class EntityGlyphidDigger extends EntityGlyphid {
      * Mainly composed of crusty old power fist code, with some touch ups
      **/
 	public void groundSlam(){
-		if (!worldObj.isRemote && entityToAttack instanceof EntityLivingBase && this.getDistanceToEntity(entityToAttack) < (useExtendedTargeting() ? 128D : 16D)) {
+		if (!worldObj.isRemote && entityToAttack instanceof EntityLivingBase && this.getDistanceToEntity(entityToAttack) < 30) {
 			Entity e = this.getEntityToAttack();
 
 			boolean topAttack = false;
@@ -91,7 +91,9 @@ public class EntityGlyphidDigger extends EntityGlyphid {
 
 			if(this.lastTarget != e) {
 				velX = velY = velZ = 0;
-			} else if (this.getDistanceToEntity(e) < 11) {
+			}
+
+			if (this.getDistanceToEntity(e) > 20) {
 				topAttack = true;
 			}
 
@@ -105,7 +107,7 @@ public class EntityGlyphidDigger extends EntityGlyphid {
 			double y = delta.yCoord;
 			double v0 = 1.2;
 			double v02 = v0 * v0;
-			double g = 0.07D;
+			double g = 0.03D;
 			double upperLower = topAttack ? 1 : -1;
 			double targetPitch = Math.atan((v02 + Math.sqrt(v02*v02 - g*(g*x*x + 2*y*v02)) * upperLower) / (g*x));
 			Vec3 fireVec = null;
@@ -126,7 +128,7 @@ public class EntityGlyphidDigger extends EntityGlyphid {
 				Block b = worldObj.getBlock(x1, y1, z1);
 				float k = b.getExplosionResistance(null);
 
-				if (k < 6000 && b.isNormalCube()) {
+				if (k < 200 && b.isNormalCube()) {
 
 					EntityRubble rubble = new EntityRubble(worldObj);
 					rubble.posX = x1 + 0.5F;

--- a/src/main/java/com/hbm/entity/mob/EntityGlyphidDigger.java
+++ b/src/main/java/com/hbm/entity/mob/EntityGlyphidDigger.java
@@ -1,12 +1,26 @@
 package com.hbm.entity.mob;
 
+import com.hbm.entity.projectile.EntityRubble;
+import com.hbm.lib.Library;
 import com.hbm.main.ResourceManager;
 
+import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
+import java.util.List;
+
 public class EntityGlyphidDigger extends EntityGlyphid {
+	protected Entity lastTarget;
+	protected double lastX;
+	protected double lastY;
+	protected double lastZ;
 
 	public EntityGlyphidDigger(World world) {
 		super(world);
@@ -18,17 +32,119 @@ public class EntityGlyphidDigger extends EntityGlyphid {
 
 	@Override
 	public double getScale() {
-		return 1.25D;
+		return 1.3D;
 	}
 
 	@Override
 	protected void applyEntityAttributes() {
 		super.applyEntityAttributes();
-		this.getEntityAttribute(SharedMonsterAttributes.maxHealth).setBaseValue(35D);
+		this.getEntityAttribute(SharedMonsterAttributes.maxHealth).setBaseValue(50D);
 		this.getEntityAttribute(SharedMonsterAttributes.movementSpeed).setBaseValue(1D);
 		this.getEntityAttribute(SharedMonsterAttributes.attackDamage).setBaseValue(5D);
 	}
 
+	public int timer = 0;
+	@Override
+	public void onUpdate(){
+		super.onUpdate();
+		Entity e = this.getEntityToAttack();
+		if (e != null) {
+
+			this.lastX = e.posX;
+			this.lastY = e.posY;
+			this.lastZ = e.posZ;
+
+			if (--timer <= 0) {
+				groundSlam();
+				timer = 120;
+			}
+		}
+	}
+	/**
+     * Mainly composed of crusty old power fist code, with some touch ups
+     **/
+	public void groundSlam(){
+		if (!worldObj.isRemote && entityToAttack instanceof EntityLivingBase && this.getDistanceToEntity(entityToAttack) < (useExtendedTargeting() ? 128D : 16D)) {
+			Entity e = this.getEntityToAttack();
+
+			boolean topAttack = false;
+
+			int l = 6;
+			float part = -1F / 16F;
+
+			int bugX = (int) posX;
+			int bugY = (int) posY;
+			int bugZ = (int) posZ;
+
+			Vec3 vec0 = getLookVec();
+
+			List<int[]> list = Library.getBlockPosInPath(bugX, bugY, bugZ, l, vec0);
+
+			for (int i = 0; i < 8; i++) {
+				vec0.rotateAroundY(part);
+				list.addAll(Library.getBlockPosInPath(bugX, bugY - 1, bugZ, l, vec0));
+			}
+
+			double velX = e.posX - lastX;
+			double velY = e.posY - lastY;
+			double velZ = e.posZ - lastZ;
+
+			if(this.lastTarget != e) {
+				velX = velY = velZ = 0;
+			} else if (this.getDistanceToEntity(e) < 11) {
+				topAttack = true;
+			}
+
+			int prediction = 60;
+			Vec3 delta = Vec3.createVectorHelper(e.posX - posX + velX * prediction, (e.posY + e.height / 2) - (posY + 1) + velY * prediction, e.posZ - posZ + velZ * prediction);
+			double len = delta.lengthVector();
+			if(len < 3) return;
+			double targetYaw = -Math.atan2(delta.xCoord, delta.zCoord);
+
+			double x = Math.sqrt(delta.xCoord * delta.xCoord + delta.zCoord * delta.zCoord);
+			double y = delta.yCoord;
+			double v0 = 1.2;
+			double v02 = v0 * v0;
+			double g = 0.07D;
+			double upperLower = topAttack ? 1 : -1;
+			double targetPitch = Math.atan((v02 + Math.sqrt(v02*v02 - g*(g*x*x + 2*y*v02)) * upperLower) / (g*x));
+			Vec3 fireVec = null;
+			if(!Double.isNaN(targetPitch)) {
+
+				fireVec = Vec3.createVectorHelper(v0, 0, 0);
+				fireVec.rotateAroundZ((float) -targetPitch);
+				fireVec.rotateAroundY((float) -(targetYaw + Math.PI * 0.5));
+			}
+
+			for (int[] ints : list) {
+
+				int x1 = ints[0];
+				int y1 = ints[1];
+				int z1 = ints[2];
+
+
+				Block b = worldObj.getBlock(x1, y1, z1);
+				float k = b.getExplosionResistance(null);
+
+				if (k < 6000 && b.isNormalCube()) {
+
+					EntityRubble rubble = new EntityRubble(worldObj);
+					rubble.posX = x1 + 0.5F;
+					rubble.posY = y1 + 2;
+					rubble.posZ = z1 + 0.5F;
+
+					rubble.setMetaBasedOnBlock(b, worldObj.getBlockMetadata(x1, y1, z1));
+
+					if(fireVec != null)
+						rubble.setThrowableHeading(fireVec.xCoord, fireVec.yCoord, fireVec.zCoord, (float) v0, rand.nextFloat());
+
+					worldObj.spawnEntityInWorld(rubble);
+
+					worldObj.setBlock(x1, y1, z1, Blocks.air);
+				}
+			}
+		}
+	}
 	@Override
 	public boolean isArmorBroken(float amount) {
 		return this.rand.nextInt(100) <= Math.min(Math.pow(amount * 0.25, 2), 100);

--- a/src/main/java/com/hbm/entity/mob/EntityGlyphidScout.java
+++ b/src/main/java/com/hbm/entity/mob/EntityGlyphidScout.java
@@ -112,6 +112,10 @@ public class EntityGlyphidScout extends EntityGlyphid {
 					hasTarget = true;
 				}
 			}
+			//fixes edge case where glyphids have no task and yet hasTarget is true
+			if(taskWaypoint == null && hasTarget){
+				hasTarget = false;
+			}
 
 			if (getCurrentTask() == TASK_TERRAFORM && super.isAtDestination() && canBuildHiveHere()) {
 				communicate(TASK_TERRAFORM, taskWaypoint);
@@ -295,9 +299,11 @@ public class EntityGlyphidScout extends EntityGlyphid {
 	@Override
 	protected Entity findPlayerToAttack() {
 		if(this.isPotionActive(Potion.blindness)) return null;
-
-		return this.worldObj.getClosestVulnerablePlayerToEntity(this, useExtendedTargeting() ? 128D : 8D);
+		//no extended targeting, and a low attack distance, ensures the scouts are focused in expanding, and not in chasing the player
+		return this.worldObj.getClosestVulnerablePlayerToEntity(this, 10);
 	}
+
+
 	///RAMPANT MODE STUFFS
 
 	/** Finds the direction from the bug's location to the target and adds it to their current coord

--- a/src/main/java/com/hbm/entity/mob/EntityGlyphidScout.java
+++ b/src/main/java/com/hbm/entity/mob/EntityGlyphidScout.java
@@ -81,6 +81,7 @@ public class EntityGlyphidScout extends EntityGlyphid {
 						target.setLocationAndAngles(dirVec.xCoord, dirVec.yCoord, dirVec.zCoord, 0, 0);
 						target.maxAge = 300;
 						target.radius = 6;
+						target.setWaypointType(TASK_BUILD_HIVE);
 						worldObj.spawnEntityInWorld(target);
 						hasTarget = true;
 
@@ -291,6 +292,12 @@ public class EntityGlyphidScout extends EntityGlyphid {
 		return false;
 	}
 
+	@Override
+	protected Entity findPlayerToAttack() {
+		if(this.isPotionActive(Potion.blindness)) return null;
+
+		return this.worldObj.getClosestVulnerablePlayerToEntity(this, useExtendedTargeting() ? 128D : 8D);
+	}
 	///RAMPANT MODE STUFFS
 
 	/** Finds the direction from the bug's location to the target and adds it to their current coord

--- a/src/main/java/com/hbm/entity/projectile/EntityRubble.java
+++ b/src/main/java/com/hbm/entity/projectile/EntityRubble.java
@@ -12,7 +12,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
-public class EntityRubble extends EntityThrowableInterp {
+public class EntityRubble extends EntityThrowableNT {
 
     public EntityRubble(World world)
     {
@@ -48,11 +48,6 @@ public class EntityRubble extends EntityThrowableInterp {
     		if(!worldObj.isRemote)
     			PacketDispatcher.wrapper.sendToAllAround(new ParticleBurstPacket((int)Math.floor(posX), (int)posY, (int)Math.floor(posZ), this.dataWatcher.getWatchableObjectInt(16), this.dataWatcher.getWatchableObjectInt(17)), new TargetPoint(worldObj.provider.dimensionId, posX, posY, posZ, 50));
         }
-    }
-
-    @Override
-    public double getGravityVelocity() {
-        return 0.07D;
     }
 
     @Override

--- a/src/main/java/com/hbm/entity/projectile/EntityRubble.java
+++ b/src/main/java/com/hbm/entity/projectile/EntityRubble.java
@@ -12,16 +12,11 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
-public class EntityRubble extends EntityThrowable {
+public class EntityRubble extends EntityThrowableInterp {
 
-    public EntityRubble(World p_i1773_1_)
+    public EntityRubble(World world)
     {
-        super(p_i1773_1_);
-    }
-
-    public EntityRubble(World p_i1774_1_, EntityLivingBase p_i1774_2_)
-    {
-        super(p_i1774_1_, p_i1774_2_);
+        super(world);
     }
 
     @Override
@@ -30,19 +25,18 @@ public class EntityRubble extends EntityThrowable {
         this.dataWatcher.addObject(17, (int)Integer.valueOf(0));
     }
 
-    public EntityRubble(World p_i1775_1_, double p_i1775_2_, double p_i1775_4_, double p_i1775_6_)
-    {
-        super(p_i1775_1_, p_i1775_2_, p_i1775_4_, p_i1775_6_);
+    public EntityRubble(World world, double x, double y, double z) {
+        super(world, x, y, z);
     }
 
     @Override
-	protected void onImpact(MovingObjectPosition p_70184_1_)
+	protected void onImpact(MovingObjectPosition mop)
     {
-        if (p_70184_1_.entityHit != null)
+        if (mop.entityHit != null)
         {
             byte b0 = 15;
 
-            p_70184_1_.entityHit.attackEntityFrom(ModDamageSource.rubble, b0);
+            mop.entityHit.attackEntityFrom(ModDamageSource.rubble, b0);
         }
 
         if(this.ticksExisted > 2) {
@@ -55,7 +49,17 @@ public class EntityRubble extends EntityThrowable {
     			PacketDispatcher.wrapper.sendToAllAround(new ParticleBurstPacket((int)Math.floor(posX), (int)posY, (int)Math.floor(posZ), this.dataWatcher.getWatchableObjectInt(16), this.dataWatcher.getWatchableObjectInt(17)), new TargetPoint(worldObj.provider.dimensionId, posX, posY, posZ, 50));
         }
     }
-    
+
+    @Override
+    public double getGravityVelocity() {
+        return 0.07D;
+    }
+
+    @Override
+    protected float getAirDrag() {
+        return 1F;
+    }
+
     public void setMetaBasedOnBlock(Block b, int i) {
 
     	this.dataWatcher.updateObject(16, Block.getIdFromBlock(b));

--- a/src/main/java/com/hbm/handler/pollution/PollutionHandler.java
+++ b/src/main/java/com/hbm/handler/pollution/PollutionHandler.java
@@ -363,6 +363,7 @@ public class PollutionHandler {
 
 						if (soot >= MobConfig.rampantScoutSpawnThresh) {
 							EntityGlyphidScout scout = new EntityGlyphidScout(event.world);
+							//escort for the scout, which can also deal with obstacles
 							EntityGlyphidDigger digger = new EntityGlyphidDigger(event.world);
 							scout.setLocationAndAngles(event.x, event.y, event.z, event.world.rand.nextFloat() * 360.0F, 0.0F);
 							digger.setLocationAndAngles(event.x, event.y, event.z, event.world.rand.nextFloat() * 360.0F, 0.0F);

--- a/src/main/java/com/hbm/handler/pollution/PollutionHandler.java
+++ b/src/main/java/com/hbm/handler/pollution/PollutionHandler.java
@@ -355,7 +355,8 @@ public class PollutionHandler {
 				&& !event.world.isRemote
 				&& event.world.provider.dimensionId == 0
 				&& event.type == EnumCreatureType.monster
-				&& event.world.canBlockSeeTheSky(event.x, event.y, event.z)) {
+				&& event.world.canBlockSeeTheSky(event.x, event.y, event.z)
+				&& !event.isCanceled()) {
 
 					if (event.world.rand.nextInt(MobConfig.rampantScoutSpawnChance) == 0) {
 

--- a/src/main/java/com/hbm/handler/pollution/PollutionHandler.java
+++ b/src/main/java/com/hbm/handler/pollution/PollutionHandler.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import com.hbm.config.MobConfig;
 import com.hbm.config.RadiationConfig;
 
+import com.hbm.entity.mob.EntityGlyphidDigger;
 import com.hbm.entity.mob.EntityGlyphidScout;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
@@ -362,8 +363,11 @@ public class PollutionHandler {
 
 						if (soot >= MobConfig.rampantScoutSpawnThresh) {
 							EntityGlyphidScout scout = new EntityGlyphidScout(event.world);
+							EntityGlyphidDigger digger = new EntityGlyphidDigger(event.world);
 							scout.setLocationAndAngles(event.x, event.y, event.z, event.world.rand.nextFloat() * 360.0F, 0.0F);
+							digger.setLocationAndAngles(event.x, event.y, event.z, event.world.rand.nextFloat() * 360.0F, 0.0F);
 							event.world.spawnEntityInWorld(scout);
+							event.world.spawnEntityInWorld(digger);
 						}
 					}
 				}


### PR DESCRIPTION
**Changes**

- New glyphid digger attack, where it lobs blocks from the ground as rubble at the player, with a similar range as the blasters and bombardiers.
   -    Rubble deals significantly more damage than the acid bombs, but is easier to evade at longer ranges.
   -    Also increased the size of the glyphid digger slightly.

-  Increased the amount of damage dealt by glyphid bombardiers and and blasters, and improved attack code.
   - They now use the mortar-like attack at longer ranges and the direct attack at short distances.

- Fixed edge cases where scouts were unfocused and did nothing, such as when extended targetting kicked in, and an edge case where hasTarget was true despite there being no waypoint.

- Changes to the rampant natural scout spawning:
  1.   The soot threshold for natural scout spawning has been lowered down to 14 soot, since 20 soot was hard to achieve
  2.   Scouts now have an escort in the form of a glyphid digger, so they can clear obstacles incase they spawned in bad locations
  3.  Fixed issue where scouts spawned even if no mobs could actually spawn in the location