### PR TITLE
Soot moment and bugs

### DIFF
--- a/src/main/java/com/hbm/config/MobConfig.java
+++ b/src/main/java/com/hbm/config/MobConfig.java
@@ -59,7 +59,7 @@ public class MobConfig {
 	public static boolean rampantMode = false;
 	public static boolean rampantNaturalScoutSpawn = false;
 	public static double rampantScoutSpawnThresh = 14;
-	public static int rampantScoutSpawnChance = 600;
+	public static int rampantScoutSpawnChance = 1400;
 	public static boolean scoutInitialSpawn = false;
 	public static boolean rampantExtendedTargetting = false;
 	public static boolean rampantDig = false;
@@ -154,8 +154,8 @@ public class MobConfig {
 		config.addCustomCategoryComment(CATEGORY, "The individual features of rampant can be used regardless of whether the main rampant toggle is enabled or not");
 
 		rampantNaturalScoutSpawn = CommonConfig.createConfigBool(config, CATEGORY,"12.R02_rampantScoutSpawn", "Whether scouts should spawn natually in highly polluted chunks", false);
-		rampantScoutSpawnThresh = CommonConfig.createConfigDouble(config, CATEGORY, "12.R02.1_rampantScoutSpawnThresh", "How much soot is needed for scouts to naturally spawn", 20);
-		rampantScoutSpawnChance = CommonConfig.createConfigInt(config, CATEGORY, "12.R02.2_rampantScoutSpawnChance", "How often scouts naturally spawn per mob population, 1/x format, the bigger the number, the more uncommon the scouts", 600);
+		rampantScoutSpawnThresh = CommonConfig.createConfigDouble(config, CATEGORY, "12.R02.1_rampantScoutSpawnThresh", "How much soot is needed for scouts to naturally spawn", 13);
+		rampantScoutSpawnChance = CommonConfig.createConfigInt(config, CATEGORY, "12.R02.2_rampantScoutSpawnChance", "How often scouts naturally spawn per mob population, 1/x format, the bigger the number, the more uncommon the scouts", 1400);
 		rampantExtendedTargetting = CommonConfig.createConfigBool(config, CATEGORY,"12.R03_rampantExtendedTargeting", "Whether Glyphids should have the extended targetting always enabled", false);
 		rampantDig = CommonConfig.createConfigBool(config, CATEGORY,"12.R04_rampantDig", "Whether Glyphids should be able to dig to waypoints", false);
 		rampantGlyphidGuidance = CommonConfig.createConfigBool(config, CATEGORY,"12.R05_rampantGlyphidGuidance", "Whether Glyphids should always expand toward a player's spawnpoint", false);
@@ -171,7 +171,7 @@ public class MobConfig {
 			scoutSwarmSpawnChance = 1;
 			scoutThreshold = 0.1;
 			if(pollutionMult == 1) {
-				pollutionMult = 2;
+				pollutionMult = 3;
 			}
 			RadiationConfig.sootFogThreshold *= pollutionMult;
 		}

--- a/src/main/java/com/hbm/config/MobConfig.java
+++ b/src/main/java/com/hbm/config/MobConfig.java
@@ -173,6 +173,9 @@ public class MobConfig {
 			if(pollutionMult == 1) {
 				pollutionMult = 3;
 			}
+			if (bombardierChance[2] == 1){
+				bombardierChance[2] = 0;
+			}
 			RadiationConfig.sootFogThreshold *= pollutionMult;
 		}
 	}

--- a/src/main/java/com/hbm/handler/pollution/PollutionHandler.java
+++ b/src/main/java/com/hbm/handler/pollution/PollutionHandler.java
@@ -397,8 +397,7 @@ public class PollutionHandler {
 	@SubscribeEvent
 	public void rampantScoutPopulator(WorldEvent.PotentialSpawns event){
 		
-		if(MobConfig.rampantNaturalScoutSpawn && !event.world.isRemote && event.world.provider.dimensionId == 0 && event.type == EnumCreatureType.monster
-				&& event.world.canBlockSeeTheSky(event.x, event.y, event.z) && !event.isCanceled()) {
+		if(MobConfig.rampantNaturalScoutSpawn && !event.world.isRemote && event.world.provider.dimensionId == 0 && event.world.canBlockSeeTheSky(event.x, event.y, event.z) && !event.isCanceled()) {
 
 					if (event.world.rand.nextInt(MobConfig.rampantScoutSpawnChance) == 0) {
 

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityCrucible.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityCrucible.java
@@ -172,7 +172,7 @@ public class TileEntityCrucible extends TileEntityMachineBase implements IGUIPro
 				
 				}
 
-				PollutionHandler.incrementPollution(worldObj, xCoord, yCoord, zCoord, PollutionType.SOOT, PollutionHandler.SOOT_PER_SECOND / 2F);
+				PollutionHandler.incrementPollution(worldObj, xCoord, yCoord, zCoord, PollutionType.SOOT, PollutionHandler.SOOT_PER_SECOND / 20F);
 			}
 			
 			/* pour recipe stack */

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityHeaterOilburner.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityHeaterOilburner.java
@@ -82,7 +82,7 @@ public class TileEntityHeaterOilburner extends TileEntityMachinePolluting implem
 					this.heatEnergy += heat * toBurn;
 
 					if(worldObj.getTotalWorldTime() % 5 == 0 && toBurn > 0) {
-						FT_Polluting.pollute(worldObj, xCoord, yCoord, zCoord, tank.getTankType(), FluidReleaseType.BURN, toBurn * 5);
+						super.pollute(tank.getTankType(), FluidReleaseType.BURN, toBurn * 5);
 					}
 					
 					shouldCool = false;

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineCombustionEngine.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineCombustionEngine.java
@@ -87,7 +87,7 @@ public class TileEntityMachineCombustionEngine extends TileEntityMachinePollutin
 					fill -= toBurn;
 
 					if(worldObj.getTotalWorldTime() % 5 == 0 && toBurn > 0) {
-						FT_Polluting.pollute(worldObj, xCoord, yCoord, zCoord, tank.getTankType(), FluidReleaseType.BURN, toBurn * 5);
+						super.pollute(tank.getTankType(), FluidReleaseType.BURN, toBurn * 0.5F);
 					}
 					
 					if(toBurn > 0) {

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineDiesel.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineDiesel.java
@@ -212,7 +212,7 @@ public class TileEntityMachineDiesel extends TileEntityMachinePolluting implemen
 					tank.setFill(0);
 				
 				if(worldObj.getTotalWorldTime() % 5 == 0) {
-					FT_Polluting.pollute(worldObj, xCoord, yCoord, zCoord, tank.getTankType(), FluidReleaseType.BURN, 5F);
+					super.pollute(tank.getTankType(), FluidReleaseType.BURN, 5F);
 				}
 
 				if(power + getHEFromFuel() <= powerCap) {

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineTurbofan.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineTurbofan.java
@@ -16,6 +16,7 @@ import com.hbm.inventory.fluid.Fluids;
 import com.hbm.inventory.fluid.tank.FluidTank;
 import com.hbm.inventory.fluid.trait.FT_Combustible;
 import com.hbm.inventory.fluid.trait.FT_Combustible.FuelGrade;
+import com.hbm.inventory.fluid.trait.FluidTrait;
 import com.hbm.inventory.gui.GUIMachineTurbofan;
 import com.hbm.items.ModItems;
 import com.hbm.items.machine.ItemMachineUpgrade.UpgradeType;
@@ -176,7 +177,7 @@ public class TileEntityMachineTurbofan extends TileEntityMachinePolluting implem
 				this.power += this.output;
 				this.consumption = amountToBurn;
 				
-				if(worldObj.getTotalWorldTime() % 20 == 0) PollutionHandler.incrementPollution(worldObj, xCoord, yCoord, zCoord, PollutionType.SOOT, PollutionHandler.SOOT_PER_SECOND * amountToBurn);
+				if(worldObj.getTotalWorldTime() % 20 == 0) super.pollute(tank.getTankType(), FluidTrait.FluidReleaseType.BURN, amountToBurn * 5);;
 			}
 			
 			power = Library.chargeItemsFromTE(slots, 3, power, power);


### PR DESCRIPTION
**Fixes**

- Fixed smokestacks not working with machines with the new fluid pollution trait system
- Fixed crucible outputting ludicrous amounts of soot
- Fixed Industrial Combustion Engine outputting ten times more soot then intended (guh.)
- Fixed natural rampant scout spawning (for the billionth time) not working during the day
  -  Changed the base scout rate to account for that, it is recommended for people in previous rampant runs to change that base value

**Minor Changes**
 - Rampant now also has an increased pollution multiplier, and bombardiers spawns by default in it again
 - Switched turbofan to new fluid pollution system, mainly for consistency's sake, users may notice reduced pollution rates, enjoy!
 