### PR TITLE
Inventory item rendering for Wiki

### DIFF
--- a/src/main/java/com/hbm/inventory/gui/GUIScreenPreview.java
+++ b/src/main/java/com/hbm/inventory/gui/GUIScreenPreview.java
@@ -54,8 +54,10 @@ public class GUIScreenPreview extends GuiScreen {
 		this.drawTexturedModalRect(res.getScaledWidth_double() / 2D / zoom - 9D, res.getScaledHeight_double() / 2D / zoom - 9D, 5, 87, 18, 18);
 		GL11.glPopMatrix();
 
-		this.fontRendererObj.drawString("Zoom: " + zoom, 2, this.height - 20, 0xff0000);
-		this.fontRendererObj.drawString("Windows Scale: " + res.getScaleFactor(), 2, this.height - 10, 0xff0000);
+		String zoomString = "Zoom: " + zoom;
+		String scaleString = "Windows Scale: " + res.getScaleFactor();
+		this.fontRendererObj.drawString(zoomString, this.width - this.fontRendererObj.getStringWidth(zoomString) - 2, this.height - 20, 0xff0000);
+		this.fontRendererObj.drawString(scaleString, this.width - this.fontRendererObj.getStringWidth(scaleString) - 2, this.height - 10, 0xff0000);
 	}
 
 	public void drawTexturedModalRect(double x, double y, int sourceX, int sourceY, int sizeX, int sizeY) {

--- a/src/main/java/com/hbm/inventory/gui/GUIScreenWikiRender.java
+++ b/src/main/java/com/hbm/inventory/gui/GUIScreenWikiRender.java
@@ -57,7 +57,9 @@ public class GUIScreenWikiRender extends GuiScreen {
 
         try {
             String slotName = preview[index].getDisplayName().replaceAll("[^\\w ().-]+", "");
-            saveScreenshot(Minecraft.getMinecraft().mcDataDir, "Slot " + slotName + ".png", 2, 2, 32, 32, 0xFF8B8B8B);
+            if(!slotName.endsWith(".name")) {
+                saveScreenshot(Minecraft.getMinecraft().mcDataDir, "Slot " + slotName + ".png", 2, 2, 32, 32, 0xFF8B8B8B);
+            }
         } catch (Exception ex) {
             // Just skip any failures caused by display name or rendering
         }

--- a/src/main/java/com/hbm/inventory/gui/GUIScreenWikiRender.java
+++ b/src/main/java/com/hbm/inventory/gui/GUIScreenWikiRender.java
@@ -56,7 +56,7 @@ public class GUIScreenWikiRender extends GuiScreen {
 		GL11.glEnable(GL11.GL_LIGHTING);
 
         try {
-            String slotName = preview[index].getDisplayName().replaceAll("[^\\w ().-]+", "");
+            String slotName = preview[index].getDisplayName().replaceAll("§.", "").replaceAll("[^\\w ().-]+", "");
             if(!slotName.endsWith(".name")) {
                 saveScreenshot(Minecraft.getMinecraft().mcDataDir, "Slot " + slotName + ".png", 2, 2, 32, 32, 0xFF8B8B8B);
             }

--- a/src/main/java/com/hbm/inventory/gui/GUIScreenWikiRender.java
+++ b/src/main/java/com/hbm/inventory/gui/GUIScreenWikiRender.java
@@ -1,0 +1,168 @@
+package com.hbm.inventory.gui;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.nio.IntBuffer;
+
+import javax.imageio.ImageIO;
+
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
+
+import com.hbm.lib.RefStrings;
+import com.hbm.main.MainRegistry;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.texture.TextureUtil;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+
+public class GUIScreenWikiRender extends GuiScreen {
+
+    // Basically the same thing as GUIScreenPreview, but will iterate through all provided preview stacks
+    // taking a screenshot of each, as fast as the game can render them
+
+	protected static final ResourceLocation texture = new ResourceLocation(RefStrings.MODID + ":textures/gui/nei/gui_nei.png");
+	protected ItemStack[] preview;
+    protected int index = 0;
+
+	public GUIScreenWikiRender(ItemStack[] stacks) {
+		this.preview = stacks;
+	}
+
+    @Override
+	public void drawScreen(int mouseX, int mouseY, float f) {
+		if(this.mc.theWorld != null) {
+			GuiScreen.drawRect(0, 0, this.width, this.height, 0xFFC6C6C6);
+		} else {
+			this.drawBackground(0);
+		}
+
+        // Once we've reached the end of the array, immedaitely close this GUI
+        if(index >= preview.length) {
+            this.mc.thePlayer.closeScreen();
+            return;
+        }
+		
+		this.drawGuiContainerBackgroundLayer();
+		GL11.glDisable(GL11.GL_LIGHTING);
+		this.drawGuiContainerForegroundLayer(preview[index]);
+		GL11.glEnable(GL11.GL_LIGHTING);
+
+        try {
+            String slotName = preview[index].getDisplayName().replaceAll("[^\\w ().-]+", "");
+            saveScreenshot(Minecraft.getMinecraft().mcDataDir, "Slot " + slotName + ".png", 2, 2, 32, 32, 0xFF8B8B8B);
+        } catch (Exception ex) {
+            // Just skip any failures caused by display name or rendering
+        }
+
+        index++;
+    }
+
+	protected void drawGuiContainerBackgroundLayer() {
+		GL11.glPushMatrix();
+		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		this.mc.getTextureManager().bindTexture(texture);
+		ScaledResolution res = new ScaledResolution(this.mc, this.mc.displayWidth, this.mc.displayHeight);
+        this.drawTexturedModalRect(0, res.getScaledHeight_double() - 18D, 5, 87, 18, 18);
+		GL11.glPopMatrix();
+	}
+
+	public void drawTexturedModalRect(double x, double y, int sourceX, int sourceY, int sizeX, int sizeY) {
+		double f = 0.00390625D;
+		double f1 = 0.00390625D;
+		Tessellator tessellator = Tessellator.instance;
+		tessellator.startDrawingQuads();
+		tessellator.addVertexWithUV((double) (x + 0), (double) (y + sizeY), (double) this.zLevel, (double) ((float) (sourceX + 0) * f), (double) ((float) (sourceY + sizeY) * f1));
+		tessellator.addVertexWithUV((double) (x + sizeX), (double) (y + sizeY), (double) this.zLevel, (double) ((float) (sourceX + sizeX) * f), (double) ((float) (sourceY + sizeY) * f1));
+		tessellator.addVertexWithUV((double) (x + sizeX), (double) (y + 0), (double) this.zLevel, (double) ((float) (sourceX + sizeX) * f), (double) ((float) (sourceY + 0) * f1));
+		tessellator.addVertexWithUV((double) (x + 0), (double) (y + 0), (double) this.zLevel, (double) ((float) (sourceX + 0) * f), (double) ((float) (sourceY + 0) * f1));
+		tessellator.draw();
+	}
+
+	protected void drawGuiContainerForegroundLayer(ItemStack preview) {
+		if(preview == null) return;
+		
+		GL11.glPushMatrix();
+		RenderHelper.enableGUIStandardItemLighting();
+		OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240F, 240F);
+		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+
+		GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+		GL11.glEnable(GL11.GL_LIGHTING);
+		GL11.glEnable(GL11.GL_DEPTH_TEST);
+		
+		ScaledResolution res = new ScaledResolution(this.mc, this.mc.displayWidth, this.mc.displayHeight);
+        GL11.glTranslated(9D, res.getScaledHeight_double() - 9D, -200);
+
+		this.zLevel = 200.0F;
+		itemRender.zLevel = 200.0F;
+
+		GL11.glEnable(GL11.GL_DEPTH_TEST);
+		itemRender.renderItemAndEffectIntoGUI(this.fontRendererObj, this.mc.getTextureManager(), preview, -8, -8);
+		itemRender.renderItemOverlayIntoGUI(this.fontRendererObj, this.mc.getTextureManager(), preview, -8, -8, null);
+
+		itemRender.zLevel = 0.0F;
+		this.zLevel = 0.0F;
+		
+		GL11.glPopMatrix();
+	}
+
+
+	private static IntBuffer pixelBuffer;
+	private static int[] pixelValues;
+
+	// This implementation is based directly on ScreenShotHelper.saveScreenshot()
+	// But allows for defining a rect where you want to sample pixels from
+	private static void saveScreenshot(File dataDir, String fileName, int x, int y, int width, int height, int transparentColor) {
+		try {
+			File screenshotDirectory = new File(dataDir, "wiki-screenshots");
+			screenshotDirectory.mkdir();
+
+			int bufferSize = width * height;
+			if(pixelBuffer == null || pixelBuffer.capacity() < bufferSize) {
+				pixelBuffer = BufferUtils.createIntBuffer(bufferSize);
+				pixelValues = new int[bufferSize];
+			}
+
+			GL11.glPixelStorei(GL11.GL_PACK_ALIGNMENT, 1);
+			GL11.glPixelStorei(GL11.GL_UNPACK_ALIGNMENT, 1);
+			pixelBuffer.clear();
+			GL11.glReadPixels(x, y, width, height, GL12.GL_BGRA, GL12.GL_UNSIGNED_INT_8_8_8_8_REV, pixelBuffer);
+
+			pixelBuffer.get(pixelValues);
+			TextureUtil.func_147953_a(pixelValues, width, height);
+			BufferedImage imageBuffer = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+			imageBuffer.setRGB(0, 0, width, height, pixelValues, 0, width);
+
+			// This is the only proper custom part, setting the background of an inventory slot to be transparent
+			if(transparentColor != 0) {
+				for(int iy = 0; iy < imageBuffer.getHeight(); ++iy) {
+					for(int ix = 0; ix < imageBuffer.getWidth(); ++ix) {
+						if(imageBuffer.getRGB(ix, iy) == transparentColor) {
+							imageBuffer.setRGB(ix, iy, 0);
+						}
+					}
+				}
+			}
+
+			File imageFile;
+			if(fileName == null) {
+				throw new IllegalArgumentException("fileName must not be null");
+			} else {
+				imageFile = new File(screenshotDirectory, fileName);
+			}
+
+			ImageIO.write(imageBuffer, "png", imageFile);
+		} catch (Exception ex) {
+			MainRegistry.logger.warn("Failed to save NTM screenshot", ex);
+		}
+	}
+
+}

--- a/src/main/java/com/hbm/main/ModEventHandlerClient.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerClient.java
@@ -1,6 +1,7 @@
 package com.hbm.main;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
@@ -30,6 +31,7 @@ import com.hbm.interfaces.Spaghetti;
 import com.hbm.inventory.RecipesCommon.ComparableStack;
 import com.hbm.inventory.gui.GUIArmorTable;
 import com.hbm.inventory.gui.GUIScreenPreview;
+import com.hbm.inventory.gui.GUIScreenWikiRender;
 import com.hbm.items.ISyncButtons;
 import com.hbm.items.ModItems;
 import com.hbm.items.armor.ArmorFSB;
@@ -908,6 +910,8 @@ public class ModEventHandlerClient {
 
 	public static int currentBrightness = 0;
 	public static int lastBrightness = 0;
+
+	static boolean isRenderingItems = false;
 	
 	@SubscribeEvent
 	public void clentTick(ClientTickEvent event) {
@@ -970,6 +974,24 @@ public class ModEventHandlerClient {
 				stack.stackSize = 1;
 				FMLCommonHandler.instance().showGuiScreen(new GUIScreenPreview(stack));
 			}
+		}
+
+		if(Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) && Keyboard.isKeyDown(Keyboard.KEY_0) && Keyboard.isKeyDown(Keyboard.KEY_1)) {
+			if (!isRenderingItems) {
+				isRenderingItems = true;
+
+				MainRegistry.logger.info("Taking a screenshot of ALL items, if you did this by mistake: fucking lmao get rekt nerd");
+
+				List<ItemStack> stacks = new ArrayList<ItemStack>();
+				for (Object reg : Item.itemRegistry) {
+					Item item = (Item) reg;
+					stacks.add(new ItemStack(item));
+				}
+
+				FMLCommonHandler.instance().showGuiScreen(new GUIScreenWikiRender(stacks.toArray(new ItemStack[0])));
+			}
+		} else {
+			isRenderingItems = false;
 		}
 		
 		if(event.phase == Phase.START) {

--- a/src/main/java/com/hbm/main/ModEventHandlerClient.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerClient.java
@@ -2,6 +2,7 @@ package com.hbm.main;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
@@ -39,6 +40,9 @@ import com.hbm.items.armor.ArmorFSBPowered;
 import com.hbm.items.armor.ArmorNo9;
 import com.hbm.items.armor.ItemArmorMod;
 import com.hbm.items.armor.JetpackBase;
+import com.hbm.items.machine.ItemDepletedFuel;
+import com.hbm.items.machine.ItemFluidDuct;
+import com.hbm.items.machine.ItemRBMKPellet;
 import com.hbm.items.weapon.ItemGunBase;
 import com.hbm.lib.Library;
 import com.hbm.lib.RefStrings;
@@ -108,6 +112,7 @@ import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
+import net.minecraft.init.Blocks;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemArmor;
@@ -982,10 +987,32 @@ public class ModEventHandlerClient {
 
 				MainRegistry.logger.info("Taking a screenshot of ALL items, if you did this by mistake: fucking lmao get rekt nerd");
 
+				List<Item> ignoredItems = Arrays.asList(
+					ModItems.assembly_template,
+					ModItems.crucible_template,
+					ModItems.chemistry_template,
+					ModItems.chemistry_icon,
+					ModItems.fluid_icon,
+					ModItems.achievement_icon,
+					Items.spawn_egg,
+					Item.getItemFromBlock(Blocks.mob_spawner)
+				);
+
+				List<Class<? extends Item>> collapsedClasses = Arrays.asList(
+					ItemRBMKPellet.class,
+					ItemDepletedFuel.class,
+					ItemFluidDuct.class
+				);
+
 				List<ItemStack> stacks = new ArrayList<ItemStack>();
 				for (Object reg : Item.itemRegistry) {
 					Item item = (Item) reg;
-					stacks.add(new ItemStack(item));
+					if(ignoredItems.contains(item)) continue;
+					if(collapsedClasses.contains(item.getClass())) {
+						stacks.add(new ItemStack(item));
+					} else {
+						item.getSubItems(item, null, stacks);
+					}
 				}
 
 				FMLCommonHandler.instance().showGuiScreen(new GUIScreenWikiRender(stacks.toArray(new ItemStack[0])));


### PR DESCRIPTION
A small one here, not a gameplay change or anything significant, this is just for Wiki maintainers. This PR adds an auto-screenshitter that will generate a perfectly sized and scaled set of images for every inventory item available in the game, including vanilla items and items with custom rendering.

The tool is activated by pressing `CTRL+0+1` while in a world and will automatically close itself upon completion. Make sure your GUI scale is 2 (small) before running, it's not a user tool so I haven't smoothed off the edges.