### PR TITLE
Fix #1918 - RBMKs turning off when chunks unload, a world is quit, or a dimension unloads

### DIFF
--- a/src/main/java/com/hbm/blocks/machine/rbmk/RBMKBase.java
+++ b/src/main/java/com/hbm/blocks/machine/rbmk/RBMKBase.java
@@ -58,31 +58,31 @@ public abstract class RBMKBase extends BlockDummyable implements IToolable, ILoo
 	public int getOffset() {
 		return 0;
 	}
-	
+
 	public boolean openInv(World world, int x, int y, int z, EntityPlayer player) {
-		
+
 		if(world.isRemote) {
 			return true;
 		}
-		
+
 		int[] pos = this.findCore(world, x, y, z);
-		
+
 		if(pos == null)
 			return false;
-		
+
 		TileEntity te = world.getTileEntity(pos[0], pos[1], pos[2]);
-		
+
 		if(!(te instanceof TileEntityRBMKBase))
 			return false;
-		
+
 		TileEntityRBMKBase rbmk = (TileEntityRBMKBase) te;
-		
+
 		if(player.getHeldItem() != null && player.getHeldItem().getItem() instanceof ItemRBMKLid) {
-			
+
 			if(!rbmk.hasLid())
 				return false;
 		}
-		
+
 		if(!player.isSneaking()) {
 			FMLNetworkHandler.openGui(player, MainRegistry.instance, 0, world, pos[0], pos[1], pos[2]);
 			return true;
@@ -93,27 +93,27 @@ public abstract class RBMKBase extends BlockDummyable implements IToolable, ILoo
 
 	@Override
 	public AxisAlignedBB getCollisionBoundingBoxFromPool(World world, int x, int y, int z) {
-		
+
 		float height = 0.0F;
-		
+
 		int[] pos = this.findCore(world, x, y, z);
-		
+
 		if(pos != null) {
 			TileEntity te = world.getTileEntity(pos[0], pos[1], pos[2]);
-			
+
 			if(te instanceof TileEntityRBMKBase) {
-				
+
 				TileEntityRBMKBase rbmk = (TileEntityRBMKBase) te;
-				
+
 				if(rbmk.hasLid()) {
 					height += 0.25F;
 				}
 			}
 		}
-		
+
 		return AxisAlignedBB.getBoundingBox(x + this.minX, y + this.minY, z + this.minZ, x + this.maxX, y + this.maxY + height, z + this.maxZ);
 	}
-	
+
 	/*
 	 * NORTH: no cover
 	 * EAST: concrete cover
@@ -130,21 +130,21 @@ public abstract class RBMKBase extends BlockDummyable implements IToolable, ILoo
 		MultiblockHandlerXR.fillSpace(world, x + dir.offsetX * o, y + dir.offsetY * o, z + dir.offsetZ * o, getDimensions(world), this, dir);
 		this.makeExtra(world, x, y + RBMKDials.getColumnHeight(world), z);
 	}
-	
+
 	@Override
 	protected ForgeDirection getDirModified(ForgeDirection dir) {
 		return DIR_NO_LID;
 	}
-	
+
 	public int[] getDimensions(World world) {
 		return new int[] {RBMKDials.getColumnHeight(world), 0, 0, 0, 0, 0};
 	}
 
 	@Override
 	public void breakBlock(World world, int x, int y, int z, Block b, int i) {
-		
+
 		if(!world.isRemote && dropLids) {
-			
+
 			if(i == DIR_NORMAL_LID.ordinal() + offset) {
 				world.spawnEntityInWorld(new EntityItem(world, x + 0.5, y + 0.5 + RBMKDials.getColumnHeight(world), z + 0.5, new ItemStack(ModItems.rbmk_lid)));
 			}
@@ -152,32 +152,32 @@ public abstract class RBMKBase extends BlockDummyable implements IToolable, ILoo
 				world.spawnEntityInWorld(new EntityItem(world, x + 0.5, y + 0.5 + RBMKDials.getColumnHeight(world), z + 0.5, new ItemStack(ModItems.rbmk_lid_glass)));
 			}
 		}
-		
+
 		super.breakBlock(world, x, y, z, b, i);
 	}
-	
+
 	@Override
 	public boolean onScrew(World world, EntityPlayer player, int x, int y, int z, int side, float fX, float fY, float fZ, ToolType tool) {
-		
+
 		if(tool != ToolType.SCREWDRIVER)
 			return false;
-		
+
 		int[] pos = this.findCore(world, x, y, z);
-		
+
 		if(pos != null) {
 			TileEntity te = world.getTileEntity(pos[0], pos[1], pos[2]);
-			
+
 			if(te instanceof TileEntityRBMKBase) {
-				
+
 				TileEntityRBMKBase rbmk = (TileEntityRBMKBase) te;
 				int i = rbmk.getBlockMetadata();
-				
+
 				if(rbmk.hasLid() && rbmk.isLidRemovable()) {
 
-					RBMKNeutronNode node = (RBMKNeutronNode) NeutronNodeWorld.getNode(new BlockPos(te));
-					if (node != null)
+					RBMKNeutronNode node = (RBMKNeutronNode) NeutronNodeWorld.getNode(world, new BlockPos(te));
+					if(node != null)
 						node.removeLid();
-					
+
 					if(!world.isRemote) {
 						if(i == DIR_NORMAL_LID.ordinal() + offset) {
 							world.spawnEntityInWorld(new EntityItem(world, pos[0] + 0.5, pos[1] + 0.5 + RBMKDials.getColumnHeight(world), pos[2] + 0.5, new ItemStack(ModItems.rbmk_lid)));
@@ -185,15 +185,15 @@ public abstract class RBMKBase extends BlockDummyable implements IToolable, ILoo
 						if(i == DIR_GLASS_LID.ordinal() + offset) {
 							world.spawnEntityInWorld(new EntityItem(world, pos[0] + 0.5, pos[1] + 0.5 + RBMKDials.getColumnHeight(world), pos[2] + 0.5, new ItemStack(ModItems.rbmk_lid_glass)));
 						}
-						
-						world.setBlockMetadataWithNotify(pos[0], pos[1], pos[2], DIR_NO_LID.ordinal() + this.offset, 3);
+
+						world.setBlockMetadataWithNotify(pos[0], pos[1], pos[2], DIR_NO_LID.ordinal() + offset, 3);
 					}
-					
+
 					return true;
 				}
 			}
 		}
-		
+
 		return false;
 	}
 

--- a/src/main/java/com/hbm/handler/neutron/NeutronNodeWorld.java
+++ b/src/main/java/com/hbm/handler/neutron/NeutronNodeWorld.java
@@ -8,55 +8,94 @@ import java.util.HashMap;
 import java.util.List;
 
 public class NeutronNodeWorld {
-	// HashMap of all neutron nodes and their positions.
-	protected static HashMap<BlockPos, NeutronNode> nodeCache = new HashMap<>();
-
-	public static void addNode(NeutronNode node) {
-		nodeCache.put(node.pos, node);
-	}
-
-	public static void removeNode(BlockPos position) {
-		nodeCache.remove(position);
-	}
-
-	public static NeutronNode getNode(BlockPos position) {
-		return nodeCache.get(position);
-	}
-
-	public static void removeAllNodes() {
-		nodeCache.clear();
-	}
 
 	// List of all stream worlds.
 	public static HashMap<World, StreamWorld> streamWorlds = new HashMap<>();
 
+	public static NeutronNode getNode(World world, BlockPos pos) {
+		StreamWorld streamWorld = streamWorlds.get(world);
+		return streamWorld != null ? streamWorld.nodeCache.get(pos) : null;
+	}
+
+	public static void addNode(World world, NeutronNode node) {
+		StreamWorld streamWorld = getOrAddWorld(world);
+		streamWorld.nodeCache.put(node.pos, node);
+	}
+
+	public static void removeNode(World world, BlockPos pos) {
+		StreamWorld streamWorld = streamWorlds.get(world);
+		if(streamWorld == null) return;
+		streamWorld.removeNode(pos);
+	}
+
+	public static StreamWorld getOrAddWorld(World world) {
+		StreamWorld streamWorld = streamWorlds.get(world);
+		if(streamWorld == null) {
+			streamWorld = new StreamWorld();
+			streamWorlds.put(world, streamWorld);
+		}
+		return streamWorld;
+	}
+
+	public static void removeAllWorlds() {
+		streamWorlds.clear();
+	}
+
+	public static void removeEmptyWorlds() {
+		streamWorlds.values().removeIf((streamWorld) -> {
+			return streamWorld.streams.isEmpty();
+		});
+	}
+
 	public static class StreamWorld {
 
-		List<NeutronStream> streams;
+		private List<NeutronStream> streams;
+		private HashMap<BlockPos, NeutronNode> nodeCache = new HashMap<>();
 
 		public StreamWorld() {
 			streams = new ArrayList<>();
 		}
 
+		public void runStreamInteractions(World world) {
+			for(NeutronStream stream : streams) {
+				stream.runStreamInteraction(world);
+			}
+		}
+
 		public void addStream(NeutronStream stream) {
-			this.streams.add(stream);
+			streams.add(stream);
 		}
 
 		public void removeAllStreams() {
-			this.streams.clear();
+			streams.clear();
+		}
+
+		public void cleanNodes() {
+			List<BlockPos> toRemove = new ArrayList<>();
+			for(NeutronNode cachedNode : nodeCache.values()) {
+				if(cachedNode.type == NeutronStream.NeutronType.RBMK) {
+					RBMKNeutronHandler.RBMKNeutronNode node = (RBMKNeutronHandler.RBMKNeutronNode) cachedNode;
+					toRemove.addAll(node.checkNode());
+				}
+				/* TODO: actually do this and uncache pile nodes
+				if(cachedNode.type == NeutronStream.NeutronType.PILE) {
+					PileNeutronNode node = (PileNeutronNode) cachedNode;
+					toRemove.addAll(node.checkNode());
+				}
+				*/
+			}
+
+			for(BlockPos pos : toRemove) {
+				nodeCache.remove(pos);
+			}
+		}
+
+		public void removeNode(BlockPos pos) {
+			nodeCache.remove(pos);
 		}
 
 		public void removeAllStreamsOfType(NeutronStream.NeutronType type) {
-			List<NeutronStream> toRemove = new ArrayList<>();
-			for (NeutronStream stream : streams) {
-				if (stream.type == type)
-					toRemove.add(stream);
-			}
-			toRemove.forEach((stream) -> streams.remove(stream));
+			streams.removeIf(stream -> stream.type == type);
 		}
