### PR TITLE
PA Detector fixes and improved diagnostics

### DIFF
--- a/src/main/java/com/hbm/inventory/recipes/ParticleAcceleratorRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/ParticleAcceleratorRecipes.java
@@ -17,9 +17,9 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 public class ParticleAcceleratorRecipes extends SerializableRecipe {
-	
+
 	public static final List<ParticleAcceleratorRecipe> recipes = new ArrayList();
-	
+
 	@Override
 	public void registerDefaults() {
 
@@ -94,31 +94,31 @@ public class ParticleAcceleratorRecipes extends SerializableRecipe {
 				new ItemStack(ModItems.nugget)
 				));
 	}
-	
+
 	public static ParticleAcceleratorRecipe getOutput(ItemStack input1, ItemStack input2) {
-		
+
 		for(ParticleAcceleratorRecipe recipe : recipes) {
-			
+
 			if(((recipe.input1.matchesRecipe(input1, true) && recipe.input2.matchesRecipe(input2, true)) ||
 							(recipe.input1.matchesRecipe(input2, true) && recipe.input2.matchesRecipe(input1, true)))) {
 				return recipe;
 			}
 		}
-		
+
 		return null;
 	}
 
 	public static HashMap getRecipes() {
-		
+
 		HashMap<Object[], Object> recipes = new HashMap<Object[], Object>();
-		
+
 		for(ParticleAcceleratorRecipe entry : ParticleAcceleratorRecipes.recipes) {
 			List<ItemStack> outputs = new ArrayList();
 			if(entry.output1 != null) outputs.add(entry.output1);
 			if(entry.output2 != null) outputs.add(entry.output2);
 			recipes.put(new Object[] {entry.input1, entry.input2}, outputs.toArray(new ItemStack[0]));
 		}
-		
+
 		return recipes;
 	}
 
@@ -128,13 +128,19 @@ public class ParticleAcceleratorRecipes extends SerializableRecipe {
 		public int momentum;
 		public ItemStack output1;
 		public ItemStack output2;
-		
+
 		public ParticleAcceleratorRecipe(AStack in1, AStack in2, int momentum, ItemStack out1, ItemStack out2) {
 			this.input1 = in1;
 			this.input2 = in2;
 			this.momentum = momentum;
 			this.output1 = out1;
 			this.output2 = out2;
+		}
+
+		// it makes more sense to have this logic here
+		public boolean matchesRecipe(ItemStack in1, ItemStack in2) {
+			return this.input1.matchesRecipe(in1, true) && this.input2.matchesRecipe(in2, true)
+				|| this.input1.matchesRecipe(in2, true) && this.input2.matchesRecipe(in1, true);
 		}
 	}
 
