### PR TITLE
forcefield emitter becomes yet another configurable machine

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityForceField.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityForceField.java
@@ -1,14 +1,18 @@
 package com.hbm.tileentity.machine;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.gson.JsonObject;
+import com.google.gson.stream.JsonWriter;
 import com.hbm.inventory.container.ContainerForceField;
 import com.hbm.inventory.gui.GUIForceField;
 import com.hbm.items.ModItems;
 import com.hbm.lib.Library;
 import com.hbm.packet.PacketDispatcher;
 import com.hbm.packet.toclient.TEFFPacket;
+import com.hbm.tileentity.IConfigurableMachine;
 import com.hbm.tileentity.IGUIProvider;
 import com.hbm.tileentity.TileEntityLoadedBase;
 
@@ -30,10 +34,10 @@ import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class TileEntityForceField extends TileEntityLoadedBase implements ISidedInventory, IEnergyReceiverMK2, IGUIProvider {
+public class TileEntityForceField extends TileEntityLoadedBase implements ISidedInventory, IEnergyReceiverMK2, IGUIProvider, IConfigurableMachine {
 
 	private ItemStack slots[];
-	
+
 	public int health = 100;
 	public int maxHealth = 100;
 	public long power;
@@ -43,17 +47,55 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 	public float radius = 16;
 	public boolean isOn = false;
 	public int color = 0x0000FF;
-	public final int baseCon = 1000;
-	public final int radCon = 500;
-	public final int shCon = 250;
-	public static final long maxPower = 1000000;
-	
+	public static int baseCon = 1000;
+	public static int radCon = 500;
+	public static int shCon = 250;
+	public static long maxPower = 1000000;
+
 	private static final int[] slots_top = new int[] {0};
 	private static final int[] slots_bottom = new int[] {0};
 	private static final int[] slots_side = new int[] {0};
-	
+
 	private String customName;
-	
+
+	// config options stuff.
+	public static int baseRadius = 16;
+	public static int radUpgrade = 16;
+	public static int shUpgrade = 50;
+	public static double cooldownModif = 1;
+	public static double healthRegenModif = 1;
+
+	@Override
+	public String getConfigName() {
+		return "forcefield";
+	}
+
+	@Override
+	public void readIfPresent(JsonObject obj) {
+		maxPower = IConfigurableMachine.grab(obj, "L:powerCap", maxPower);
+		baseCon = IConfigurableMachine.grab(obj, "I:baseConsumption", baseCon);
+		radCon = IConfigurableMachine.grab(obj, "I:radiusConsumption", radCon);
+		shCon = IConfigurableMachine.grab(obj, "I:shieldConsumption", shCon);
+		baseRadius = IConfigurableMachine.grab(obj, "I:baseRadius", baseRadius);
+		radUpgrade = IConfigurableMachine.grab(obj, "I:radiusUpgrade", radUpgrade);
+		shUpgrade = IConfigurableMachine.grab(obj, "I:shieldUpgrade", shUpgrade);
+		cooldownModif = IConfigurableMachine.grab(obj, "D:cooldownModifier", cooldownModif);
+		healthRegenModif = IConfigurableMachine.grab(obj, "D:healthRegenModifier", healthRegenModif);
+	}
+
+	@Override
+	public void writeConfig(JsonWriter writer) throws IOException {
+		writer.name("L:powerCap").value(maxPower);
+		writer.name("I:baseConsumption").value(baseCon);
+		writer.name("I:radiusConsumption").value(radCon);
+		writer.name("I:shieldConsumption").value(shCon);
+		writer.name("I:baseRadius").value(baseRadius);
+		writer.name("I:radiusUpgrade").value(radUpgrade);
+		writer.name("I:shieldUpgrade").value(shUpgrade);
+		writer.name("D:cooldownModifier").value(cooldownModif);
+		writer.name("D:healthRegenModifier").value(healthRegenModif);
+	}
+
 	public TileEntityForceField() {
 		slots = new ItemStack[3];
 	}
@@ -98,7 +140,7 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 	public boolean hasCustomInventoryName() {
 		return this.customName != null && this.customName.length() > 0;
 	}
-	
+
 	public void setCustomName(String name) {
 		this.customName = name;
 	}
@@ -117,7 +159,7 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 			return player.getDistanceSq(xCoord + 0.5D, yCoord + 0.5D, zCoord + 0.5D) <=64;
 		}
 	}
