### PR TITLE
Make RBMK crane rotatable

### DIFF
--- a/src/main/java/com/hbm/blocks/machine/rbmk/RBMKCraneConsole.java
+++ b/src/main/java/com/hbm/blocks/machine/rbmk/RBMKCraneConsole.java
@@ -4,14 +4,17 @@ import com.hbm.blocks.BlockDummyable;
 import com.hbm.handler.MultiblockHandlerXR;
 import com.hbm.tileentity.machine.rbmk.TileEntityCraneConsole;
 
+import api.hbm.block.IToolable;
+import api.hbm.block.IToolable.ToolType;
 import net.minecraft.block.material.Material;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class RBMKCraneConsole extends BlockDummyable {
+public class RBMKCraneConsole extends BlockDummyable implements IToolable {
 
 	public RBMKCraneConsole() {
 		super(Material.iron);
@@ -71,5 +74,20 @@ public class RBMKCraneConsole extends BlockDummyable {
 		} else {
 			this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
 		}
+	}
+
+	@Override
+	public boolean onScrew(World world, EntityPlayer player, int x, int y, int z, int side, float fX, float fY, float fZ, ToolType tool) {
+		
+		if(tool == ToolType.SCREWDRIVER) {
+			if(world.isRemote) return true;
+
+			TileEntityCraneConsole tile = (TileEntityCraneConsole) world.getTileEntity(x, y, z);
+			tile.cycleCraneRotation();
+			tile.markDirty();
+			return true;
+		}
+		
+		return false;
 	}
 }

--- a/src/main/java/com/hbm/blocks/machine/rbmk/RBMKCraneConsole.java
+++ b/src/main/java/com/hbm/blocks/machine/rbmk/RBMKCraneConsole.java
@@ -81,8 +81,9 @@ public class RBMKCraneConsole extends BlockDummyable implements IToolable {
 		
 		if(tool == ToolType.SCREWDRIVER) {
 			if(world.isRemote) return true;
-
-			TileEntityCraneConsole tile = (TileEntityCraneConsole) world.getTileEntity(x, y, z);
+			
+			int[] pos = findCore(world, x, y, z);
+			TileEntityCraneConsole tile = (TileEntityCraneConsole) world.getTileEntity(pos[0], pos[1], pos[2]);
 			tile.cycleCraneRotation();
 			tile.markDirty();
 			return true;

--- a/src/main/java/com/hbm/render/tileentity/RenderCraneConsole.java
+++ b/src/main/java/com/hbm/render/tileentity/RenderCraneConsole.java
@@ -99,12 +99,7 @@ public class RenderCraneConsole extends TileEntitySpecialRenderer {
 			double cranePosZ = (-te.zCoord + console.centerZ);
 			
 			GL11.glTranslated(cranePosX, cranePosY, cranePosZ);
-			switch(te.getBlockMetadata() - BlockDummyable.offset) {
-			case 2: GL11.glRotatef(90, 0F, 1F, 0F); break;
-			case 4: GL11.glRotatef(180, 0F, 1F, 0F); break;
-			case 3: GL11.glRotatef(270, 0F, 1F, 0F); break;
-			case 5: GL11.glRotatef(0, 0F, 1F, 0F); break;
-			}
+			GL11.glRotatef(((TileEntityCraneConsole)te).getCraneRotation(), 0F, 1F, 0F);
 
 			double posX = (console.lastPosFront + (console.posFront - console.lastPosFront) * interp);
 			double posZ = (console.lastPosLeft + (console.posLeft - console.lastPosLeft) * interp);

--- a/src/main/java/com/hbm/render/tileentity/RenderCraneConsole.java
+++ b/src/main/java/com/hbm/render/tileentity/RenderCraneConsole.java
@@ -99,22 +99,49 @@ public class RenderCraneConsole extends TileEntitySpecialRenderer {
 			double cranePosZ = (-te.zCoord + console.centerZ);
 			
 			GL11.glTranslated(cranePosX, cranePosY, cranePosZ);
-			GL11.glRotatef(((TileEntityCraneConsole)te).getCraneRotation(), 0F, 1F, 0F);
+			switch(te.getBlockMetadata() - BlockDummyable.offset) {
+			case 2: GL11.glRotatef(90, 0F, 1F, 0F); break;
+			case 4: GL11.glRotatef(180, 0F, 1F, 0F); break;
+			case 3: GL11.glRotatef(270, 0F, 1F, 0F); break;
+			case 5: GL11.glRotatef(0, 0F, 1F, 0F); break;
+			}
 
 			double posX = (console.lastPosFront + (console.posFront - console.lastPosFront) * interp);
 			double posZ = (console.lastPosLeft + (console.posLeft - console.lastPosLeft) * interp);
-			GL11.glTranslated(0, 0, posZ);
+			GL11.glTranslated(-posX, 0, posZ);
+
+			int craneRotationOffset = ((TileEntityCraneConsole)te).craneRotationOffset;
+			GL11.glRotatef(craneRotationOffset, 0F, 1F, 0F);
 			
 			GL11.glPushMatrix();
-			GL11.glTranslated(-console.spanL, height - 1, 0);
+			int girderSpan = 0;
+			GL11.glRotatef(-craneRotationOffset, 0F, 1F, 0F);
+			switch(craneRotationOffset) {
+			case 0:
+				girderSpan = console.spanL + console.spanR + 1;
+				GL11.glTranslated(posX - console.spanL, 0, 0);
+				break;
+			case 90:
+				girderSpan = console.spanF + console.spanB + 1;
+				GL11.glTranslated(0, 0, -posZ + console.spanB);
+				break;
+			case 180:
+				girderSpan = console.spanL + console.spanR + 1;
+				GL11.glTranslated(posX + console.spanR, 0, 0);
+				break;
+			case 270:
+				girderSpan = console.spanF + console.spanB + 1;
+				GL11.glTranslated(0, 0, -posZ - console.spanF);
+				break;
+			}
+			GL11.glRotatef(craneRotationOffset, 0F, 1F, 0F);
 			
-			for(int i = -console.spanL; i <= console.spanR; i++) {
+			for(int i = 0; i < girderSpan; i++) {
 				ResourceManager.rbmk_crane.renderPart("Girder");
 				GL11.glTranslated(1, 0, 0);
 			}
 			GL11.glPopMatrix();
 			
-			GL11.glTranslated(-posX, 0, 0);
 			ResourceManager.rbmk_crane.renderPart("Main");
 			
 			GL11.glPushMatrix();

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
@@ -28,6 +28,8 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import java.util.List;
 
+import org.lwjgl.opengl.GL11;
+
 @Optional.InterfaceList({@Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers")})
 public class TileEntityCraneConsole extends TileEntity implements INBTPacketReceiver, SimpleComponent, CompatHandler.OCComponent {
 	
@@ -43,6 +45,8 @@ public class TileEntityCraneConsole extends TileEntity implements INBTPacketRece
 	public int height;
 	
 	public boolean setUpCrane = false;
+
+	public int craneRotationOffset = 0;
 
 	public double lastTiltFront = 0;
 	public double lastTiltLeft = 0;
@@ -169,6 +173,7 @@ public class TileEntityCraneConsole extends TileEntity implements INBTPacketRece
 			nbt.setBoolean("crane", setUpCrane);
 			
 			if(setUpCrane) { //no need to send any of this if there's NO FUCKING CRANE THERE
+				nbt.setInteger("craneRotationOffset", craneRotationOffset);
 				nbt.setInteger("centerX", centerX);
 				nbt.setInteger("centerY", centerY);
 				nbt.setInteger("centerZ", centerZ);
@@ -250,6 +255,7 @@ public class TileEntityCraneConsole extends TileEntity implements INBTPacketRece
 		lastProgress = progress;
 		
 		this.setUpCrane = nbt.getBoolean("crane");
+		this.craneRotationOffset = nbt.getInteger("craneRotationOffset");
 		this.centerX = nbt.getInteger("centerX");
 		this.centerY = nbt.getInteger("centerY");
 		this.centerZ = nbt.getInteger("centerZ");
@@ -277,9 +283,25 @@ public class TileEntityCraneConsole extends TileEntity implements INBTPacketRece
 		this.spanR = 7;
 		
 		this.height = 7;
+
 		this.setUpCrane = true;
 		
 		this.markDirty();
+	}
+
+	public int getCraneRotation() {
+		int result = craneRotationOffset;
+		switch(this.getBlockMetadata() - BlockDummyable.offset) {
+		case 2: result += 90; break;
+		case 4: result += 180; break;
+		case 3: result += 270; break;
+		case 5: result += 0; break;
+		}
+		return result % 360;
+	}
+
+	public void cycleCraneRotation() {
+		this.craneRotationOffset = (this.craneRotationOffset + 90) % 360;
 	}
 	
 	@Override
@@ -287,6 +309,7 @@ public class TileEntityCraneConsole extends TileEntity implements INBTPacketRece
 		super.readFromNBT(nbt);
 
 		this.setUpCrane = nbt.getBoolean("crane");
+		this.craneRotationOffset = nbt.getInteger("craneRotationOffset");
 		this.centerX = nbt.getInteger("centerX");
 		this.centerY = nbt.getInteger("centerY");
 		this.centerZ = nbt.getInteger("centerZ");
@@ -307,6 +330,7 @@ public class TileEntityCraneConsole extends TileEntity implements INBTPacketRece
 		super.writeToNBT(nbt);
 
 		nbt.setBoolean("crane", setUpCrane);
+		nbt.setInteger("craneRotationOffset", craneRotationOffset);
 		nbt.setInteger("centerX", centerX);
 		nbt.setInteger("centerY", centerY);
 		nbt.setInteger("centerZ", centerZ);

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
@@ -289,17 +289,6 @@ public class TileEntityCraneConsole extends TileEntity implements INBTPacketRece
 		this.markDirty();
 	}
 
-	public int getCraneRotation() {
-		int result = craneRotationOffset;
-		switch(this.getBlockMetadata() - BlockDummyable.offset) {
-		case 2: result += 90; break;
-		case 4: result += 180; break;
-		case 3: result += 270; break;
-		case 5: result += 0; break;
-		}
-		return result % 360;
-	}
-
 	public void cycleCraneRotation() {
 		this.craneRotationOffset = (this.craneRotationOffset + 90) % 360;
 	}


### PR DESCRIPTION
Clicking the RBMK crane console with a screwdriver now rotates the crane visually. The controls remain as is, only the crane model and the girder are rotated. Crane positioning and girder span is correctly handled. I've tested the changes and all appears to be in working order.

The only reason for this is that it bothered me that I had to either place the panel at 90 degrees to the reactor and deal with unintuitive controls, or endure the girder facing straight at me and completely unsupported at that side. Now I can place the controls facing the reactor, and then click it with a screwdriver to make the crane model right.