### PR TITLE
Fix RBMK Crane Console

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
@@ -265,7 +265,6 @@ public class TileEntityCraneConsole extends TileEntityLoadedBase implements Simp
 			this.posFront = buf.readDouble();
 			this.posLeft = buf.readDouble();
 			this.hasLoaded = buf.readBoolean();
-			this.posLeft = buf.readDouble();
 			this.loadedHeat = buf.readDouble();
 			this.loadedEnrichment = buf.readDouble();
 		}


### PR DESCRIPTION
Fixed RBMK Crane Console moving problem. I actually don't know how the new packet sending code works. I compared the posLeft variable with the similar posFront variable and found that it performed an additional operation during deserialization, so I removed it, and this fix the problem that RBMK Crane Console can't move left or right. 