@@ -159,7 +165,7 @@ public class ParticleAcceleratorRecipes extends SerializableRecipe {
 		int momentum = obj.get("momentum").getAsInt();
 		AStack[] in = this.readAStackArray(obj.get("inputs").getAsJsonArray());
 		ItemStack[] out = this.readItemStackArray(obj.get("outputs").getAsJsonArray());
-		
+
 		this.recipes.add(new ParticleAcceleratorRecipe(
 				in[0],
 				in[1],
@@ -172,14 +178,14 @@ public class ParticleAcceleratorRecipes extends SerializableRecipe {
 	@Override
 	public void writeRecipe(Object recipe, JsonWriter writer) throws IOException {
 		ParticleAcceleratorRecipe rec = (ParticleAcceleratorRecipe) recipe;
-		
+
 		writer.name("momentum").value(rec.momentum);
-		
+
 		writer.name("inputs").beginArray();
 		this.writeAStack(rec.input1, writer);
 		this.writeAStack(rec.input2, writer);
 		writer.endArray();
-		
+
 		writer.name("outputs").beginArray();
 		this.writeItemStack(rec.output1, writer);
 		if(rec.output2 != null) this.writeItemStack(rec.output2, writer);

--- a/src/main/java/com/hbm/tileentity/machine/albion/TileEntityPADetector.java
+++ b/src/main/java/com/hbm/tileentity/machine/albion/TileEntityPADetector.java
@@ -23,7 +23,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 public class TileEntityPADetector extends TileEntityCooledBase implements IGUIProvider, IParticleUser {
 
 	public static final long usage = 100_000;
-	
+
 	public TileEntityPADetector() {
 		super(5);
 	}
@@ -35,11 +35,11 @@ public class TileEntityPADetector extends TileEntityCooledBase implements IGUIPr
 
 	@Override
 	public void updateEntity() {
-		
+
 		if(!worldObj.isRemote) {
 			this.power = Library.chargeTEFromItems(slots, 0, power, this.getMaxPower());
 		}
-		
+
 		super.updateEntity();
 	}
 
@@ -64,12 +64,12 @@ public class TileEntityPADetector extends TileEntityCooledBase implements IGUIPr
 	@Override public boolean isItemValidForSlot(int slot, ItemStack stack) { return slot == 1 || slot == 2; }
 	@Override public boolean canExtractItem(int slot, ItemStack stack, int side) { return slot == 3 || slot == 4; }
 	@Override public int[] getAccessibleSlotsFromSide(int side) { return new int[] { 1, 2, 3, 4 }; }
-	
+
 	AxisAlignedBB bb = null;
-	
+
 	@Override
 	public AxisAlignedBB getRenderBoundingBox() {
-		
+
 		if(bb == null) {
 			bb = AxisAlignedBB.getBoundingBox(
 					xCoord - 4,
@@ -80,10 +80,10 @@ public class TileEntityPADetector extends TileEntityCooledBase implements IGUIPr
 					zCoord + 5
 					);
 		}
-		
+
 		return bb;
 	}
-	
+
 	@Override
 	@SideOnly(Side.CLIENT)
 	public double getMaxRenderDistanceSquared() {
@@ -112,44 +112,48 @@ public class TileEntityPADetector extends TileEntityCooledBase implements IGUIPr
 		particle.invalid = true;
 		//particle will crash if not perfectly focused
 		if(particle.defocus > 0) { particle.crash(PAState.CRASH_DEFOCUS); return; }
-		if(this.power < this.usage) { particle.crash(PAState.CRASH_NOPOWER); return; }
+		if(this.power < usage) { particle.crash(PAState.CRASH_NOPOWER); return; }
 		if(!isCool()) { particle.crash(PAState.CRASH_NOCOOL); return; }
 
 		for(ParticleAcceleratorRecipe recipe : ParticleAcceleratorRecipes.recipes) {
-			
-			if(particle.momentum >= recipe.momentum &&
-					((recipe.input1.matchesRecipe(particle.input1, true) && recipe.input2.matchesRecipe(particle.input2, true)) ||
-					(recipe.input1.matchesRecipe(particle.input2, true) && recipe.input2.matchesRecipe(particle.input1, true)))) {
-				if(canAccept(recipe)) {
-					if(recipe.output1.getItem().hasContainerItem(recipe.output1)) this.decrStackSize(1, 1);
-					if(recipe.output2 != null && recipe.output2.getItem().hasContainerItem(recipe.output2)) this.decrStackSize(2, 1);
-					
-					if(slots[3] == null) {
-						slots[3] = recipe.output1.copy();
-					} else {
-						slots[3].stackSize += recipe.output1.stackSize;
-					}
-					
-					if(recipe.output2 != null) {
-						if(slots[4] == null) {
-							slots[4] = recipe.output2.copy();
-						} else {
-							slots[4].stackSize += recipe.output2.stackSize;
-						}
-					}
-				}
-				particle.crash(PAState.SUCCESS);
+			if(!recipe.matchesRecipe(particle.input1, particle.input2)) continue; // another W for continue
+			if(particle.momentum < recipe.momentum) {
+				this.power -= usage;
+				particle.crash(PAState.CRASH_UNDERSPEED);
 				return;
 			}
+
+			if(canAccept(recipe)) {
+				if(recipe.output1.getItem().hasContainerItem(recipe.output1)) this.decrStackSize(1, 1);
+				if(recipe.output2 != null && recipe.output2.getItem().hasContainerItem(recipe.output2)) this.decrStackSize(2, 1);
+
+				if(slots[3] == null) {
+					slots[3] = recipe.output1.copy();
+				} else {
+					slots[3].stackSize += recipe.output1.stackSize;
+				}
+
+				if(recipe.output2 != null) {
+					if(slots[4] == null) {
+						slots[4] = recipe.output2.copy();
+					} else {
+						slots[4].stackSize += recipe.output2.stackSize;
+					}
+				}
+			}
+			this.power -= usage;
+			particle.crash(PAState.SUCCESS);
+			return;
 		}
-		
-		this.power -= this.usage;
+
+		this.power -= usage;
+		particle.crash(PAState.CRASH_NORECIPE);
 	}
-	
+
 	public boolean canAccept(ParticleAcceleratorRecipe recipe) {
 		return checkSlot(recipe.output1, 1, 3) && checkSlot(recipe.output2, 2, 4);
 	}
-	
+
 	public boolean checkSlot(ItemStack output, int containerSlot, int outputSlot) {
 		if(output != null) {
 			if(slots[outputSlot] != null) {
@@ -162,7 +166,7 @@ public class TileEntityPADetector extends TileEntityCooledBase implements IGUIPr
 				if(slots[containerSlot] == null || slots[containerSlot].getItem() != container.getItem() || slots[containerSlot].getItemDamage() != container.getItemDamage()) return false;
 			}
 		}
-		
+
 		return true;
 	}
 

--- a/src/main/resources/assets/hbm/lang/en_US.lang
+++ b/src/main/resources/assets/hbm/lang/en_US.lang
@@ -4865,6 +4865,10 @@ pa.crash_nocoil=No coils!
 pa.crash_nocoil.desc=The particle has entered a dipole$or quadrupole which lacks coils.$Install coils to allow this part to work.
 pa.crash_overspeed=Overspeed!
 pa.crash_overspeed.desc=The particle has entered a dipole$or quadrupole, while its speed exceeded$the coil's rating. Install higher$tier coils, or configure the dipoles$to leave the accelerator ring sooner.
+pa.crash_norecipe=No recipe!
+pa.crash_norecipe.desc=The particle entered a detector with an invalid set of inputs. Ensure the particle source inputs match a valid recipe.
+pa.crash_underspeed=Underspeed!
+pa.crash_underspeed.desc=The particle entered a detector with insufficient speed to perform the current recipe. Ensure the accelerator is configured correctly for the recipe.
 
 potion.hbm_bang=! ! !
 potion.hbm_death=Astolfization


### PR DESCRIPTION
Fixed a bug where some code paths in `TileEntityPADetector.onEnter` would not call `particle.crash` causing the diagnostics in the PA source to not update; New diagnostics/PAStates were also added for these code paths.

Fixed the PA detector not consuming power on a successful recipe.

Slightly refactored to make the PA detector code more readable.

I have tested these changes in game and they seem to work fine :)