### PR TITLE
Allow collecting Euphy's statue with a red key

### DIFF
--- a/src/main/java/com/hbm/blocks/generic/DecoBlockAlt.java
+++ b/src/main/java/com/hbm/blocks/generic/DecoBlockAlt.java
@@ -1,5 +1,6 @@
 package com.hbm.blocks.generic;
 
+import java.util.ArrayList;
 import java.util.Random;
 
 import com.hbm.blocks.ModBlocks;
@@ -51,11 +52,20 @@ public class DecoBlockAlt extends BlockContainer {
 		return null;
 	}
 
-    @Override
-	public Item getItemDropped(int p_149650_1_, Random p_149650_2_, int p_149650_3_)
-    {
-        return Item.getItemFromBlock(ModBlocks.statue_elb);
-    }
+	@Override
+	public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune)
+	{
+		ArrayList<ItemStack> drops = new ArrayList<ItemStack>();
+		drops.add(new ItemStack(Item.getItemFromBlock(ModBlocks.statue_elb)));
+		if (this == ModBlocks.statue_elb_g || this == ModBlocks.statue_elb_f)
+		{
+			drops.add(new ItemStack(ModItems.gun_revolver_cursed, 1, 0));
+		}
+		if (this == ModBlocks.statue_elb_w || this == ModBlocks.statue_elb_f) {
+			drops.add(new ItemStack(ModItems.watch, 1, 0));
+		}
+		return drops;
+	}
 	
 	@Override
 	public int getRenderType(){

--- a/src/main/java/com/hbm/blocks/generic/DecoBlockAlt.java
+++ b/src/main/java/com/hbm/blocks/generic/DecoBlockAlt.java
@@ -153,6 +153,13 @@ public class DecoBlockAlt extends BlockContainer {
 						return true;
 					}
 				}
+				boolean cracked = player.getHeldItem().getItem() == ModItems.key_red_cracked;
+				if((player.getHeldItem().getItem() == ModItems.key_red || cracked)) {
+					if(cracked) player.getHeldItem().stackSize--;
+					world.func_147480_a(x, y, z, false);
+					this.dropBlockAsItem(world, x, y, z, world.getBlockMetadata(x, y, z), 0);
+					return true;
+				}
 			}
 		}
 		return false;


### PR DESCRIPTION
I've just found my first `elb_statue` in a meteor dungeon in a survival world, and I felt a bit upset that I had no way to bring it home with me (from another planet, as I'm playing on JamesH2's fork). So I thought of a balanced way to enable this: now right-clicking the statue with a red key (cracked or regular, and cracked ones are consumed in the process) drops the statue (the bare variant), as well as whatever it came equipped with. If you'd like, I could change it to drop the statue with the items equipped instead. I thought this way is a bit more interesting, since now the player gets the option to take a little shortcut in crafting euphemium armor, if they were lucky enough to find a statue in a meteor dungeon. (The plates are still locked behind osmiridium, but no yharonite is needed for the watch).