-	
+
 	//You scrubs aren't needed for anything (right now)
 	@Override
 	public void openInventory() {}
@@ -129,13 +171,13 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 		if(i == 0)
 			if(itemStack.getItem() instanceof IBatteryItem)
 				return true;
-		
+
 		if(i == 1)
 			return true;
-		
+
 		return false;
 	}
-	
+
 	@Override
 	public ItemStack decrStackSize(int i, int j) {
 		if(slots[i] != null)
@@ -151,18 +193,18 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 			{
 				slots[i] = null;
 			}
-			
+
 			return itemStack1;
 		} else {
 			return null;
 		}
 	}
-	
+
 	@Override
 	public void readFromNBT(NBTTagCompound nbt) {
 		super.readFromNBT(nbt);
 		NBTTagList list = nbt.getTagList("items", 10);
-		
+
 		this.power = nbt.getLong("powerTime");
 		this.health = nbt.getInteger("health");
 		this.maxHealth = nbt.getInteger("maxHealth");
@@ -170,9 +212,9 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 		this.blink = nbt.getInteger("blink");
 		this.radius = nbt.getFloat("radius");
 		this.isOn = nbt.getBoolean("isOn");
-		
+
 		slots = new ItemStack[getSizeInventory()];
-		
+
 		for(int i = 0; i < list.tagCount(); i++)
 		{
 			NBTTagCompound nbt1 = list.getCompoundTagAt(i);
@@ -183,7 +225,7 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 			}
 		}
 	}
-	
+
 	@Override
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
@@ -194,9 +236,9 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 		nbt.setInteger("blink", blink);
 		nbt.setFloat("radius", radius);
 		nbt.setBoolean("isOn", isOn);
-		
+
 		NBTTagList list = new NBTTagList();
-		
+
 		for(int i = 0; i < slots.length; i++)
 		{
 			if(slots[i] != null)
@@ -209,7 +251,7 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 		}
 		nbt.setTag("items", list);
 	}
