### PR TITLE
Config option to disable cooling tower particle emissions

### DIFF
--- a/src/main/java/com/hbm/config/GeneralConfig.java
+++ b/src/main/java/com/hbm/config/GeneralConfig.java
@@ -34,6 +34,7 @@ public class GeneralConfig {
 	public static boolean enableFluidContainerCompat = true;
 	public static boolean enableMOTD = true;
 	public static boolean enableGuideBook = true;
+	public static boolean enableSteamParticles = true;
 	public static int hintPos = 0;
 
 	public static boolean enableExpensiveMode = false;
@@ -98,7 +99,8 @@ public class GeneralConfig {
 		enableFluidContainerCompat = config.get(CATEGORY_GENERAL, "1.35_enableFluidContainerCompat", true, "If enabled, fluid containers will be oredicted and interchangable in recipes with other mods' containers, as well as TrainCraft's diesel being considered a valid diesel canister.").getBoolean(true);
 		enableMOTD = config.get(CATEGORY_GENERAL, "1.36_enableMOTD", true, "If enabled, shows the 'Loaded mod!' chat message as well as update notifications when joining a world").getBoolean(true);
 		enableGuideBook = config.get(CATEGORY_GENERAL, "1.37_enableGuideBook", true, "If enabled, gives players the guide book when joining the world for the first time").getBoolean(true);
-		
+		enableSteamParticles = config.get(CATEGORY_GENERAL, "1.38_enableSteamParticles",true, "If disabled, auxiliary cooling towers and large cooling towers will not emit steam particles when in use.").getBoolean(true);
+
 		enableExpensiveMode = config.get(CATEGORY_GENERAL, "1.99_enableExpensiveMode", false, "It does what the name implies.").getBoolean(false);
 		
 		final String CATEGORY_528 = CommonConfig.CATEGORY_528;

--- a/src/main/java/com/hbm/config/GeneralConfig.java
+++ b/src/main/java/com/hbm/config/GeneralConfig.java
@@ -35,7 +35,6 @@ public class GeneralConfig {
 	public static boolean enableMOTD = true;
 	public static boolean enableGuideBook = true;
 	public static boolean enableSteamParticles = true;
-
 	public static int hintPos = 0;
 
 	public static boolean enableExpensiveMode = false;

--- a/src/main/java/com/hbm/config/GeneralConfig.java
+++ b/src/main/java/com/hbm/config/GeneralConfig.java
@@ -35,6 +35,7 @@ public class GeneralConfig {
 	public static boolean enableMOTD = true;
 	public static boolean enableGuideBook = true;
 	public static boolean enableSteamParticles = true;
+
 	public static int hintPos = 0;
 
 	public static boolean enableExpensiveMode = false;

--- a/src/main/java/com/hbm/main/ClientProxy.java
+++ b/src/main/java/com/hbm/main/ClientProxy.java
@@ -127,7 +127,6 @@ import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.ReflectionHelper;
-import scala.tools.nsc.backend.icode.analysis.TypeFlowAnalysis;
 
  public class ClientProxy extends ServerProxy {
 	

--- a/src/main/java/com/hbm/main/ClientProxy.java
+++ b/src/main/java/com/hbm/main/ClientProxy.java
@@ -55,6 +55,7 @@ import com.hbm.blocks.generic.BlockSnowglobe.TileEntitySnowglobe;
 import com.hbm.blocks.machine.MachineFan.TileEntityFan;
 import com.hbm.blocks.machine.PistonInserter.TileEntityPistonInserter;
 import com.hbm.blocks.machine.WatzPump.TileEntityWatzPump;
+import com.hbm.config.GeneralConfig;
 import com.hbm.entity.cart.*;
 import com.hbm.entity.effect.*;
 import com.hbm.entity.grenade.*;
@@ -126,11 +127,12 @@ import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.ReflectionHelper;
+import scala.tools.nsc.backend.icode.analysis.TypeFlowAnalysis;
 
-public class ClientProxy extends ServerProxy {
+ public class ClientProxy extends ServerProxy {
 	
 	public RenderInfoSystem theInfoSystem = new RenderInfoSystem();
-	
+
 	@Override
 	public void registerRenderInfo() {
 
@@ -1742,7 +1744,7 @@ public class ClientProxy extends ServerProxy {
 		}
 		
 		if("tower".equals(type)) {
-			if(particleSetting == 0 || (particleSetting == 1 && rand.nextBoolean())) {
+			if(GeneralConfig.enableSteamParticles && (particleSetting == 0 || (particleSetting == 1 && rand.nextBoolean()))) {
 				ParticleCoolingTower fx = new ParticleCoolingTower(man, world, x, y, z);
 				fx.setLift(data.getFloat("lift"));
 				fx.setBaseScale(data.getFloat("base"));

--- a/src/main/java/com/hbm/main/ClientProxy.java
+++ b/src/main/java/com/hbm/main/ClientProxy.java
@@ -131,7 +131,7 @@ import cpw.mods.fml.relauncher.ReflectionHelper;
 public class ClientProxy extends ServerProxy {
 	
 	public RenderInfoSystem theInfoSystem = new RenderInfoSystem();
-
+	
 	@Override
 	public void registerRenderInfo() {
 

--- a/src/main/java/com/hbm/main/ClientProxy.java
+++ b/src/main/java/com/hbm/main/ClientProxy.java
@@ -128,7 +128,7 @@ import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.ReflectionHelper;
 
- public class ClientProxy extends ServerProxy {
+public class ClientProxy extends ServerProxy {
 	
 	public RenderInfoSystem theInfoSystem = new RenderInfoSystem();
 


### PR DESCRIPTION
All this does is add a toggle in the config to disable the steam particles from cooling towers even on "All" and "Decreased" particle settings. I only thought of this because I have like 10 cooling towers around my base and it's hard to see anything without changing the settings to minimal but I'd like to keep the rest of the particle effects on.

There's also 6 commits because I made a couple mistakes and each time I noticed one I'd just make a new commit cause I assumed that it would be the last change (I'm still new to this stuff).