### PR TITLE
Turret CompatExternal fix

### DIFF
--- a/src/main/java/com/hbm/util/CompatExternal.java
+++ b/src/main/java/com/hbm/util/CompatExternal.java
@@ -181,7 +181,7 @@ public class CompatExternal {
 	 * class on the side of whoever is adding compat, allowing the compat class to be used entirely with reflection.
 	 */
 	public static void registerTurretTargetingCondition(Class clazz, BiFunction<Entity, Object, Integer> bi) {
-		turretTargetBlacklist.add(clazz);
+		turretTargetCondition.put(clazz, bi);
 	}
 
 	public static void setWarheadLabel(WarheadType type, String label) { type.labelCustom = label; }


### PR DESCRIPTION
``CompatExternal.registerTurretTargetingCondition`` now should work as intended

TECHNICALLY this is meaningless, considering you can just manually add it to ``CompatExternal.turretTargetCondition``, but my ass was so bothered with the fact that it didnt work out of the box