### PR TITLE
Fix the armor rendering a bit

### DIFF
--- a/src/main/java/com/hbm/render/model/ModelArmorBase.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorBase.java
@@ -1,15 +1,17 @@
 package com.hbm.render.model;
 
 import com.hbm.interfaces.IHoldableWeapon;
+import com.hbm.items.weapon.sedna.ItemGunBaseNT;
 import com.hbm.render.loader.ModelRendererObj;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.EnumAction;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
 
@@ -82,8 +84,15 @@ public class ModelArmorBase extends ModelBiped {
 
 			this.isSneak = player.isSneaking();
 			this.isRiding = player.isRiding();
+		} else if (entity instanceof EntityLivingBase) {
+			EntityLivingBase entityLivingBase = (EntityLivingBase) entity;
+			this.isSneak = entityLivingBase.isSneaking();
+			ItemStack held = entityLivingBase.getHeldItem();
+			if(held != null && held.getItem() instanceof ItemGunBaseNT) {
+				this.aimedBow = true;
+			}
 		}
-
+		
 		if(this.isRiding) {
 			rightArm.rotateAngleX += -((float) Math.PI / 5F);
 			leftArm.rotateAngleX += -((float) Math.PI / 5F);

--- a/src/main/java/com/hbm/render/model/ModelT45Boots.java
+++ b/src/main/java/com/hbm/render/model/ModelT45Boots.java
@@ -6,6 +6,7 @@
 
 package com.hbm.render.model;
 
+import net.minecraft.entity.EntityLivingBase;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.model.ModelBiped;
@@ -73,16 +74,12 @@ public class ModelT45Boots extends ModelBiped {
 
 	@Override
 	public void setRotationAngles(float f, float f1, float f2, float f3, float f4, float f5, Entity entity) {
-
-		if (entity instanceof EntityPlayer) {
-			EntityPlayer player = (EntityPlayer) entity;
-			if (player.isSneaking()) {
-				this.isSneak = true;
-			} else {
-				this.isSneak = false;
-			}
+		
+		if(entity instanceof EntityLivingBase) {
+			EntityLivingBase entityLivingBase = (EntityLivingBase) entity;
+			this.isSneak = entityLivingBase.isSneaking();
 		}
-
+		
 		super.setRotationAngles(f, f1, f2, f3, f4, f5, entity);
 		this.leftleg.rotationPointX = this.bipedLeftLeg.rotationPointX;
 		this.leftleg.rotationPointY = this.bipedLeftLeg.rotationPointY - 1.5F;

--- a/src/main/java/com/hbm/render/model/ModelT45Chest.java
+++ b/src/main/java/com/hbm/render/model/ModelT45Chest.java
@@ -6,6 +6,8 @@
 
 package com.hbm.render.model;
 
+import com.hbm.items.weapon.sedna.ItemGunBaseNT;
+import net.minecraft.entity.EntityLivingBase;
 import org.lwjgl.opengl.GL11;
 
 import com.hbm.interfaces.IHoldableWeapon;
@@ -207,13 +209,10 @@ public class ModelT45Chest extends ModelBiped {
 
 	@Override
 	public void setRotationAngles(float f, float f1, float f2, float f3, float f4, float f5, Entity entity) {
+		
 		if (entity instanceof EntityPlayer) {
 			EntityPlayer player = (EntityPlayer) entity;
-			if (player.isSneaking()) {
-				this.isSneak = true;
-			} else {
-				this.isSneak = false;
-			}
+			this.isSneak = player.isSneaking();
 			ItemStack itemstack = player.inventory.getCurrentItem();
 			this.heldItemRight = itemstack != null ? 1 : 0;
 
@@ -227,9 +226,18 @@ public class ModelT45Chest extends ModelBiped {
 				}
 			}
 
-			if(itemstack != null && player.getHeldItem().getItem() instanceof IHoldableWeapon)
+			if(itemstack != null && (player.getHeldItem().getItem() instanceof IHoldableWeapon || player.getHeldItem().getItem() instanceof ItemGunBaseNT))
 				this.aimedBow = true;
+		} else if(entity instanceof EntityLivingBase) {
+			EntityLivingBase entityLivingBase = (EntityLivingBase) entity;
+			this.isSneak = entityLivingBase.isSneaking();
+
+			ItemStack held = entityLivingBase.getHeldItem();
+			if(held != null && held.getItem() instanceof ItemGunBaseNT) {
+				this.aimedBow = true;
+			}
 		}
+		
 		super.setRotationAngles(f, f1, f2, f3, f4, f5, entity);
 		this.chest.rotationPointX = this.bipedBody.rotationPointX;
 		this.chest.rotationPointY = this.bipedBody.rotationPointY;

--- a/src/main/java/com/hbm/render/model/ModelT45Helmet.java
+++ b/src/main/java/com/hbm/render/model/ModelT45Helmet.java
@@ -6,6 +6,7 @@
 
 package com.hbm.render.model;
 
+import net.minecraft.entity.EntityLivingBase;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.model.ModelBiped;
@@ -105,16 +106,12 @@ public class ModelT45Helmet extends ModelBiped {
 
 	@Override
 	public void setRotationAngles(float f, float f1, float f2, float f3, float f4, float f5, Entity entity) {
-
-		if (entity instanceof EntityPlayer) {
-			EntityPlayer player = (EntityPlayer) entity;
-			if (player.isSneaking()) {
-				this.isSneak = true;
-			} else {
-				this.isSneak = false;
-			}
+		
+		 if(entity instanceof EntityLivingBase) {
+			EntityLivingBase entityLivingBase = (EntityLivingBase) entity;
+			this.isSneak = entityLivingBase.isSneaking();
 		}
-
+		
 		super.setRotationAngles(f, f1, f2, f3, f4, f5, entity);
 		this.helmet.rotationPointX = this.bipedHead.rotationPointX;
 		this.helmet.rotationPointY = this.bipedHead.rotationPointY;

--- a/src/main/java/com/hbm/render/model/ModelT45Legs.java
+++ b/src/main/java/com/hbm/render/model/ModelT45Legs.java
@@ -6,6 +6,7 @@
 
 package com.hbm.render.model;
 
+import net.minecraft.entity.EntityLivingBase;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.model.ModelBiped;
@@ -90,16 +91,12 @@ public class ModelT45Legs extends ModelBiped {
 
 	@Override
 	public void setRotationAngles(float f, float f1, float f2, float f3, float f4, float f5, Entity entity) {
-
-		if (entity instanceof EntityPlayer) {
-			EntityPlayer player = (EntityPlayer) entity;
-			if (player.isSneaking()) {
-				this.isSneak = true;
-			} else {
-				this.isSneak = false;
-			}
-		}
-
+		
+		if(entity instanceof EntityLivingBase) {
+			EntityLivingBase entityLivingBase = (EntityLivingBase) entity;
+			this.isSneak = entityLivingBase.isSneaking();
+		} 
+		
 		super.setRotationAngles(f, f1, f2, f3, f4, f5, entity);
 		this.leftleg.rotationPointX = this.bipedLeftLeg.rotationPointX;
 		this.leftleg.rotationPointY = this.bipedLeftLeg.rotationPointY - 1.5F;


### PR DESCRIPTION
So, this PR fixes a few issues with armor rendering (mostly weapon related)

## 1) Fixed* T45 arms not raising with weapon

Before:

![2025-01-01_02 39 15](https://github.com/user-attachments/assets/1cc09540-e7c6-48d9-a80a-a661f3c89b8b)

After:

![2025-01-01_02 47 43](https://github.com/user-attachments/assets/4722d3f3-4e50-4a7d-b469-490b9ab14620)

"*" - dual wielding weapon still looks weird (left arm)

## 2) Fixed armor on other mobs `isSneak = true` if player `isSneak = true`

Before:

![2025-01-01_02 40 18](https://github.com/user-attachments/assets/608537b4-7b9d-4c71-9a33-78e419d8af4c)
![2025-01-01_02 45 00](https://github.com/user-attachments/assets/3e021e33-cd5f-49ec-9f82-8455bd35032e)

After:

![2025-01-01_02 41 52](https://github.com/user-attachments/assets/9e7e90cc-f23a-41e0-b499-1fa4ba133f5d)

![2025-01-01_02 42 24](https://github.com/user-attachments/assets/a12dc648-b7f5-441b-a072-8511fce91f4a)


## 3) Fixed armor arms not raising with weapon on other mobs

The problem was that `aimedBow = true` was only set if `entity instanceof EntityPlayer`.
 So if you give a mob power armor and a weapon, the power armor arms won't raise with weapon, even though it works on the player