### PR TITLE
Cache tile entity network packets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,28 @@
 # eclipse
-eclipse
-bin
-*.launch
-.settings
-.metadata
-.classpath
-.project
+/eclipse
+/bin
+/*.launch
+/.settings
+/.metadata
+/.classpath
+/.project
 
 # idea
-out
-*.ipr
-*.iws
-*.iml
-.idea
+/out
+/*.ipr
+/*.iws
+/*.iml
+/.idea
 
 # gradle
-build
-.gradle
+/build
+/.gradle
+
+# vscode
+/.vscode
 
 # other
-run
+/run
 
 # CurseForge configuration
 /curseforge.properties

--- a/src/main/java/com/hbm/blocks/ModBlocks.java
+++ b/src/main/java/com/hbm/blocks/ModBlocks.java
@@ -2626,7 +2626,7 @@ public class ModBlocks {
 		GameRegistry.registerBlock(reinforced_ducrete, ItemBlockBlastInfo.class, reinforced_ducrete.getUnlocalizedName());
 		GameRegistry.registerBlock(concrete_smooth, ItemBlockBlastInfo.class, concrete_smooth.getUnlocalizedName());
 		GameRegistry.registerBlock(concrete_colored, ItemBlockColoredConcrete.class, concrete_colored.getUnlocalizedName());
-		register(concrete_colored_ext);
+		GameRegistry.registerBlock(concrete_colored_ext, ItemBlockBlastInfo.class, concrete_colored_ext.getUnlocalizedName());
 		GameRegistry.registerBlock(concrete, ItemBlockBlastInfo.class, concrete.getUnlocalizedName());
 		GameRegistry.registerBlock(concrete_asbestos, ItemBlockBlastInfo.class, concrete_asbestos.getUnlocalizedName());
 		GameRegistry.registerBlock(concrete_super, ItemBlockBlastInfo.class, concrete_super.getUnlocalizedName());

--- a/src/main/java/com/hbm/blocks/generic/BlockScaffoldDynamic.java
+++ b/src/main/java/com/hbm/blocks/generic/BlockScaffoldDynamic.java
@@ -167,7 +167,8 @@ public class BlockScaffoldDynamic extends BlockContainer implements IToolable, I
 		}
 	}
 	
-	public static class TileEntityScaffoldDynamic extends TileEntity {
+	// Full class name needed because otherwise there's some conflict with the static import * from this class
+	public static class TileEntityScaffoldDynamic extends net.minecraft.tileentity.TileEntity {
 
 		public int composite;
 		public int prevComposite;

--- a/src/main/java/com/hbm/tileentity/network/TileEntityCraneGrabber.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityCraneGrabber.java
@@ -32,6 +32,7 @@ public class TileEntityCraneGrabber extends TileEntityCraneBase implements IGUIP
 
 	public boolean isWhitelist = false;
 	public ModulePatternMatcher matcher;
+	public long lastGrabbedTick = 0;
 
 	public TileEntityCraneGrabber() {
 		super(11);
@@ -63,7 +64,7 @@ public class TileEntityCraneGrabber extends TileEntityCraneBase implements IGUIP
 				}
 			}
 			
-			if(worldObj.getTotalWorldTime() % delay == 0 && !this.worldObj.isBlockIndirectlyGettingPowered(xCoord, yCoord, zCoord)) {
+			if(worldObj.getTotalWorldTime() >= lastGrabbedTick + delay && !this.worldObj.isBlockIndirectlyGettingPowered(xCoord, yCoord, zCoord)) {
 				int amount = 1;
 				
 				if(slots[9] != null && slots[9].getItem() == ModItems.upgrade_stack) {
@@ -111,6 +112,8 @@ public class TileEntityCraneGrabber extends TileEntityCraneBase implements IGUIP
 						boolean match = this.matchesFilter(stack);
 						if(this.isWhitelist && !match || !this.isWhitelist && match) continue;
 						
+						lastGrabbedTick = worldObj.getTotalWorldTime();
+						
 						ItemStack copy = stack.copy();
 						int toAdd = Math.min(stack.stackSize, amount);
 						copy.stackSize = toAdd;
@@ -132,8 +135,7 @@ public class TileEntityCraneGrabber extends TileEntityCraneBase implements IGUIP
 			
 			
 			NBTTagCompound data = new NBTTagCompound();
-			data.setBoolean("isWhitelist", isWhitelist);
-			this.matcher.writeToNBT(data);
+			this.writeToNBT(data);
 			this.networkPack(data, 15);
 		}
 	}
@@ -141,9 +143,7 @@ public class TileEntityCraneGrabber extends TileEntityCraneBase implements IGUIP
 	public void networkUnpack(NBTTagCompound nbt) {
 		super.networkUnpack(nbt);
 		
-		this.isWhitelist = nbt.getBoolean("isWhitelist");
-		this.matcher.modes = new String[this.matcher.modes.length];
-		this.matcher.readFromNBT(nbt);
+		this.readFromNBT(nbt);
 	}
 	
 	public boolean matchesFilter(ItemStack stack) {
@@ -175,6 +175,7 @@ public class TileEntityCraneGrabber extends TileEntityCraneBase implements IGUIP
 		super.readFromNBT(nbt);
 		this.isWhitelist = nbt.getBoolean("isWhitelist");
 		this.matcher.readFromNBT(nbt);
+		this.lastGrabbedTick = nbt.getLong("lastGrabbedTick");
 	}
 	
 	@Override
@@ -182,6 +183,7 @@ public class TileEntityCraneGrabber extends TileEntityCraneBase implements IGUIP
 		super.writeToNBT(nbt);
 		nbt.setBoolean("isWhitelist", this.isWhitelist);
 		this.matcher.writeToNBT(nbt);
+		nbt.setLong("lastGrabbedTick", lastGrabbedTick);
 	}
 
 	@Override


### PR DESCRIPTION
While I'm at it, I might as well share the rest of my personal changes

When investigating high network lag on my server, I noticed a lot of machines constantly sent update packets every tick, even when nothing changed, and decided to optimize it. Now packets are only sent when something in them is different AND every 20th tick to accommodate for the fact some machines appear to be initialized incorrectly when unloaded and loaded by a client. (In my testing, filled fluid barrels did this, but I assume there might be more machines with this problem).

Also includes fixes for #1686 and #1692.