### PR TITLE
Tweaks for glyphids

### DIFF
--- a/src/main/java/com/hbm/entity/mob/glyphid/EntityGlyphidBehemoth.java
+++ b/src/main/java/com/hbm/entity/mob/glyphid/EntityGlyphidBehemoth.java
@@ -74,7 +74,7 @@ public class EntityGlyphidBehemoth extends EntityGlyphid {
 		super.onDeath(source);
 		if (!worldObj.isRemote) {
 			EntityMist mist = new EntityMist(worldObj);
-			mist.setType(Fluids.ACID);
+			mist.setType(Fluids.SULFURIC_ACID);
 			mist.setPosition(posX, posY, posZ);
 			mist.setArea(10, 4);
 			mist.setDuration(120);
@@ -88,7 +88,7 @@ public class EntityGlyphidBehemoth extends EntityGlyphid {
 			this.addPotionEffect(new PotionEffect(Potion.moveSlowdown.id, 2 * 20, 6));
 			EntityChemical chem = new EntityChemical(worldObj, this);
 
-			chem.setFluid(Fluids.ACID);
+			chem.setFluid(Fluids.SULFURIC_ACID);
 			worldObj.spawnEntityInWorld(chem);
 		}
 	}

--- a/src/main/java/com/hbm/entity/mob/glyphid/EntityGlyphidBrawler.java
+++ b/src/main/java/com/hbm/entity/mob/glyphid/EntityGlyphidBrawler.java
@@ -1,10 +1,18 @@
 package com.hbm.entity.mob.glyphid;
 
+
 import com.hbm.main.ResourceManager;
 
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
+
 
 public class EntityGlyphidBrawler extends EntityGlyphid {
 
@@ -12,7 +20,85 @@ public class EntityGlyphidBrawler extends EntityGlyphid {
 		super(world);
 		this.setSize(2F, 1.125F);
 	}
-	
+
+	public int timer = 0;
+	protected Entity lastTarget;
+	protected double lastX;
+	protected double lastY;
+	protected double lastZ;
+
+	@Override
+	public void onUpdate(){
+		super.onUpdate();
+		Entity e = this.getEntityToAttack();
+		if (e != null && this.isEntityAlive()) {
+
+			this.lastX = e.posX;
+			this.lastY = e.posY;
+			this.lastZ = e.posZ;
+
+			if (--timer <= 0) {
+				leap();
+				timer = 80 + worldObj.rand.nextInt(30);
+			}
+		}
+	}
+
+	/** Mainly composed of crusty old power fist code, with some touch ups **/
+	public void leap() {
+		if (!worldObj.isRemote && entityToAttack instanceof EntityLivingBase && this.getDistanceToEntity(entityToAttack) < 20) {
+			Entity e = this.getEntityToAttack();
+
+			double velX = e.posX - lastX;
+			double velY = e.posY - lastY;
+			double velZ = e.posZ - lastZ;
+
+			if (this.lastTarget != e) {
+				velX = velY = velZ = 0;
+			}
+
+			int prediction = 60;
+			Vec3 delta = Vec3.createVectorHelper(e.posX - posX + velX * prediction, (e.posY + e.height / 2) - (posY + 1) + velY * prediction, e.posZ - posZ + velZ * prediction);
+			double len = delta.lengthVector();
+			if (len < 3) return;
+			double targetYaw = -Math.atan2(delta.xCoord, delta.zCoord);
+
+			double x = Math.sqrt(delta.xCoord * delta.xCoord + delta.zCoord * delta.zCoord);
+			double y = delta.yCoord;
+			double v0 = 1.5;
+			double v02 = v0 * v0;
+			double g = 0.01;
+			double targetPitch = Math.atan((v02 + Math.sqrt(v02 * v02 - g * (g * x * x + 2 * y * v02)) * 1) / (g * x));
+			Vec3 fireVec = null;
+			if (!Double.isNaN(targetPitch)) {
+
+				fireVec = Vec3.createVectorHelper(v0, 0, 0);
+				fireVec.rotateAroundZ((float) (-targetPitch / 3.5));
+				fireVec.rotateAroundY((float) -(targetYaw + Math.PI * 0.5));
+			}
+			if (fireVec != null)
+				this.setThrowableHeading(fireVec.xCoord, fireVec.yCoord, fireVec.zCoord, (float) v0, rand.nextFloat());
+		}
+	}
+	//yeag this is now a motherfucking projectile
+	public void setThrowableHeading(double motionX, double motionY, double motionZ, float velocity, float inaccuracy) {
+		float throwLen = MathHelper.sqrt_double(motionX * motionX + motionY * motionY + motionZ * motionZ);
+		motionX /= (double) throwLen;
+		motionY /= (double) throwLen;
+		motionZ /= (double) throwLen;
+		motionX += this.rand.nextGaussian() * 0.0075D * (double) inaccuracy;
+		motionY += this.rand.nextGaussian() * 0.0075D * (double) inaccuracy;
+		motionZ += this.rand.nextGaussian() * 0.0075D * (double) inaccuracy;
+		motionX *= (double) velocity;
+		motionY *= (double) velocity;
+		motionZ *= (double) velocity;
+		this.motionX = motionX;
+		this.motionY = motionY;
+		this.motionZ = motionZ;
+		float hyp = MathHelper.sqrt_double(motionX * motionX + motionZ * motionZ);
+		this.prevRotationYaw = this.rotationYaw = (float) (Math.atan2(motionX, motionZ) * 180.0D / Math.PI);
+		this.prevRotationPitch = this.rotationPitch = (float) (Math.atan2(motionY, (double) hyp) * 180.0D / Math.PI);
+	}
 	@Override
 	public ResourceLocation getSkin() {
 		return ResourceManager.glyphid_brawler_tex;
@@ -33,7 +119,18 @@ public class EntityGlyphidBrawler extends EntityGlyphid {
 
 	@Override public float getDivisorPerArmorPoint() { return GlyphidStats.getStats().getBrawler().divisor; }
 	@Override public float getDamageThreshold() { return GlyphidStats.getStats().getBrawler().damageThreshold; }
+	@Override
+	public boolean attackEntityFrom(DamageSource source, float amount) {
 
+		/*NBTTagCompound data = new NBTTagCompound();
+		data.setString("type", "debug");
+		data.setInteger("color", 0x0000ff);
+		data.setFloat("scale", 2.5F);
+		data.setString("text", "" + (int) amount);
+		PacketDispatcher.wrapper.sendToAllAround(new AuxParticlePacketNT(data, posX, posY + 2, posZ), new TargetPoint(dimension, posX, posY + 2, posZ, 50));*/
+		if(source != DamageSource.fall) super.attackEntityFrom(source, amount);
+		return false;
+	}
 	@Override
 	public boolean isArmorBroken(float amount) {
 		return this.rand.nextInt(100) <= Math.min(Math.pow(amount * 0.25, 2), 100);

--- a/src/main/java/com/hbm/entity/mob/glyphid/EntityGlyphidBrawler.java
+++ b/src/main/java/com/hbm/entity/mob/glyphid/EntityGlyphidBrawler.java
@@ -44,7 +44,7 @@ public class EntityGlyphidBrawler extends EntityGlyphid {
 		}
 	}
 
-	/** Mainly composed of crusty old power fist code, with some touch ups **/
+	/** Mainly composed of repurposed bombardier code**/
 	public void leap() {
 		if (!worldObj.isRemote && entityToAttack instanceof EntityLivingBase && this.getDistanceToEntity(entityToAttack) < 20) {
 			Entity e = this.getEntityToAttack();
@@ -128,8 +128,9 @@ public class EntityGlyphidBrawler extends EntityGlyphid {
 		data.setFloat("scale", 2.5F);
 		data.setString("text", "" + (int) amount);
 		PacketDispatcher.wrapper.sendToAllAround(new AuxParticlePacketNT(data, posX, posY + 2, posZ), new TargetPoint(dimension, posX, posY + 2, posZ, 50));*/
-		if(source != DamageSource.fall) super.attackEntityFrom(source, amount);
-		return false;
+		//allows brawlers to get no damage on short leaps, but still affected by fall damage on big drops
+		if(source == DamageSource.fall && amount <= 10) return false;
+		return super.attackEntityFrom(source, amount);
 	}
 	@Override
 	public boolean isArmorBroken(float amount) {

--- a/src/main/java/com/hbm/entity/mob/glyphid/EntityGlyphidScout.java
+++ b/src/main/java/com/hbm/entity/mob/glyphid/EntityGlyphidScout.java
@@ -336,15 +336,13 @@ public class EntityGlyphidScout extends EntityGlyphid {
 		int y = MathHelper.floor_double(this.boundingBox.minY);
 		int z = MathHelper.floor_double(this.posZ);
 
-		int light = this.worldObj.getBlockLightValue(x, y, z);
+		int skylightSubtracted = this.worldObj.skylightSubtracted;
 
-		if(this.worldObj.isThundering()) {
-			int skylightSubtracted = this.worldObj.skylightSubtracted;
-			this.worldObj.skylightSubtracted = 10;
-			light = this.worldObj.getBlockLightValue(x, y, z);
-			this.worldObj.skylightSubtracted = skylightSubtracted;
-		}
-			
+		if(this.worldObj.isThundering()) this.worldObj.skylightSubtracted = 10;
+		int light = worldObj.getChunkFromChunkCoords(x >> 4, z >> 4).getBlockLightValue(x & 15, y, z & 15, worldObj.skylightSubtracted);
+
+		this.worldObj.skylightSubtracted = skylightSubtracted;
 		return light <= 7;
+
 	}
 }

--- a/src/main/java/com/hbm/entity/mob/glyphid/EntityGlyphidScout.java
+++ b/src/main/java/com/hbm/entity/mob/glyphid/EntityGlyphidScout.java
@@ -73,7 +73,10 @@ public class EntityGlyphidScout extends EntityGlyphid {
 	@Override
 	public void onUpdate() {
 		super.onUpdate();
-
+		//Updates to check whether the player still exists, important to make sure it wont stop doing work
+		if(entityToAttack != null && ticksExisted % 60 == 0){
+			entityToAttack = findPlayerToAttack();
+		}
 		if((getCurrentTask() != TASK_BUILD_HIVE || getCurrentTask() != TASK_TERRAFORM) && taskWaypoint == null) {
 
 				if(MobConfig.rampantGlyphidGuidance && PollutionHandler.targetCoords != null){


### PR DESCRIPTION
**Changes**

- Made light logic on natural scout spawning (rampant) only count artificial lighting sources and not skylight
- Added a leap attack to brawlers, similar to vanilla spiders
- Fixed scouts forgetting their tasks if a player they were attacking goes out of range
- Buffed the behemoth acid attack, due to lacking damage even against early armor

