### PR TITLE
Prevent EntityItemBuoyant from floating on falling water

### DIFF
--- a/src/main/java/com/hbm/entity/item/EntityItemBuoyant.java
+++ b/src/main/java/com/hbm/entity/item/EntityItemBuoyant.java
@@ -17,8 +17,12 @@ public class EntityItemBuoyant extends EntityItem {
 	
 	@Override
 	public void onUpdate() {
-		
-		if(worldObj.getBlock((int) Math.floor(posX), (int) Math.floor(posY - 0.0625), (int) Math.floor(posZ)).getMaterial() == Material.water) {
+
+		int x = (int) Math.floor(posX);
+		int y = (int) Math.floor(posY - 0.0625);
+		int z = (int) Math.floor(posZ);
+
+		if(worldObj.getBlock(x, y, z).getMaterial() == Material.water && worldObj.getBlockMetadata(x, y, z) < 8) {
 			this.motionY += 0.045D;
 		}
 		


### PR DESCRIPTION
Large scale dynamite fishing automation is hindered by `EntityItemBuoyant`'s floating behavior. As a compromise solution, water that is flowing down, i.e. "falling", will not be floated in. This change doesn't affect other more common scenarios such as natural river or ocean fishing, or anywhere where a body of water consists completely of source blocks.