### PR TITLE
Quantum virtual particles

### DIFF
--- a/src/main/java/com/hbm/main/ModEventHandlerRenderer.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerRenderer.java
@@ -428,8 +428,8 @@ public class ModEventHandlerRenderer {
 		int[] ranges = ForgeModContainer.blendRanges;
 		int distance = 0;
 		
-		if(settings.fancyGraphics && settings.renderDistanceChunks >= 0 && settings.renderDistanceChunks < ranges.length) {
-			distance = ranges[settings.renderDistanceChunks];
+		if(settings.fancyGraphics && settings.renderDistanceChunks >= 0) {
+			distance = ranges[Math.min(settings.renderDistanceChunks, ranges.length - 1)];
 		}
 
 		float r = 0F;
@@ -456,7 +456,7 @@ public class ModEventHandlerRenderer {
 		if(doesBiomeApply) {
 			fogRGBMultiplier = Vec3.createVectorHelper(r / divider, g / divider, b / divider);
 		} else {
-			fogRGBMultiplier = Vec3.createVectorHelper(red, green, blue);
+			fogRGBMultiplier = null;
 		}
 
 		return fogRGBMultiplier;

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityHadron.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityHadron.java
@@ -141,15 +141,11 @@ public class TileEntityHadron extends TileEntityMachineBase implements IEnergyUs
 			// If we succeed, "collapse" the cheapest particle that had enough momentum
 			// If we fail to make anything, "collapse" the most expensive particle
 			if (particles.isEmpty() && !particlesCompleted.isEmpty()) {
-				MainRegistry.logger.info("number of COMPLETED: " + particlesCompleted.size());
-
 				ItemStack[] result = null;
 				Particle particle = null;
 
 				particlesCompleted.sort((p1, p2) -> { return p1.momentum - p2.momentum; });
 				for(Particle p : particlesCompleted) {
-					MainRegistry.logger.info(p.momentum);
-		
 					particle = p;
 					result = HadronRecipes.getOutput(p.item1, p.item2, p.momentum, analysisOnly);
 					if(result != null) break;
@@ -648,11 +644,14 @@ public class TileEntityHadron extends TileEntityMachineBase implements IEnergyUs
 				p.expire(EnumHadronState.ERROR_ANALYSIS_TOO_LONG);
 			
 			if(p.analysis == 2) {
+				// Only pop for the first particle
+				if(this.state != EnumHadronState.ANALYSIS) {
+					this.worldObj.playSoundEffect(p.posX + 0.5, p.posY + 0.5, p.posZ + 0.5, "fireworks.blast", 2.0F, 2F);
+					NBTTagCompound data = new NBTTagCompound();
+					data.setString("type", "hadron");
+					PacketDispatcher.wrapper.sendToAllAround(new AuxParticlePacketNT(data, p.posX + 0.5, p.posY + 0.5, p.posZ + 0.5), new TargetPoint(worldObj.provider.dimensionId, p.posX + 0.5, p.posY + 0.5, p.posZ + 0.5, 25));
+				}
 				this.state = EnumHadronState.ANALYSIS;
-				this.worldObj.playSoundEffect(p.posX + 0.5, p.posY + 0.5, p.posZ + 0.5, "fireworks.blast", 2.0F, 2F);
-				NBTTagCompound data = new NBTTagCompound();
-				data.setString("type", "hadron");
-				PacketDispatcher.wrapper.sendToAllAround(new AuxParticlePacketNT(data, p.posX + 0.5, p.posY + 0.5, p.posZ + 0.5), new TargetPoint(worldObj.provider.dimensionId, p.posX + 0.5, p.posY + 0.5, p.posZ + 0.5, 25));
 			}
 
 			//if operating in line accelerator mode, halt after 2 blocks and staart the reading


### PR DESCRIPTION
> _I never thought I'd **see** a Resonance Cascade, let alone create one..._

This PR changes the Schottky Particle Accelerator Diode behaviour to introduce the concept of _virtual particles_. Each valid exit of a Schottky diode will now create a parallel universe virtual particle, such that the accelerator **simultaneously uses all valid path**s. Assuming no building errors are encountered on any path, it will use the lowest momentum particle that is valid for the current recipe and collapse it to become a _real particle_, consuming only the power from plugs that the real particle encountered.

If a building error is encountered, the erroring particle is made real, consuming only the power from the broken segment of the accelerator, and cancelling any successful particles. This makes it much easier to debug any building errors, since the accelerator won't ever exist in the superposition of simultaneously failing and succeeding.

The reason for this change is simple, to remove the need to dismantle your particle accelerator just to screwdriver your Schottkys every time you wish to change the accelerator power for different recipes. This has value in automating the accelerator as well!

Also included:
* Fog doesn't cache unnecessarily, improving responsiveness outside of nuclear biomes
* Fog blending should work with render distances greater than 16 now