### PR TITLE
Jetpack-like wings

### DIFF
--- a/src/main/java/com/hbm/items/ModItems.java
+++ b/src/main/java/com/hbm/items/ModItems.java
@@ -5269,8 +5269,8 @@ public class ModItems {
 		jetpack_break = new JetpackBreak(Fluids.KEROSENE, 12000).setUnlocalizedName("jetpack_break").setCreativeTab(CreativeTabs.tabCombat).setMaxStackSize(1).setTextureName(RefStrings.MODID + ":jetpack_break");
 		jetpack_fly = new JetpackRegular(Fluids.KEROSENE, 12000).setUnlocalizedName("jetpack_fly").setCreativeTab(CreativeTabs.tabCombat).setMaxStackSize(1).setTextureName(RefStrings.MODID + ":jetpack_fly");
 		jetpack_vector = new JetpackVectorized(Fluids.KEROSENE, 16000).setUnlocalizedName("jetpack_vector").setCreativeTab(CreativeTabs.tabCombat).setMaxStackSize(1).setTextureName(RefStrings.MODID + ":jetpack_vector");
-		wings_murk = new WingsMurk(MainRegistry.aMatCobalt).setUnlocalizedName("wings_murk").setCreativeTab(CreativeTabs.tabCombat).setMaxStackSize(1).setTextureName(RefStrings.MODID + ":wings_murk");
-		wings_limp = new WingsMurk(MainRegistry.aMatCobalt).setUnlocalizedName("wings_limp").setCreativeTab(CreativeTabs.tabCombat).setMaxStackSize(1).setTextureName(RefStrings.MODID + ":wings_limp");
+		wings_murk = new WingsMurk().setUnlocalizedName("wings_murk").setCreativeTab(CreativeTabs.tabCombat).setMaxStackSize(1).setTextureName(RefStrings.MODID + ":wings_murk");
+		wings_limp = new WingsMurk().setUnlocalizedName("wings_limp").setCreativeTab(CreativeTabs.tabCombat).setMaxStackSize(1).setTextureName(RefStrings.MODID + ":wings_limp");
 
 		cape_radiation = new ArmorModel(ArmorMaterial.CHAIN, 1).setUnlocalizedName("cape_radiation").setCreativeTab(MainRegistry.consumableTab).setMaxStackSize(1).setTextureName(RefStrings.MODID + ":cape_radiation");
 		cape_gasmask = new ArmorModel(ArmorMaterial.CHAIN, 1).setUnlocalizedName("cape_gasmask").setCreativeTab(MainRegistry.consumableTab).setMaxStackSize(1).setTextureName(RefStrings.MODID + ":cape_gasmask");

--- a/src/main/java/com/hbm/items/armor/JetpackBase.java
+++ b/src/main/java/com/hbm/items/armor/JetpackBase.java
@@ -3,7 +3,6 @@ package com.hbm.items.armor;
 import java.util.List;
 
 import com.hbm.handler.ArmorModHandler;
-import com.hbm.inventory.fluid.FluidType;
 import com.hbm.render.model.ModelJetPack;
 import com.hbm.util.ArmorUtil;
 
@@ -17,28 +16,21 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.RenderPlayerEvent;
 
-public abstract class JetpackBase extends ItemArmorMod implements IFillableItem {
+public abstract class JetpackBase extends ItemArmorMod {
 
-	private ModelJetPack model;
-	public FluidType fuel;
-	public int maxFuel;
+	protected ModelBiped cachedModel;
 
-	public JetpackBase(FluidType fuel, int maxFuel) {
+	public JetpackBase() {
 		super(ArmorModHandler.plate_only, false, true, false, false);
-		this.fuel = fuel;
-		this.maxFuel = maxFuel;
 	}
 	
 	@Override
 	public void addInformation(ItemStack itemstack, EntityPlayer player, List list, boolean bool) {
-		list.add(EnumChatFormatting.LIGHT_PURPLE + fuel.getLocalizedName() + ": " + this.getFuel(itemstack) + "mB / " + this.maxFuel + "mB");
-		list.add("");
 		super.addInformation(itemstack, player, list, bool);
 		list.add(EnumChatFormatting.GOLD + "Can be worn on its own!");
 	}
@@ -51,7 +43,7 @@ public abstract class JetpackBase extends ItemArmorMod implements IFillableItem 
 		if(jetpack == null)
 			return;
 		
-		list.add(EnumChatFormatting.RED + "  " + stack.getDisplayName() + " (" + fuel.getLocalizedName() + ": " + this.getFuel(jetpack) + "mB / " + this.maxFuel + "mB");
+		list.add(EnumChatFormatting.RED + "  " + stack.getDisplayName());
 	}
 	
 	@Override
@@ -103,87 +95,12 @@ public abstract class JetpackBase extends ItemArmorMod implements IFillableItem 
 	@SideOnly(Side.CLIENT)
 	public ModelBiped getArmorModel(EntityLivingBase entityLiving, ItemStack itemStack, int armorSlot) {
 		if (armorSlot == 1) {
-			if (model == null) {
-				this.model = new ModelJetPack();
+			if (cachedModel == null) {
+				this.cachedModel = new ModelJetPack();
 			}
-			return this.model;
+			return this.cachedModel;
 		}
 		
 		return null;
-	}
-	
-	protected void useUpFuel(EntityPlayer player, ItemStack stack, int rate) {
-
-		if(player.ticksExisted % rate == 0)
-			this.setFuel(stack, this.getFuel(stack) - 1);
-	}
-	
-    public static int getFuel(ItemStack stack) {
-		if(stack.stackTagCompound == null) {
-			stack.stackTagCompound = new NBTTagCompound();
-			return 0;
-		}
-		
-		return stack.stackTagCompound.getInteger("fuel");
-		
-	}
-	
-	public static void setFuel(ItemStack stack, int i) {
-		if(stack.stackTagCompound == null) {
-			stack.stackTagCompound = new NBTTagCompound();
-		}
-		
-		stack.stackTagCompound.setInteger("fuel", i);
-		
-	}
-
-	public int getMaxFill(ItemStack stack) {
-		return this.maxFuel;
-	}
-
-	public int getLoadSpeed(ItemStack stack) {
-		return 10;
-	}
-
-	@Override
-	public boolean acceptsFluid(FluidType type, ItemStack stack) {
-		return type == this.fuel;
-	}
-
-	@Override
-	public int tryFill(FluidType type, int amount, ItemStack stack) {
-		
-		if(!acceptsFluid(type, stack))
-			return amount;
-		
-		int fill = this.getFuel(stack);
-		int req = maxFuel - fill;
-		
-		int toFill = Math.min(amount, req);
-		//toFill = Math.min(toFill, getLoadSpeed(stack));
-		
-		this.setFuel(stack, fill + toFill);
-		
-		return amount - toFill;
-	}
-
-	@Override
-	public boolean providesFluid(FluidType type, ItemStack stack) {
-		return false;
-	}
-
-	@Override
-	public int tryEmpty(FluidType type, int amount, ItemStack stack) {
-		return 0;
-	}
-
-	@Override
-	public FluidType getFirstFluidType(ItemStack stack) {
-		return null;
-	}
-
-	@Override
-	public int getFill(ItemStack stack) {
-		return 0;
 	}
 }

--- a/src/main/java/com/hbm/items/armor/JetpackBase.java
+++ b/src/main/java/com/hbm/items/armor/JetpackBase.java
@@ -6,7 +6,6 @@ import com.hbm.handler.ArmorModHandler;
 import com.hbm.render.model.ModelJetPack;
 import com.hbm.util.ArmorUtil;
 
-import api.hbm.fluid.IFillableItem;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/hbm/items/armor/JetpackBooster.java
+++ b/src/main/java/com/hbm/items/armor/JetpackBooster.java
@@ -17,7 +17,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
-public class JetpackBooster extends JetpackBase {
+public class JetpackBooster extends JetpackFueledBase {
 
 	public JetpackBooster(FluidType fuel, int maxFuel) {
 		super(fuel, maxFuel);

--- a/src/main/java/com/hbm/items/armor/JetpackBreak.java
+++ b/src/main/java/com/hbm/items/armor/JetpackBreak.java
@@ -16,7 +16,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
-public class JetpackBreak extends JetpackBase {
+public class JetpackBreak extends JetpackFueledBase {
 
 	public static int maxFuel = 1200;
 

--- a/src/main/java/com/hbm/items/armor/JetpackFueledBase.java
+++ b/src/main/java/com/hbm/items/armor/JetpackFueledBase.java
@@ -1,0 +1,117 @@
+package com.hbm.items.armor;
+
+import java.util.List;
+
+import com.hbm.handler.ArmorModHandler;
+import com.hbm.inventory.fluid.FluidType;
+
+import api.hbm.fluid.IFillableItem;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumChatFormatting;
+
+public abstract class JetpackFueledBase extends JetpackBase implements IFillableItem {
+
+	public FluidType fuel;
+	public int maxFuel;
+
+	public JetpackFueledBase(FluidType fuel, int maxFuel) {
+		super();
+		this.fuel = fuel;
+		this.maxFuel = maxFuel;
+	}
+	
+	@Override
+	public void addInformation(ItemStack itemstack, EntityPlayer player, List list, boolean bool) {
+		list.add(EnumChatFormatting.LIGHT_PURPLE + fuel.getLocalizedName() + ": " + this.getFuel(itemstack) + "mB / " + this.maxFuel + "mB");
+		list.add("");
+		super.addInformation(itemstack, player, list, bool);
+	}
+	
+	@Override
+	public void addDesc(List list, ItemStack stack, ItemStack armor) {
+		
+		ItemStack jetpack = ArmorModHandler.pryMods(armor)[ArmorModHandler.plate_only];
+		
+		if(jetpack == null)
+			return;
+		
+		list.add(EnumChatFormatting.RED + "  " + stack.getDisplayName() + " (" + fuel.getLocalizedName() + ": " + this.getFuel(jetpack) + "mB / " + this.maxFuel + "mB)");
+	}
+	
+	protected void useUpFuel(EntityPlayer player, ItemStack stack, int rate) {
+		if(player.ticksExisted % rate == 0){
+			this.setFuel(stack, this.getFuel(stack) - 1);
+        }
+	}
+	
+    public static int getFuel(ItemStack stack) {
+		if(stack.stackTagCompound == null) {
+			stack.stackTagCompound = new NBTTagCompound();
+			return 0;
+		}
+		
+		return stack.stackTagCompound.getInteger("fuel");
+		
+	}
+	
+	public static void setFuel(ItemStack stack, int i) {
+		if(stack.stackTagCompound == null) {
+			stack.stackTagCompound = new NBTTagCompound();
+		}
+		
+		stack.stackTagCompound.setInteger("fuel", i);
+		
+	}
+
+	public int getMaxFill(ItemStack stack) {
+		return this.maxFuel;
+	}
+
+	public int getLoadSpeed(ItemStack stack) {
+		return 10;
+	}
+
+	@Override
+	public boolean acceptsFluid(FluidType type, ItemStack stack) {
+		return type == this.fuel;
+	}
+
+	@Override
+	public int tryFill(FluidType type, int amount, ItemStack stack) {
+		
+		if(!acceptsFluid(type, stack))
+			return amount;
+		
+		int fill = this.getFuel(stack);
+		int req = maxFuel - fill;
+		
+		int toFill = Math.min(amount, req);
+		//toFill = Math.min(toFill, getLoadSpeed(stack));
+		
+		this.setFuel(stack, fill + toFill);
+		
+		return amount - toFill;
+	}
+
+	@Override
+	public boolean providesFluid(FluidType type, ItemStack stack) {
+		return false;
+	}
+
+	@Override
+	public int tryEmpty(FluidType type, int amount, ItemStack stack) {
+		return 0;
+	}
+
+	@Override
+	public FluidType getFirstFluidType(ItemStack stack) {
+		return null;
+	}
+
+	@Override
+	public int getFill(ItemStack stack) {
+		return 0;
+	}
+}

--- a/src/main/java/com/hbm/items/armor/JetpackRegular.java
+++ b/src/main/java/com/hbm/items/armor/JetpackRegular.java
@@ -16,7 +16,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
-public class JetpackRegular extends JetpackBase {
+public class JetpackRegular extends JetpackFueledBase {
 
 	public JetpackRegular(FluidType fuel, int maxFuel) {
 		super(fuel, maxFuel);

--- a/src/main/java/com/hbm/items/armor/JetpackVectorized.java
+++ b/src/main/java/com/hbm/items/armor/JetpackVectorized.java
@@ -17,7 +17,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
-public class JetpackVectorized extends JetpackBase {
+public class JetpackVectorized extends JetpackFueledBase {
 
 	public JetpackVectorized(FluidType fuel, int maxFuel) {
 		super(fuel, maxFuel);

--- a/src/main/java/com/hbm/items/armor/WingsMurk.java
+++ b/src/main/java/com/hbm/items/armor/WingsMurk.java
@@ -1,6 +1,9 @@
 package com.hbm.items.armor;
 
+import java.util.List;
+
 import com.hbm.extprop.HbmPlayerProps;
+import com.hbm.handler.ArmorModHandler;
 import com.hbm.items.ModItems;
 import com.hbm.render.model.ModelArmorWings;
 import com.hbm.util.ArmorUtil;
@@ -10,29 +13,24 @@ import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
-public class WingsMurk extends ItemArmor {
+public class WingsMurk extends JetpackBase {
 
-	public WingsMurk(ArmorMaterial material) {
-		super(material, 0, 1);
+	public WingsMurk() {
+		super();
 	}
-
-	@SideOnly(Side.CLIENT)
-	ModelArmorWings model;
 
 	@Override
 	@SideOnly(Side.CLIENT)
 	public ModelBiped getArmorModel(EntityLivingBase entityLiving, ItemStack itemStack, int armorSlot) {
-		
-		if(model == null) {
-			model = new ModelArmorWings(this == ModItems.wings_murk ? 0 : 1);
+		if(cachedModel == null) {
+			cachedModel = new ModelArmorWings(this == ModItems.wings_murk ? 0 : 1);
 		}
 		
-		return model;
+		return cachedModel;
 	}
 
 	public void onArmorTick(World world, EntityPlayer player, ItemStack stack) {

--- a/src/main/java/com/hbm/items/armor/WingsMurk.java
+++ b/src/main/java/com/hbm/items/armor/WingsMurk.java
@@ -1,16 +1,16 @@
 package com.hbm.items.armor;
 
-import java.util.List;
-
 import com.hbm.extprop.HbmPlayerProps;
-import com.hbm.handler.ArmorModHandler;
 import com.hbm.items.ModItems;
+import com.hbm.main.MainRegistry;
+import com.hbm.main.ResourceManager;
 import com.hbm.render.model.ModelArmorWings;
 import com.hbm.util.ArmorUtil;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.model.ModelBiped;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -24,13 +24,23 @@ public class WingsMurk extends JetpackBase {
 	}
 
 	@Override
+	public String getArmorTexture(ItemStack stack, Entity entity, int slot, String type) {
+		MainRegistry.logger.info("[ABEL] Wings texture: " + ResourceManager.wings_murk.toString());
+		return ResourceManager.wings_murk.toString();
+	}
+
+	@Override
 	@SideOnly(Side.CLIENT)
 	public ModelBiped getArmorModel(EntityLivingBase entityLiving, ItemStack itemStack, int armorSlot) {
-		if(cachedModel == null) {
-			cachedModel = new ModelArmorWings(this == ModItems.wings_murk ? 0 : 1);
+		if (armorSlot == 1) {
+			if(cachedModel == null) {
+				cachedModel = new ModelArmorWings(this == ModItems.wings_murk ? 0 : 1);
+			}
+			
+			return cachedModel;
 		}
-		
-		return cachedModel;
+
+		return null;
 	}
 
 	public void onArmorTick(World world, EntityPlayer player, ItemStack stack) {

--- a/src/main/java/com/hbm/main/ModEventHandlerClient.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerClient.java
@@ -41,6 +41,7 @@ import com.hbm.items.armor.ArmorFSBPowered;
 import com.hbm.items.armor.ArmorNo9;
 import com.hbm.items.armor.ItemArmorMod;
 import com.hbm.items.armor.JetpackBase;
+import com.hbm.items.armor.JetpackFueledBase;
 import com.hbm.items.machine.ItemDepletedFuel;
 import com.hbm.items.machine.ItemFluidDuct;
 import com.hbm.items.machine.ItemRBMKPellet;
@@ -441,11 +442,11 @@ public class ModEventHandlerClient {
 
 				GL11.glEnable(GL11.GL_TEXTURE_2D);
 
-			} else if(player.inventory.armorInventory[2] != null && player.inventory.armorInventory[2].getItem() instanceof JetpackBase) {
+			} else if(player.inventory.armorInventory[2] != null && player.inventory.armorInventory[2].getItem() instanceof JetpackFueledBase) {
 
 				ItemStack stack = player.inventory.armorInventory[2];
 
-				float tot = (float) ((JetpackBase) stack.getItem()).getFuel(stack) / (float) ((JetpackBase) stack.getItem()).getMaxFill(stack);
+				float tot = (float) ((JetpackFueledBase) stack.getItem()).getFuel(stack) / (float) ((JetpackFueledBase) stack.getItem()).getMaxFill(stack);
 				
 				int top = height - GuiIngameForge.left_height + 3;
 


### PR DESCRIPTION
Now limp and murky wings can not only be worn, but also attached to armor. Functionally, they now share a base class with jetpacks (`JetpackBase`, except everything related to fuel has been extracted into `JetpackFueledBase`, which the actual jetpacks now inherit from).

This means they no longer act as defensive armor when worn on their own and don't get damaged when the player is attacked, but to me this makes more sense than otherwise. The previous behavior can be attained by attaching them to actual armor.

As per usual, I've tested this and it works perfectly, both when worn standalone or attached to a chestpiece.