-	}
-
-	public static void removeAllWorlds() {
-		streamWorlds.clear();
 	}
 }

--- a/src/main/java/com/hbm/handler/neutron/NeutronStream.java
+++ b/src/main/java/com/hbm/handler/neutron/NeutronStream.java
@@ -3,7 +3,6 @@ package com.hbm.handler.neutron;
 import com.hbm.util.fauxpointtwelve.BlockPos;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
-import com.hbm.handler.neutron.NeutronNodeWorld.StreamWorld;
 
 import java.util.Iterator;
 
@@ -43,13 +42,8 @@ public abstract class NeutronStream {
 		this.fluxQuantity = flux;
 		this.fluxRatio = ratio;
 		this.type = type;
-		World worldObj = origin.tile.getWorldObj();
-		if (NeutronNodeWorld.streamWorlds.get(worldObj) == null) {
-			StreamWorld world = new StreamWorld();
-			world.addStream(this);
-			NeutronNodeWorld.streamWorlds.put(worldObj, world);
-		} else
-			NeutronNodeWorld.streamWorlds.get(worldObj).addStream(this);
+
+		NeutronNodeWorld.getOrAddWorld(origin.tile.getWorldObj()).addStream(this);
 	}
 
 	protected BlockPos posInstance;

--- a/src/main/java/com/hbm/handler/neutron/PileNeutronHandler.java
+++ b/src/main/java/com/hbm/handler/neutron/PileNeutronHandler.java
@@ -65,7 +65,7 @@ public class PileNeutronHandler {
 				TileEntity tile;
 
 				NeutronNode node = NeutronNodeWorld.getNode(worldObj, nodePos);
-				if(node != null) {
+				if(node != null && node instanceof PileNeutronNode) {
 					tile = node.tile;
 				} else {
 					tile = blockPosToTE(worldObj, nodePos);

--- a/src/main/java/com/hbm/handler/neutron/PileNeutronHandler.java
+++ b/src/main/java/com/hbm/handler/neutron/PileNeutronHandler.java
@@ -28,9 +28,8 @@ public class PileNeutronHandler {
 
 	public static PileNeutronNode makeNode(TileEntityPileBase tile) {
 		BlockPos pos = new BlockPos(tile);
-		if (NeutronNodeWorld.nodeCache.containsKey(pos))
-			return (PileNeutronNode) NeutronNodeWorld.getNode(pos);
-		return new PileNeutronNode(tile);
+		PileNeutronNode node = (PileNeutronNode) NeutronNodeWorld.getNode(tile.getWorldObj(), pos);
+		return node != null ? node : new PileNeutronNode(tile);
 	}
 
 	private static TileEntity blockPosToTE(World worldObj, BlockPos pos) {
@@ -43,6 +42,7 @@ public class PileNeutronHandler {
 			super(origin, vector, flux, 0D, NeutronType.PILE);
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
 		public void runStreamInteraction(World worldObj) {
 
@@ -51,27 +51,29 @@ public class PileNeutronHandler {
 
 			for(float i = 1; i <= range; i += 0.5F) {
 
-				BlockPos node = new BlockPos(
+				BlockPos nodePos = new BlockPos(
 						(int)Math.floor(pos.getX() + 0.5 + vector.xCoord * i),
 						(int)Math.floor(pos.getY() + 0.5 + vector.yCoord * i),
 						(int)Math.floor(pos.getZ() + 0.5 + vector.zCoord * i)
 				);
 
-				if(node.equals(pos))
+				if(nodePos.equals(pos))
 					continue; // don't interact with itself!
 
-				pos.mutate(node.getX(), node.getY(), node.getZ());
+				pos.mutate(nodePos.getX(), nodePos.getY(), nodePos.getZ());
 
 				TileEntity tile;
 
-				if (NeutronNodeWorld.nodeCache.containsKey(node))
-					tile = NeutronNodeWorld.nodeCache.get(node).tile;
-				else {
-					tile = blockPosToTE(worldObj, node);
-					if (tile == null)
-						return; // Doesn't exist!
-					if (tile instanceof TileEntityPileBase)
-						NeutronNodeWorld.addNode(new PileNeutronNode((TileEntityPileBase) tile));
+				NeutronNode node = NeutronNodeWorld.getNode(worldObj, nodePos);
+				if(node != null) {
+					tile = node.tile;
+				} else {
+					tile = blockPosToTE(worldObj, nodePos);
+					if(tile == null) return;
+
+					if(tile instanceof TileEntityPileBase) {
+						NeutronNodeWorld.addNode(worldObj, new PileNeutronNode((TileEntityPileBase) tile));
+					}
 				}
 
 				Block block = tile.getBlockType();
@@ -79,17 +81,17 @@ public class PileNeutronHandler {
 				if(!(tile instanceof TileEntityPileBase)) {
 
 					// Return when a boron block is hit
-					if (block == ModBlocks.block_boron)
+					if(block == ModBlocks.block_boron)
 						return;
 
-					else if (block == ModBlocks.concrete ||
+					else if(block == ModBlocks.concrete ||
 						block == ModBlocks.concrete_smooth ||
 						block == ModBlocks.concrete_asbestos ||
 						block == ModBlocks.concrete_colored ||
 						block == ModBlocks.brick_concrete)
 						fluxQuantity *= 0.25;
 
-					if (block == ModBlocks.block_graphite_rod && (meta & 8) == 0)
+					if(block == ModBlocks.block_graphite_rod && (meta & 8) == 0)
 						return;
 				}
 
@@ -102,9 +104,9 @@ public class PileNeutronHandler {
 						return;
 				}
 
-				int x = (int) (node.getX() + 0.5);
-				int y = (int) (node.getY() + 0.5);
-				int z = (int) (node.getZ() + 0.5);
+				int x = (int) (nodePos.getX() + 0.5);
+				int y = (int) (nodePos.getY() + 0.5);
+				int z = (int) (nodePos.getZ() + 0.5);
 				List<EntityLivingBase> entities = worldObj.getEntitiesWithinAABB(EntityLivingBase.class, AxisAlignedBB.getBoundingBox(x, y, z, x, y, z));
 
 				if(entities != null)

--- a/src/main/java/com/hbm/handler/neutron/RBMKNeutronHandler.java
+++ b/src/main/java/com/hbm/handler/neutron/RBMKNeutronHandler.java
@@ -222,7 +222,7 @@ public class RBMKNeutronHandler {
 				pos.mutate(origin.tile.xCoord + x, origin.tile.yCoord, origin.tile.zCoord + z);
 
 				NeutronNode node = NeutronNodeWorld.getNode(world, pos);
-				if(node != null) {
+				if(node != null && node instanceof RBMKNeutronNode) {
 					positions[i - 1] = node;
 				} else if(this.origin.tile.getBlockType() instanceof RBMKBase) {
 					TileEntity te = blockPosToTE(world, pos);
@@ -292,7 +292,7 @@ public class RBMKNeutronHandler {
 
 				RBMKType type = (RBMKType) targetNode.data.get("type");
 
-				if(type == RBMKType.OTHER) // pass right on by!
+				if(type == RBMKType.OTHER || type == null) // pass right on by!
 					continue;
 
 				// we established earlier during `getNodes()` that they should all be RBMKBase TEs

--- a/src/main/java/com/hbm/handler/neutron/RBMKNeutronHandler.java
+++ b/src/main/java/com/hbm/handler/neutron/RBMKNeutronHandler.java
@@ -39,9 +39,8 @@ public class RBMKNeutronHandler {
 
 	public static RBMKNeutronNode makeNode(TileEntityRBMKBase tile) {
 		BlockPos pos = new BlockPos(tile);
-		if (NeutronNodeWorld.nodeCache.containsKey(pos))
-			return (RBMKNeutronNode) NeutronNodeWorld.getNode(pos);
-		return new RBMKNeutronNode(tile, tile.getRBMKType(), tile.hasLid());
+		RBMKNeutronNode node = (RBMKNeutronNode) NeutronNodeWorld.getNode(tile.getWorldObj(), pos);
+		return node != null ? node : new RBMKNeutronNode(tile, tile.getRBMKType(), tile.hasLid());
 	}
 
 	public static class RBMKNeutronNode extends NeutronNode {
@@ -79,16 +78,16 @@ public class RBMKNeutronHandler {
 
 				@Override
 				public BlockPos next() {
-					if (Math.pow(x, 2) + Math.pow(z, 2) <= fluxRange * fluxRange) {
+					if(Math.pow(x, 2) + Math.pow(z, 2) <= fluxRange * fluxRange) {
 						z++;
-						if (z > fluxRange) {
+						if(z > fluxRange) {
 							z = -fluxRange;
 							x++;
 						}
 						return posInstance.mutate(tile.xCoord + x, tile.yCoord, tile.zCoord + z);
 					} else {
 						z++;
-						if (z > fluxRange) {
+						if(z > fluxRange) {
 							z = -fluxRange;
 							x++;
 						}
@@ -102,23 +101,24 @@ public class RBMKNeutronHandler {
 			List<BlockPos> list = new ArrayList<>();
 
 			BlockPos pos = new BlockPos(this.tile);
+			World world = tile.getWorldObj();
 
 			RBMKNeutronStream[] streams = new RBMKNeutronStream[TileEntityRBMKRod.fluxDirs.length];
 
 			// Simulate streams coming out of the RBMK rod.
 			ForgeDirection[] fluxDirs = TileEntityRBMKRod.fluxDirs;
-			for (int i = 0; i < fluxDirs.length; i++) {
+			for(int i = 0; i < fluxDirs.length; i++) {
 				streams[i] = (new RBMKNeutronStream(this, Vec3.createVectorHelper(fluxDirs[i].offsetX, 0, fluxDirs[i].offsetZ)));
 			}
 
 			// Check if the rod should uncache nodes.
-			if (tile instanceof TileEntityRBMKRod && !(tile instanceof TileEntityRBMKRodReaSim)) {
+			if(tile instanceof TileEntityRBMKRod && !(tile instanceof TileEntityRBMKRodReaSim)) {
 				TileEntityRBMKRod rod = (TileEntityRBMKRod) tile;
-				if (!rod.hasRod || rod.lastFluxQuantity == 0) {
+				if(!rod.hasRod || rod.lastFluxQuantity == 0) {
 
-					for (RBMKNeutronStream stream : streams) {
-						for(RBMKNeutronNode node : stream.getNodes(false))
-							if (node != null)
+					for(RBMKNeutronStream stream : streams) {
+						for(NeutronNode node : stream.getNodes(false))
+							if(node != null)
 								list.add(new BlockPos(node.tile));
 					}
 
@@ -130,11 +130,11 @@ public class RBMKNeutronHandler {
 				Iterator<BlockPos> reaSimNodes = getReaSimNodes();
 
 				// Check if the ReaSim rod should be culled from the cache due to no rod or no flux.
-				if (tile instanceof TileEntityRBMKRodReaSim) { // fuckkkkkkk
+				if(tile instanceof TileEntityRBMKRodReaSim) { // fuckkkkkkk
 					TileEntityRBMKRodReaSim rod = (TileEntityRBMKRodReaSim) tile;
-					if (!rod.hasRod || rod.lastFluxQuantity == 0) {
+					if(!rod.hasRod || rod.lastFluxQuantity == 0) {
 						reaSimNodes.forEachRemaining((a) -> {
-							if (a != null)
+							if(a != null)
 								list.add(a.clone()); // ae The RAM usage will be really high here but hopefully the GC can take care of it :pray:
 						});
 						return list;
@@ -155,32 +155,32 @@ public class RBMKNeutronHandler {
 					if(nodePos == null)
 						continue;
 
-					NeutronNode node = NeutronNodeWorld.nodeCache.get(nodePos);
+					NeutronNode node = NeutronNodeWorld.getNode(world, nodePos);
 
-					if (node != null && node.tile instanceof TileEntityRBMKRod) {
+					if(node != null && node.tile instanceof TileEntityRBMKRod) {
 
 						TileEntityRBMKRod rod = (TileEntityRBMKRod) node.tile;
 
-						if (rod.hasRod && rod.lastFluxQuantity > 0) {
+						if(rod.hasRod && rod.lastFluxQuantity > 0) {
 							hasRod = true;
 							break;
 						}
 					}
 				}
 
-				if (!hasRod) {
+				if(!hasRod) {
 					list.add(pos);
 					return list;
 				}
 			}
 
 			// Check if non-rod nodes should be uncached due to no rod in range.
-			for (RBMKNeutronStream stream : streams) {
+			for(RBMKNeutronStream stream : streams) {
 
-				RBMKNeutronNode[] nodes = stream.getNodes(false);
+				NeutronNode[] nodes = stream.getNodes(false);
 
-				for (RBMKNeutronNode node : nodes) {
-					if (!(node == null) && node.tile instanceof TileEntityRBMKRod)
+				for(NeutronNode node : nodes) {
+					if(!(node == null) && node.tile instanceof TileEntityRBMKRod)
 						return list;
 				}
 			}
@@ -209,28 +209,28 @@ public class RBMKNeutronHandler {
 
 		// Does NOT include the origin node
 		// USES THE CACHE!!!
-		public RBMKNeutronNode[] getNodes(boolean addNode) {
-			RBMKNeutronNode[] positions = new RBMKNeutronNode[fluxRange];
+		public NeutronNode[] getNodes(boolean addNode) {
+			NeutronNode[] positions = new RBMKNeutronNode[fluxRange];
 
 			BlockPos pos = new BlockPos(origin.tile);
+			World world = origin.tile.getWorldObj();
 
-			for (int i = 1; i <= fluxRange; i++) {
+			for(int i = 1; i <= fluxRange; i++) {
 				int x = (int) Math.floor(0.5 + vector.xCoord * i);
 				int z = (int) Math.floor(0.5 + vector.zCoord * i);
 
 				pos.mutate(origin.tile.xCoord + x, origin.tile.yCoord, origin.tile.zCoord + z);
 
-				if (NeutronNodeWorld.nodeCache.containsKey(pos))
-					positions[i - 1] = (RBMKNeutronNode) NeutronNodeWorld.getNode(pos);
-
-				else if (this.origin.tile.getBlockType() instanceof RBMKBase) {
-					TileEntity te = blockPosToTE(this.origin.tile.getWorldObj(), pos);
-					if (te instanceof TileEntityRBMKBase) {
+				NeutronNode node = NeutronNodeWorld.getNode(world, pos);
+				if(node != null) {
+					positions[i - 1] = node;
+				} else if(this.origin.tile.getBlockType() instanceof RBMKBase) {
+					TileEntity te = blockPosToTE(world, pos);
+					if(te instanceof TileEntityRBMKBase) {
 						TileEntityRBMKBase rbmkBase = (TileEntityRBMKBase) te;
-						RBMKNeutronNode node = makeNode(rbmkBase);
+						node = makeNode(rbmkBase);
 						positions[i - 1] = node;
-						if (addNode)
-							NeutronNodeWorld.addNode(node);
+						if(addNode) NeutronNodeWorld.addNode(world, node);
 					}
 				}
 			}
@@ -241,20 +241,21 @@ public class RBMKNeutronHandler {
 		public void runStreamInteraction(World worldObj) {
 
 			// do nothing if there's nothing to do lmao
-			if (fluxQuantity == 0D)
+			if(fluxQuantity == 0D)
 				return;
 
 			BlockPos pos = new BlockPos(origin.tile);
 
 			TileEntityRBMKBase originTE;
 
-			if (NeutronNodeWorld.nodeCache.containsKey(pos))
-				originTE = (TileEntityRBMKBase) NeutronNodeWorld.nodeCache.get(pos).tile;
-			else {
+			NeutronNode node = NeutronNodeWorld.getNode(worldObj, pos);
+			if(node != null) {
+				originTE = (TileEntityRBMKBase) node.tile;
+			} else {
 				originTE = (TileEntityRBMKBase) blockPosToTE(worldObj, pos);
-				if (originTE == null)
-					return; // Doesn't exist anymore!
-				NeutronNodeWorld.addNode(new RBMKNeutronNode(originTE, originTE.getRBMKType(), originTE.hasLid()));
+				if(originTE == null) return; // Doesn't exist anymore!
+
+				NeutronNodeWorld.addNode(worldObj, new RBMKNeutronNode(originTE, originTE.getRBMKType(), originTE.hasLid()));
 			}
 
 			int moderatedCount = 0;
@@ -263,23 +264,22 @@ public class RBMKNeutronHandler {
 
 			while(iterator.hasNext()) {
 
-				BlockPos nodePos = iterator.next();
+				BlockPos targetPos = iterator.next();
 
-				if (fluxQuantity == 0D) // Whoops, used it all up!
+				if(fluxQuantity == 0D) // Whoops, used it all up!
 					return;
 
-				RBMKNeutronNode node;
-
-				if (!NeutronNodeWorld.nodeCache.containsKey(nodePos)) {
-					TileEntity te = blockPosToTE(worldObj, nodePos); // ok, maybe it didn't get added to the list somehow??
-					if (te instanceof TileEntityRBMKBase) {
-						node = makeNode((TileEntityRBMKBase) te);
-						NeutronNodeWorld.addNode(node); // whoops!
+				NeutronNode targetNode = NeutronNodeWorld.getNode(worldObj, targetPos);
+				if(targetNode == null) {
+					TileEntity te = blockPosToTE(worldObj, targetPos); // ok, maybe it didn't get added to the list somehow??
+					if(te instanceof TileEntityRBMKBase) {
+						targetNode = makeNode((TileEntityRBMKBase) te);
+						NeutronNodeWorld.addNode(worldObj, targetNode); // whoops!
 					} else {
-						int hits = getHits(nodePos); // Get the amount of hits on blocks.
-						if (hits == columnHeight) // If stream is fully blocked.
+						int hits = getHits(targetPos); // Get the amount of hits on blocks.
+						if(hits == columnHeight) // If stream is fully blocked.
 							return;
-						else if (hits > 0) { // If stream is partially blocked.
+						else if(hits > 0) { // If stream is partially blocked.
 							irradiateFromFlux(pos, hits);
 							fluxQuantity *= 1 - ((double) hits / columnHeight); // Inverse to get partial blocking by blocks.
 							continue;
@@ -290,81 +290,79 @@ public class RBMKNeutronHandler {
 					}
 				}
 
-				node = (RBMKNeutronNode) NeutronNodeWorld.nodeCache.get(nodePos);
+				RBMKType type = (RBMKType) targetNode.data.get("type");
 
-				RBMKType type = (RBMKType) node.data.get("type");
-
-				if (type == RBMKType.OTHER) // pass right on by!
+				if(type == RBMKType.OTHER) // pass right on by!
 					continue;
 
 				// we established earlier during `getNodes()` that they should all be RBMKBase TEs
 				// no issue with casting here!
-				TileEntityRBMKBase nodeTE = (TileEntityRBMKBase) node.tile;
+				TileEntityRBMKBase nodeTE = (TileEntityRBMKBase) targetNode.tile;
 
-				if (!(boolean) node.data.get("hasLid"))
-					ChunkRadiationManager.proxy.incrementRad(worldObj, nodePos.getX(), nodePos.getY(), nodePos.getZ(), (float) (this.fluxQuantity * 0.05F));
+				if(!(boolean) targetNode.data.get("hasLid"))
+					ChunkRadiationManager.proxy.incrementRad(worldObj, targetPos.getX(), targetPos.getY(), targetPos.getZ(), (float) (this.fluxQuantity * 0.05F));
 
-				if (type == RBMKType.MODERATOR || nodeTE.isModerated()) {
+				if(type == RBMKType.MODERATOR || nodeTE.isModerated()) {
 					moderatedCount++;
 					moderateStream();
 				}
 
-				if (nodeTE instanceof IRBMKFluxReceiver) {
+				if(nodeTE instanceof IRBMKFluxReceiver) {
 					IRBMKFluxReceiver column = (IRBMKFluxReceiver) nodeTE;
 
-					if (type == RBMKType.ROD) {
+					if(type == RBMKType.ROD) {
 						TileEntityRBMKRod rod = (TileEntityRBMKRod) column;
 
-						if (rod.hasRod) {
+						if(rod.hasRod) {
 							rod.receiveFlux(this);
 							return;
 						}
 
-					} else if (type == RBMKType.OUTGASSER) {
+					} else if(type == RBMKType.OUTGASSER) {
 						TileEntityRBMKOutgasser outgasser = ((TileEntityRBMKOutgasser) column);
 
-						if (outgasser.canProcess()) {
+						if(outgasser.canProcess()) {
 							column.receiveFlux(this);
 							return;
 						}
 					}
 
-				} else if (type == RBMKType.CONTROL_ROD) {
+				} else if(type == RBMKType.CONTROL_ROD) {
 					TileEntityRBMKControl rod = (TileEntityRBMKControl) nodeTE;
 
-					if (rod.level > 0.0D) {
+					if(rod.level > 0.0D) {
 
 						this.fluxQuantity *= rod.getMult();
 						continue;
 					}
 					return;
-				} else if (type == RBMKType.REFLECTOR) {
+				} else if(type == RBMKType.REFLECTOR) {
 
-					if (((TileEntityRBMKBase) this.origin.tile).isModerated())
+					if(((TileEntityRBMKBase) this.origin.tile).isModerated())
 						moderatedCount++;
 
-					if (this.fluxRatio > 0 && moderatedCount > 0)
-						for (int i = 0; i < moderatedCount; i++)
+					if(this.fluxRatio > 0 && moderatedCount > 0)
+						for(int i = 0; i < moderatedCount; i++)
 							moderateStream();
 
-					if (reflectorEfficiency != 1.0D) {
+					if(reflectorEfficiency != 1.0D) {
 						this.fluxQuantity *= reflectorEfficiency;
 						continue;
 					}
 
 					((TileEntityRBMKRod) originTE).receiveFlux(this);
 					return;
-				} else if (type == RBMKType.ABSORBER) {
-					if (absorberEfficiency == 1)
+				} else if(type == RBMKType.ABSORBER) {
+					if(absorberEfficiency == 1)
 						return;
 
 					this.fluxQuantity *= absorberEfficiency;
 				}
 			}
 
-			RBMKNeutronNode[] nodes = getNodes(true);
+			NeutronNode[] nodes = getNodes(true);
 
-			RBMKNeutronNode lastNode = nodes[(nodes.length - 1)];
+			NeutronNode lastNode = nodes[(nodes.length - 1)];
 
 			if(lastNode == null) { // This implies that there was *no* last node, meaning either way it was never caught.
 				// There is really no good way to figure out where exactly it should irradiate, so just irradiate at the origin tile.
@@ -374,9 +372,9 @@ public class RBMKNeutronHandler {
 
 			RBMKType lastNodeType = (RBMKType) lastNode.data.get("type");
 
-			if (lastNodeType == RBMKType.CONTROL_ROD) {
+			if(lastNodeType == RBMKType.CONTROL_ROD) {
 				TileEntityRBMKControl rod = (TileEntityRBMKControl) lastNode.tile;
-				if (rod.getMult() > 0.0D) {
+				if(rod.getMult() > 0.0D) {
 					this.fluxQuantity *= rod.getMult();
 					irradiateFromFlux(new BlockPos(lastNode.tile.xCoord + this.vector.xCoord, lastNode.tile.yCoord, lastNode.tile.zCoord + this.vector.zCoord));
 				}
@@ -392,7 +390,7 @@ public class RBMKNeutronHandler {
 				// I FUCKING HATE THIS
 				// total count of bugs fixed attributed to this function: 13
 				Block block = origin.tile.getWorldObj().getBlock(pos.getX(), pos.getY() + h, pos.getZ());
-				if (block.isOpaqueCube())
+				if(block.isOpaqueCube())
 					hits += 1;
 			}
 

--- a/src/main/java/com/hbm/items/machine/ItemRBMKLid.java
+++ b/src/main/java/com/hbm/items/machine/ItemRBMKLid.java
@@ -20,46 +20,46 @@ public class ItemRBMKLid extends Item {
 
 	@Override
 	public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float fx, float fy, float fz) {
-		
+
 		Block b = world.getBlock(x, y, z);
-		
+
 		if(b instanceof RBMKBase) {
 			RBMKBase rbmk = (RBMKBase) b;
-			
+
 			int[] pos = rbmk.findCore(world, x, y, z);
-			
+
 			if(pos == null)
 				return false;
-			
+
 			TileEntity te = world.getTileEntity(pos[0], pos[1], pos[2]);
-			
+
 			if(!(te instanceof TileEntityRBMKBase))
 				return false;
-			
+
 			TileEntityRBMKBase tile = (TileEntityRBMKBase) te;
-			
+
 			if(tile.hasLid())
 				return false;
 
-			RBMKNeutronNode node = (RBMKNeutronNode) NeutronNodeWorld.getNode(new BlockPos(te));
-			if (node != null)
+			RBMKNeutronNode node = (RBMKNeutronNode) NeutronNodeWorld.getNode(world, new BlockPos(te));
+			if(node != null)
 				node.addLid();
 
 			int meta = RBMKBase.DIR_NORMAL_LID.ordinal();
-			
+
 			if(this == ModItems.rbmk_lid_glass) {
 				meta = RBMKBase.DIR_GLASS_LID.ordinal();
 				world.playSoundEffect(x + 0.5, y + 0.5, z + 0.5, Blocks.glass.stepSound.func_150496_b(), (Blocks.glass.stepSound.getVolume() + 1.0F) / 2.0F, Blocks.glass.stepSound.getPitch() * 0.8F);
 			} else {
 				world.playSoundEffect(x + 0.5, y + 0.5, z + 0.5, ModBlocks.concrete_smooth.stepSound.func_150496_b(), (ModBlocks.concrete_smooth.stepSound.getVolume() + 1.0F) / 2.0F, ModBlocks.concrete_smooth.stepSound.getPitch() * 0.8F);
 			}
-			
+
 			world.setBlockMetadataWithNotify(pos[0], pos[1], pos[2], meta + RBMKBase.offset, 3);
 			stack.stackSize--;
-			
+
 			return true;
 		}
-		
+
 		return false;
 	}
 }

--- a/src/main/java/com/hbm/main/ModEventHandler.java
+++ b/src/main/java/com/hbm/main/ModEventHandler.java
@@ -566,8 +566,7 @@ public class ModEventHandler {
 
 	@SubscribeEvent
 	public void onUnload(WorldEvent.Unload event) {
-		NeutronNodeWorld.removeAllWorlds(); // Remove world from worlds when unloaded to avoid world issues.
-		NeutronNodeWorld.removeAllNodes(); // Remove all nodes.
+		NeutronNodeWorld.streamWorlds.remove(event.world);
 	}
 
 	public static boolean didSit = false;

--- a/src/main/java/com/hbm/tileentity/machine/pile/TileEntityPileBase.java
+++ b/src/main/java/com/hbm/tileentity/machine/pile/TileEntityPileBase.java
@@ -17,25 +17,30 @@ public abstract class TileEntityPileBase extends TileEntity {
 	@Override
 	public void invalidate() {
 		super.invalidate();
+		NeutronNodeWorld.removeNode(worldObj, new BlockPos(this));
+	}
 
-		NeutronNodeWorld.removeNode(new BlockPos(this));
+	@Override
+	public void onChunkUnload() {
+		super.onChunkUnload();
+		NeutronNodeWorld.removeNode(worldObj, new BlockPos(this));
 	}
 
 	protected void castRay(int flux) {
 
 		BlockPos pos = new BlockPos(this);
 
-		if (flux == 0) {
+		if(flux == 0) {
 			// simple way to remove the node from the cache when no flux is going into it!
-			NeutronNodeWorld.removeNode(pos);
+			NeutronNodeWorld.removeNode(worldObj, pos);
 			return;
 		}
 
-		PileNeutronNode node = (PileNeutronNode) NeutronNodeWorld.getNode(pos);
+		PileNeutronNode node = (PileNeutronNode) NeutronNodeWorld.getNode(worldObj, pos);
 
 		if(node == null) {
 			node = PileNeutronHandler.makeNode(this);
-			NeutronNodeWorld.addNode(node);
+			NeutronNodeWorld.addNode(worldObj, node);
 		}
 
 		Vec3 neutronVector = Vec3.createVectorHelper(1, 0, 0);

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKRodReaSim.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKRodReaSim.java
@@ -28,22 +28,22 @@ public class TileEntityRBMKRodReaSim extends TileEntityRBMKRod {
 		if(pos == null)
 			pos = new BlockPos(this);
 
-		if (flux == 0) {
+		if(flux == 0) {
 			// simple way to remove the node from the cache when no flux is going into it!
-			NeutronNodeWorld.removeNode(pos);
+			NeutronNodeWorld.removeNode(worldObj, pos);
 			return;
 		}
 
-		RBMKNeutronNode node = (RBMKNeutronNode) NeutronNodeWorld.getNode(pos);
+		RBMKNeutronNode node = (RBMKNeutronNode) NeutronNodeWorld.getNode(worldObj, pos);
 
 		if(node == null) {
 			node = makeNode(this);
-			NeutronNodeWorld.addNode(node);
+			NeutronNodeWorld.addNode(worldObj, node);
 		}
 
 		int count = RBMKDials.getReaSimCount(worldObj);
 
-		for (int i = 0; i < count; i++) {
+		for(int i = 0; i < count; i++) {
 			Vec3 neutronVector = Vec3.createVectorHelper(1, 0, 0);
 
 			neutronVector.rotateAroundY((float)(Math.PI * 2D * worldObj.rand.nextDouble()));

--- a/src/main/java/com/hbm/world/gen/NTMWorldGenerator.java
+++ b/src/main/java/com/hbm/world/gen/NTMWorldGenerator.java
@@ -40,25 +40,25 @@ public class NTMWorldGenerator implements IWorldGenerator {
 		NBTStructure.registerStructure(0, new SpawnCondition() {{
 			canSpawn = biome -> !invalidBiomes.contains(biome);
 			start = d -> new MapGenNTMFeatures.Start(d.getW(), d.getX(), d.getY(), d.getZ());
-			spawnWeight = 14;
+			spawnWeight = 14 * 4;
 		}});
 
 		NBTStructure.registerStructure(0, new SpawnCondition() {{
 			canSpawn = biome -> !invalidBiomes.contains(biome);
 			start = d -> new BunkerStart(d.getW(), d.getX(), d.getY(), d.getZ());
-			spawnWeight = 1;
+			spawnWeight = 1 * 4;
 		}});
 
 		NBTStructure.registerStructure(0, new SpawnCondition() {{
 			canSpawn = biome -> !biome.canSpawnLightningBolt() && biome.temperature >= 2F;
 			structure = new JigsawPiece("vertibird", StructureManager.vertibird);
-			spawnWeight = 3;
+			spawnWeight = 3 * 4;
 		}});
 
 		NBTStructure.registerStructure(0, new SpawnCondition() {{
 			canSpawn = biome -> !biome.canSpawnLightningBolt() && biome.temperature >= 2F;
 			structure = new JigsawPiece("crashed_vertibird", StructureManager.crashed_vertibird);
-			spawnWeight = 3;
+			spawnWeight = 3 * 4;
 		}});
 
 		Map<Block, BlockSelector> bricks = new HashMap<Block, BlockSelector>() {{


### PR DESCRIPTION
Make sure node caching is per world, remove nodes from cache correctly, and prevent unloading dimensions immediately ceasing all reactivity.

Also fixes rod information not updating unless the GUI is open.

gam gam please double check my work thx