### PR TITLE
Miscellaneous fixes for the optimization update.

### DIFF
--- a/src/main/java/com/hbm/handler/threading/PacketThreading.java
+++ b/src/main/java/com/hbm/handler/threading/PacketThreading.java
@@ -132,7 +132,8 @@ public class PacketThreading {
 				for (Future<?> future : futureList) {
 					nanoTimeWaited = System.nanoTime() - startTime;
 					future.get(50, TimeUnit.MILLISECONDS); // I HATE EVERYTHING
-					if(TimeUnit.MILLISECONDS.convert(nanoTimeWaited, TimeUnit.NANOSECONDS) > 50) throw new TimeoutException(); // >50ms total time? timeout? yes sir, ooh rah!
+					// if(TimeUnit.MILLISECONDS.convert(nanoTimeWaited, TimeUnit.NANOSECONDS) > 50) throw new TimeoutException(); // >50ms total time? timeout? yes sir, ooh rah!
+					// this seems to cause big problems with large worlds, never mind...
 				}
 			}
 		} catch (ExecutionException ignored) {

--- a/src/main/java/com/hbm/tileentity/bomb/TileEntityCharge.java
+++ b/src/main/java/com/hbm/tileentity/bomb/TileEntityCharge.java
@@ -32,7 +32,7 @@ public class TileEntityCharge extends TileEntityLoadedBase {
 
 	@Override
 	public void serialize(ByteBuf buf) {
-		buf.writeLong(this.timer);
+		buf.writeInt(this.timer);
 		buf.writeBoolean(this.started);
 	}
 

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityBroadcaster.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityBroadcaster.java
@@ -12,7 +12,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.tileentity.TileEntity;
@@ -52,18 +51,6 @@ public class TileEntityBroadcaster extends TileEntityLoadedBase {
 				audio = rebootAudio(audio);
 			}
 
-			int intendedVolume = 25;
-
-			EntityPlayer player = MainRegistry.proxy.me();
-			float volume;
-			if(player != null) {
-				float f = (float)Math.sqrt(Math.pow(xCoord - player.posX, 2) + Math.pow(yCoord - player.posY, 2) + Math.pow(zCoord - player.posZ, 2));
-				volume = (f / intendedVolume) * -2 + 2;
-			} else {
-				volume = intendedVolume;
-			}
-
-			audio.updateVolume(getVolume(volume));
 			audio.keepAlive();
 		}
 	}
@@ -89,7 +76,7 @@ public class TileEntityBroadcaster extends TileEntityLoadedBase {
 	@Override
 	public AudioWrapper createAudioLoop() {
 		Random rand = new Random(xCoord + yCoord + zCoord);
-		return MainRegistry.proxy.getLoopedSound("hbm:block.broadcast" + (rand.nextInt(3) + 1), xCoord, yCoord, zCoord, 1.0F, 10F, 1.0F);
+		return MainRegistry.proxy.getLoopedSound("hbm:block.broadcast" + (rand.nextInt(3) + 1), xCoord, yCoord, zCoord, 25F, 25F, 1.0F);
 	}
 
 	@Override

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityCustomMachine.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityCustomMachine.java
@@ -231,6 +231,8 @@ public class TileEntityCustomMachine extends TileEntityMachinePolluting implemen
 	public void serialize(ByteBuf buf) {
 		super.serialize(buf);
 
+		BufferUtil.writeString(buf, this.machineType);
+
 		buf.writeLong(power);
 		buf.writeInt(progress);
 		buf.writeInt(flux);
@@ -596,13 +598,13 @@ public class TileEntityCustomMachine extends TileEntityMachinePolluting implemen
 
 		return 0;
 	}
-	
+
 	@Override
 	public long getReceiverSpeed() {
 		if(this.config != null && !this.config.generatorMode) return this.getMaxPower();
 		return 0;
 	}
-	
+
 	@Override
 	public long getProviderSpeed() {
 		if(this.config != null && this.config.generatorMode) return this.getMaxPower();


### PR DESCRIPTION
Fixed corrupted broadcaster playing sound invertedly due to multiple (unnoticed) distance checks and linear interpolation steps.
Fixed custom machine crashing servers due to packet underflow.
The above also fixes clients crashing due to `/ by 0` errors, as they were caused by the underflow shifting the buffer several bytes and reading invalid values.
Fixed large bases with a lot of packet-sending TileEntities timing out large quantities of packets due to blocking.