### PR TITLE
Fixed steam particles config option

### DIFF
--- a/src/main/java/com/hbm/main/ClientProxy.java
+++ b/src/main/java/com/hbm/main/ClientProxy.java
@@ -55,7 +55,6 @@ import com.hbm.blocks.generic.BlockSnowglobe.TileEntitySnowglobe;
 import com.hbm.blocks.machine.MachineFan.TileEntityFan;
 import com.hbm.blocks.machine.PistonInserter.TileEntityPistonInserter;
 import com.hbm.blocks.machine.WatzPump.TileEntityWatzPump;
-import com.hbm.config.GeneralConfig;
 import com.hbm.entity.cart.*;
 import com.hbm.entity.effect.*;
 import com.hbm.entity.grenade.*;
@@ -1743,7 +1742,7 @@ public class ClientProxy extends ServerProxy {
 		}
 		
 		if("tower".equals(type)) {
-			if(GeneralConfig.enableSteamParticles && (particleSetting == 0 || (particleSetting == 1 && rand.nextBoolean()))) {
+			if(particleSetting == 0 || (particleSetting == 1 && rand.nextBoolean())) {
 				ParticleCoolingTower fx = new ParticleCoolingTower(man, world, x, y, z);
 				fx.setLift(data.getFloat("lift"));
 				fx.setBaseScale(data.getFloat("base"));

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityTowerLarge.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityTowerLarge.java
@@ -1,5 +1,6 @@
 package com.hbm.tileentity.machine;
 
+import com.hbm.config.GeneralConfig;
 import com.hbm.inventory.fluid.FluidType;
 import com.hbm.inventory.fluid.Fluids;
 import com.hbm.inventory.fluid.tank.FluidTank;
@@ -26,7 +27,7 @@ public class TileEntityTowerLarge extends TileEntityCondenser {
 		
 		if(worldObj.isRemote) {
 			
-			if(this.waterTimer > 0 && this.worldObj.getTotalWorldTime() % 4 == 0) {
+			if(GeneralConfig.enableSteamParticles && (this.waterTimer > 0 && this.worldObj.getTotalWorldTime() % 4 == 0)) {
 				NBTTagCompound data = new NBTTagCompound();
 				data.setString("type", "tower");
 				data.setFloat("lift", 0.5F);

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityTowerSmall.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityTowerSmall.java
@@ -1,5 +1,6 @@
 package com.hbm.tileentity.machine;
 
+import com.hbm.config.GeneralConfig;
 import com.hbm.inventory.fluid.FluidType;
 import com.hbm.inventory.fluid.Fluids;
 import com.hbm.inventory.fluid.tank.FluidTank;
@@ -26,7 +27,7 @@ public class TileEntityTowerSmall extends TileEntityCondenser {
 		
 		if(worldObj.isRemote) {
 			
-			if(this.waterTimer > 0 && this.worldObj.getTotalWorldTime() % 2 == 0) {
+			if(GeneralConfig.enableSteamParticles && (this.waterTimer > 0 && this.worldObj.getTotalWorldTime() % 2 == 0)) {
 				NBTTagCompound data = new NBTTagCompound();
 				data.setString("type", "tower");
 				data.setFloat("lift", 1F);


### PR DESCRIPTION
Turns out more machines use the "tower" type than I thought, so the enableSteamParticles config also affects the flare stack, drainage pipe, and probably a few other blocks. Fixed it so only auxillary and large cooling towers have particle effects disabled.