-	
+
 	@Override
 	public int[] getAccessibleSlotsFromSide(int p_94128_1_)
     {
@@ -225,41 +267,41 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 	public boolean canExtractItem(int i, ItemStack itemStack, int j) {
 		return false;
 	}
-	
+
 	public int getHealthScaled(int i) {
 		return (health * i) / maxHealth;
 	}
-	
+
 	public long getPowerScaled(long i) {
 		return (power * i) / maxPower;
 	}
-	
+
 	@Override
 	public void updateEntity() {
 
 		if(!worldObj.isRemote) {
-			
+
 			updateConnections();
-			
+
 			int rStack = 0;
 			int hStack = 0;
-			radius = 16;
+			radius = baseRadius;
 			maxHealth = 100;
-			
+
 			if(slots[1] != null && slots[1].getItem() == ModItems.upgrade_radius) {
 				rStack = slots[1].stackSize;
-				radius += rStack * 16;
+				radius += rStack * radUpgrade;
 			}
-			
+
 			if(slots[2] != null && slots[2].getItem() == ModItems.upgrade_health) {
 				hStack = slots[2].stackSize;
-				maxHealth += hStack * 50;
+				maxHealth += hStack * shUpgrade;
 			}
-			
-			this.powerCons = this.baseCon + rStack * this.radCon + hStack * this.shCon;
-			
+
+			this.powerCons = baseCon + rStack * radCon + hStack * shCon;
+
 			power = Library.chargeTEFromItems(slots, 0, power, maxPower);
-			
+
 			if(blink > 0) {
 				blink--;
 				color = 0xFF0000;
@@ -267,20 +309,20 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 				color = 0x00FF00;
 			}
 		}
-		
+
 		if(cooldown > 0) {
 			cooldown--;
 		} else {
 			if(health < maxHealth)
-				health += maxHealth / 100;
-			
+				health += (maxHealth / 100) * healthRegenModif;
+
 			if(health > maxHealth)
 				health = maxHealth;
 		}
-		
+
 		if(isOn && cooldown == 0 && health > 0 && power >= powerCons) {
 			doField(radius);
-			
+
 			if(!worldObj.isRemote) {
 				power -= powerCons;
 			}
@@ -293,34 +335,34 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 			if(power < powerCons)
 				power = 0;
 		}
-		
+
 		if(!worldObj.isRemote) {
 			PacketDispatcher.wrapper.sendToAllAround(new TEFFPacket(xCoord, yCoord, zCoord, radius, health, maxHealth, (int) power, isOn, color, cooldown), new TargetPoint(worldObj.provider.dimensionId, xCoord, yCoord, zCoord, 500));
 		}
 	}
-	
+
 	private int impact(Entity e) {
-		
+
 		double mass = e.height * e.width * e.width;
 		double speed = getMotionWithFallback(e);
 		return (int)(mass * speed * 50);
 	}
-	
+
 	private void damage(int ouch) {
 		health -= ouch;
-		
+
 		if(ouch >= (this.maxHealth / 250))
 		blink = 5;
-		
+
 		if(health <= 0) {
 			health = 0;
-			cooldown = (int) (100 + radius);
+			cooldown = (int) (100 + radius * (float)cooldownModif);
 		}
 	}
 
 	List<Entity> outside = new ArrayList();
 	List<Entity> inside = new ArrayList();
-	
+
 	private void doField(float rad) {
 
 		List<Entity> oLegacy = new ArrayList(outside);
@@ -328,18 +370,18 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 
 		outside.clear();
 		inside.clear();
-		
+
 		List<Object> list = worldObj.getEntitiesWithinAABBExcludingEntity(null, AxisAlignedBB.getBoundingBox(xCoord + 0.5 - (rad + 25), yCoord + 0.5 - (rad + 25), zCoord + 0.5 - (rad + 25), xCoord + 0.5 + (rad + 25), yCoord + 0.5 + (rad + 25), zCoord + 0.5 + (rad + 25)));
-		
+
 		for(Object o : list) {
-			
+
 			if(o instanceof Entity && !(o instanceof EntityPlayer)) {
 				Entity entity = (Entity)o;
-				
+
 				double dist = Math.sqrt(Math.pow(xCoord + 0.5 - entity.posX, 2) + Math.pow(yCoord + 0.5 - entity.posY, 2) + Math.pow(zCoord + 0.5 - entity.posZ, 2));
-				
+
 				boolean out = dist > rad;
-				
+
 				//if the entity has not been registered yet
 				if(!oLegacy.contains(entity) && !iLegacy.contains(entity)) {
 					if(out) {
@@ -347,21 +389,21 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 					} else {
 						inside.add(entity);
 					}
-					
+
 				//if the entity has been detected before
 				} else {
-					
+
 					//if the entity has crossed inwards
 					if(oLegacy.contains(entity) && !out) {
 						Vec3 vec = Vec3.createVectorHelper(xCoord + 0.5 - entity.posX, yCoord + 0.5 - entity.posY, zCoord + 0.5 - entity.posZ);
 						vec = vec.normalize();
-						
+
 						double mx = -vec.xCoord * (rad + 1);
 						double my = -vec.yCoord * (rad + 1);
 						double mz = -vec.zCoord * (rad + 1);
-						
+
 						entity.setLocationAndAngles(xCoord + 0.5 + mx, yCoord + 0.5 + my, zCoord + 0.5 + mz, 0, 0);
-						
+
 						double mo = Math.sqrt(Math.pow(entity.motionX, 2) + Math.pow(entity.motionY, 2) + Math.pow(entity.motionZ, 2));
 
 						entity.motionX = vec.xCoord * -mo;
@@ -374,24 +416,24 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 
 			    		worldObj.playSoundAtEntity(entity, "hbm:weapon.sparkShoot", 2.5F, 1.0F);
 						outside.add(entity);
-						
+
 						if(!worldObj.isRemote) {
 							this.damage(this.impact(entity));
 						}
-						
+
 					} else
-					
+
 					//if the entity has crossed outwards
 					if(iLegacy.contains(entity) && out) {
 						Vec3 vec = Vec3.createVectorHelper(xCoord + 0.5 - entity.posX, yCoord + 0.5 - entity.posY, zCoord + 0.5 - entity.posZ);
 						vec = vec.normalize();
-						
+
 						double mx = -vec.xCoord * (rad - 1);
 						double my = -vec.yCoord * (rad - 1);
 						double mz = -vec.zCoord * (rad - 1);
 
 						entity.setLocationAndAngles(xCoord + 0.5 + mx, yCoord + 0.5 + my, zCoord + 0.5 + mz, 0, 0);
-						
+
 						double mo = Math.sqrt(Math.pow(entity.motionX, 2) + Math.pow(entity.motionY, 2) + Math.pow(entity.motionZ, 2));
 
 						entity.motionX = vec.xCoord * mo;
@@ -404,13 +446,13 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 
 			    		worldObj.playSoundAtEntity(entity, "hbm:weapon.sparkShoot", 2.5F, 1.0F);
 						inside.add(entity);
-						
+
 						if(!worldObj.isRemote) {
 							this.damage(this.impact(entity));
 						}
-						
+
 					} else {
-						
+
 						if(out) {
 							outside.add(entity);
 						} else {
@@ -421,7 +463,7 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 			}
 		}
 	}
-	
+
 	private double getMotionWithFallback(Entity e) {
 
 		Vec3 v1 = Vec3.createVectorHelper(e.motionX, e.motionY, e.motionZ);
@@ -429,13 +471,13 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 
 		double s1 = v1.lengthVector();
 		double s2 = v2.lengthVector();
-		
+
 		if(s1 == 0)
 			return s2;
-		
+
 		if(s2 == 0)
 			return s1;
-		
+
 		return Math.min(s1, s2);
 	}
 
@@ -448,7 +490,7 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 	@Override
 	public long getPower() {
 		return power;
-		
+
 	}
 
 	@Override
@@ -460,7 +502,7 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 	public boolean canConnect(ForgeDirection dir) {
 		return dir != ForgeDirection.UP && dir != ForgeDirection.UNKNOWN;
 	}
-	
+
 	private void updateConnections() {
 		this.trySubscribe(worldObj, xCoord + 1, yCoord, zCoord, Library.POS_X);
 		this.trySubscribe(worldObj, xCoord - 1, yCoord, zCoord, Library.NEG_X);
@@ -473,7 +515,7 @@ public class TileEntityForceField extends TileEntityLoadedBase implements ISided
 	public AxisAlignedBB getRenderBoundingBox() {
 		return TileEntity.INFINITE_EXTENT_AABB;
 	}
-	
+
 	@Override
 	@SideOnly(Side.CLIENT)
 	public double getMaxRenderDistanceSquared()


### PR DESCRIPTION
changes:
- made the forcefield emitter implement ``IConfigurableMachine``

the config options in question are:
```
"L:powerCap": 1000000,
"I:baseConsumption": 1000,
"I:radiusConsumption": 500,
"I:shieldConsumption": 250,
"I:baseRadius": 16,
"I:radiusUpgrade": 16,
"I:shieldUpgrade": 50,
"D:cooldownModifier": 1.0,
"D:healthRegenModifier": 1.0
```

when you change the ``radiusUpgrade`` and ``shieldUpgrade`` it doesn't properly reflect the items' tooltips, i am not sure how to fix this without fucking everything else up
``healthRegenModifier`` wont work below a certain point as the ``health`` is a ``int``, should i be changing it into ``double`` instead?