### PR TITLE
Gerald alt recipe as config option

### DIFF
--- a/src/main/java/com/hbm/config/GeneralConfig.java
+++ b/src/main/java/com/hbm/config/GeneralConfig.java
@@ -35,7 +35,8 @@ public class GeneralConfig {
 	public static boolean enableMOTD = true;
 	public static boolean enableGuideBook = true;
 	public static int hintPos = 0;
-
+	
+	public static boolean alternateGeraldRecipe = false;
 	public static boolean enableExpensiveMode = false;
 	
 	public static boolean enable528 = false;
@@ -99,6 +100,7 @@ public class GeneralConfig {
 		enableMOTD = config.get(CATEGORY_GENERAL, "1.36_enableMOTD", true, "If enabled, shows the 'Loaded mod!' chat message as well as update notifications when joining a world").getBoolean(true);
 		enableGuideBook = config.get(CATEGORY_GENERAL, "1.37_enableGuideBook", true, "If enabled, gives players the guide book when joining the world for the first time").getBoolean(true);
 		
+		alternateGeraldRecipe = config.get(CATEGORY_GENERAL, "1.98_alternateGeraldRecipe", false, "Replaces the recipe for gerald with a less RNG based, but still difficult, recipe.").getBoolean(false);
 		enableExpensiveMode = config.get(CATEGORY_GENERAL, "1.99_enableExpensiveMode", false, "It does what the name implies.").getBoolean(false);
 		
 		final String CATEGORY_528 = CommonConfig.CATEGORY_528;

--- a/src/main/java/com/hbm/config/GeneralConfig.java
+++ b/src/main/java/com/hbm/config/GeneralConfig.java
@@ -37,6 +37,7 @@ public class GeneralConfig {
 	public static int hintPos = 0;
 
 	public static boolean enableExpensiveMode = false;
+	public static boolean alternateGeraldRecipe = false;
 	
 	public static boolean enable528 = false;
 	public static boolean enable528ReasimBoilers = true;
@@ -99,6 +100,7 @@ public class GeneralConfig {
 		enableMOTD = config.get(CATEGORY_GENERAL, "1.36_enableMOTD", true, "If enabled, shows the 'Loaded mod!' chat message as well as update notifications when joining a world").getBoolean(true);
 		enableGuideBook = config.get(CATEGORY_GENERAL, "1.37_enableGuideBook", true, "If enabled, gives players the guide book when joining the world for the first time").getBoolean(true);
 		
+		alternateGeraldRecipe = config.get(CATEGORY_GENERAL, "1.98_alternateGeraldRecipe", false, "Replaces the recipe for gerald with a less RNG based, but still difficult, recipe.").getBoolean(false);
 		enableExpensiveMode = config.get(CATEGORY_GENERAL, "1.99_enableExpensiveMode", false, "It does what the name implies.").getBoolean(false);
 		
 		final String CATEGORY_528 = CommonConfig.CATEGORY_528;
@@ -106,7 +108,7 @@ public class GeneralConfig {
 		config.addCustomCategoryComment(CATEGORY_528, "CAUTION\n"
 				+ "528 Mode: Please proceed with caution!\n"
 				+ "528-Modus: Lassen Sie Vorsicht walten!\n"
-				+ "способ-528: действовать с осторожностью!");
+				+ "Ñ�Ð¿Ð¾Ñ�Ð¾Ð±-528: Ð´ÐµÐ¹Ñ�Ñ‚Ð²Ð¾Ð²Ð°Ñ‚ÑŒ Ñ� Ð¾Ñ�Ñ‚Ð¾Ñ€Ð¾Ð¶Ð½Ð¾Ñ�Ñ‚ÑŒÑŽ!");
 		
 		enable528 = CommonConfig.createConfigBool(config, CATEGORY_528, "enable528Mode", "The central toggle for 528 mode.", false);
 		enable528ReasimBoilers = CommonConfig.createConfigBool(config, CATEGORY_528, "X528_forceReasimBoilers", "Keeps the RBMK dial for ReaSim boilers on, preventing use of non-ReaSim boiler columns and forcing the use of steam in-/outlets", true);

--- a/src/main/java/com/hbm/config/GeneralConfig.java
+++ b/src/main/java/com/hbm/config/GeneralConfig.java
@@ -37,7 +37,6 @@ public class GeneralConfig {
 	public static int hintPos = 0;
 
 	public static boolean enableExpensiveMode = false;
-	public static boolean alternateGeraldRecipe = false;
 	
 	public static boolean enable528 = false;
 	public static boolean enable528ReasimBoilers = true;
@@ -100,7 +99,6 @@ public class GeneralConfig {
 		enableMOTD = config.get(CATEGORY_GENERAL, "1.36_enableMOTD", true, "If enabled, shows the 'Loaded mod!' chat message as well as update notifications when joining a world").getBoolean(true);
 		enableGuideBook = config.get(CATEGORY_GENERAL, "1.37_enableGuideBook", true, "If enabled, gives players the guide book when joining the world for the first time").getBoolean(true);
 		
-		alternateGeraldRecipe = config.get(CATEGORY_GENERAL, "1.98_alternateGeraldRecipe", false, "Replaces the recipe for gerald with a less RNG based, but still difficult, recipe.").getBoolean(false);
 		enableExpensiveMode = config.get(CATEGORY_GENERAL, "1.99_enableExpensiveMode", false, "It does what the name implies.").getBoolean(false);
 		
 		final String CATEGORY_528 = CommonConfig.CATEGORY_528;
@@ -108,7 +106,7 @@ public class GeneralConfig {
 		config.addCustomCategoryComment(CATEGORY_528, "CAUTION\n"
 				+ "528 Mode: Please proceed with caution!\n"
 				+ "528-Modus: Lassen Sie Vorsicht walten!\n"
-				+ "Ñ�Ð¿Ð¾Ñ�Ð¾Ð±-528: Ð´ÐµÐ¹Ñ�Ñ‚Ð²Ð¾Ð²Ð°Ñ‚ÑŒ Ñ� Ð¾Ñ�Ñ‚Ð¾Ñ€Ð¾Ð¶Ð½Ð¾Ñ�Ñ‚ÑŒÑŽ!");
+				+ "способ-528: действовать с осторожностью!");
 		
 		enable528 = CommonConfig.createConfigBool(config, CATEGORY_528, "enable528Mode", "The central toggle for 528 mode.", false);
 		enable528ReasimBoilers = CommonConfig.createConfigBool(config, CATEGORY_528, "X528_forceReasimBoilers", "Keeps the RBMK dial for ReaSim boilers on, preventing use of non-ReaSim boiler columns and forcing the use of steam in-/outlets", true);

--- a/src/main/java/com/hbm/inventory/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/AssemblerRecipes.java
@@ -586,13 +586,12 @@ public class AssemblerRecipes extends SerializableRecipe {
 					new ComparableStack(ModItems.combine_scrap, 1),
 					new ComparableStack(ModItems.mp_warhead_15_balefire, 1),
 					new ComparableStack(ModItems.gem_rad, 4),
-					new ComparableStack(ModBlocks.machine_assemfac, 2),
 					
-					new ComparableStack(ModItems.circuit_gold, 16),
+					new ComparableStack(ModItems.circuit_gold, 32),
 					new ComparableStack(ModItems.ingot_cft, 16),
 					new ComparableStack(ModItems.explosive_lenses, 12),
-					new ComparableStack(ModItems.drone, 8 , 2),
-					
+					new ComparableStack(ModBlocks.det_nuke, 16),
+					new OreDictStack(STAR.ingot(), 32),
 					
 					new ComparableStack(ModItems.coin_creeper, 1),
 					new ComparableStack(ModItems.coin_radiation, 1),

--- a/src/main/java/com/hbm/inventory/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/AssemblerRecipes.java
@@ -586,12 +586,13 @@ public class AssemblerRecipes extends SerializableRecipe {
 					new ComparableStack(ModItems.combine_scrap, 1),
 					new ComparableStack(ModItems.mp_warhead_15_balefire, 1),
 					new ComparableStack(ModItems.gem_rad, 4),
-					new ComparableStack(ModBlocks.machine_assemfac, 4),
+					new ComparableStack(ModBlocks.machine_assemfac, 2),
 					
-					new ComparableStack(ModItems.circuit_gold, 32),
+					new ComparableStack(ModItems.circuit_gold, 16),
 					new ComparableStack(ModItems.ingot_cft, 16),
-					new ComparableStack(ModItems.drone, 12 , 2),
-					new ComparableStack(ModItems.explosive_lenses, 8),
+					new ComparableStack(ModItems.explosive_lenses, 12),
+					new ComparableStack(ModItems.drone, 8 , 2),
+					
 					
 					new ComparableStack(ModItems.coin_creeper, 1),
 					new ComparableStack(ModItems.coin_radiation, 1),

--- a/src/main/java/com/hbm/inventory/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/AssemblerRecipes.java
@@ -54,7 +54,7 @@ public class AssemblerRecipes extends SerializableRecipe {
 	public void registerDefaults() {
 		
 		boolean exp = GeneralConfig.enableExpensiveMode;
-		
+
 		makeRecipe(new ComparableStack(ModItems.plate_iron, 2), new AStack[] {new OreDictStack(IRON.ingot(), 3), },30);
 		makeRecipe(new ComparableStack(ModItems.plate_gold, 2), new AStack[] {new OreDictStack(GOLD.ingot(), 3), },30);
 		makeRecipe(new ComparableStack(ModItems.plate_titanium, 2), new AStack[] {new OreDictStack(TI.ingot(), 3), },30);
@@ -563,21 +563,42 @@ public class AssemblerRecipes extends SerializableRecipe {
 				new ComparableStack(ModItems.plate_armor_titanium, 50),
 				new ComparableStack(ModItems.coin_worm, 1)
 			}, 1200);
-
-		makeRecipe(new ComparableStack(ModItems.sat_gerald, 1), new AStack[] {
-				new ComparableStack(ModItems.burnt_bark, 1),
-				new ComparableStack(ModItems.combine_scrap, 1),
-				new ComparableStack(ModItems.crystal_horn, 1),
-				new ComparableStack(ModItems.crystal_charred, 1),
-				new ComparableStack(ModBlocks.pink_log, 1),
-				new ComparableStack(ModItems.mp_warhead_15_balefire, 1),
-				new ComparableStack(ModBlocks.det_nuke, 16),
-				new OreDictStack(STAR.ingot(), 32),
-				new ComparableStack(ModItems.coin_creeper, 1),
-				new ComparableStack(ModItems.coin_radiation, 1),
-				new ComparableStack(ModItems.coin_maskman, 1),
-				new ComparableStack(ModItems.coin_worm, 1),
+		
+		if(!GeneralConfig.alternateGeraldRecipe) {
+			makeRecipe(new ComparableStack(ModItems.sat_gerald, 1), new AStack[] {
+					new ComparableStack(ModItems.burnt_bark, 1),
+					new ComparableStack(ModItems.combine_scrap, 1),
+					new ComparableStack(ModItems.crystal_horn, 1),
+					new ComparableStack(ModItems.crystal_charred, 1),
+					new ComparableStack(ModBlocks.pink_log, 1),
+					new ComparableStack(ModItems.mp_warhead_15_balefire, 1),
+					new ComparableStack(ModBlocks.det_nuke, 16),
+					new OreDictStack(STAR.ingot(), 32),
+					new ComparableStack(ModItems.coin_creeper, 1),
+					new ComparableStack(ModItems.coin_radiation, 1),
+					new ComparableStack(ModItems.coin_maskman, 1),
+					new ComparableStack(ModItems.coin_worm, 1),
 			}, 1200, ModItems.journal_bj);
+		
+		} else {
+			
+			makeRecipe(new ComparableStack(ModItems.sat_gerald, 1), new AStack[] {
+					new ComparableStack(ModItems.combine_scrap, 1),
+					new ComparableStack(ModItems.mp_warhead_15_balefire, 1),
+					new ComparableStack(ModItems.gem_rad, 4),
+					new ComparableStack(ModBlocks.machine_assemfac, 4),
+					
+					new ComparableStack(ModItems.circuit_gold, 32),
+					new ComparableStack(ModItems.ingot_cft, 16),
+					new ComparableStack(ModItems.drone, 12 , 2),
+					new ComparableStack(ModItems.explosive_lenses, 8),
+					
+					new ComparableStack(ModItems.coin_creeper, 1),
+					new ComparableStack(ModItems.coin_radiation, 1),
+					new ComparableStack(ModItems.coin_maskman, 1),
+					new ComparableStack(ModItems.coin_worm, 1),
+			}, 6000, ModItems.journal_bj);
+		}
 		
 		makeRecipe(new ComparableStack(ModBlocks.vault_door, 1), new AStack[] {
 				new OreDictStack(STEEL.ingot(), 32),


### PR DESCRIPTION
Adds a config option to replace the current Gerald recipe with a recipe that does not need pink logs or burnt bark.

The alt recipe keeps BF warhead, CMB scrap, and the boss medals, but replaces the remaining ingredients with a mix of industrial items chosen to both be expensive and suitable for a self replicating lunar robotics platform.
