### PR TITLE
Return OC integration with Energy storage block

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/storage/TileEntityMachineBattery.java
+++ b/src/main/java/com/hbm/tileentity/machine/storage/TileEntityMachineBattery.java
@@ -25,6 +25,7 @@ import io.netty.buffer.ByteBuf;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.SimpleComponent;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
@@ -34,7 +35,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 @Optional.InterfaceList({@Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "opencomputers")})
-public class TileEntityMachineBattery extends TileEntityMachineBase implements IEnergyConductorMK2, IEnergyProviderMK2, IEnergyReceiverMK2, IPersistentNBT, IGUIProvider, IInfoProviderEC, CompatHandler.OCComponent {
+public class TileEntityMachineBattery extends TileEntityMachineBase implements IEnergyConductorMK2, IEnergyProviderMK2, IEnergyReceiverMK2, IPersistentNBT, SimpleComponent, IGUIProvider, IInfoProviderEC, CompatHandler.OCComponent {
 	
 	public long[] log = new long[20];
 	public long delta = 0;


### PR DESCRIPTION
In a merge pull request (402d54d669ef05f8fe65c702047f9f8b578c1b1c), commit (f58d97c007168c981376bfb22549adf900bfc3db) Energy storage block integration was removed in Open Computers with removing interface implementation, despite leaving all methods and anotations.
Just reverted little changes connected to it