### PR TITLE
spent casings prrrrrr!!!

### DIFF
--- a/src/main/java/com/hbm/handler/CasingEjector.java
+++ b/src/main/java/com/hbm/handler/CasingEjector.java
@@ -94,7 +94,7 @@ public class CasingEjector implements Cloneable {
 	@SideOnly(Side.CLIENT)
 	public void spawnCasing(TextureManager textureManager, SpentCasing config, World world, double x, double y, double z, float pitch, float yaw, boolean crouched) {
 		Vec3 rotatedMotionVec = rotateVector(getMotion(), pitch + (float) rand.nextGaussian() * getPitchFactor(), yaw + (float) rand.nextGaussian() * getPitchFactor(), getPitchFactor(), getPitchFactor());
-		ParticleSpentCasing casing = new ParticleSpentCasing(textureManager, world, x, y, z, rotatedMotionVec.xCoord, rotatedMotionVec.yCoord, rotatedMotionVec.zCoord, (float) (getPitchFactor() * rand.nextGaussian()), (float) (getYawFactor() * rand.nextGaussian()), config, false, 0, 0, 0);
+		ParticleSpentCasing casing = new ParticleSpentCasing(textureManager, world, x, y, z, rotatedMotionVec.xCoord, rotatedMotionVec.yCoord, rotatedMotionVec.zCoord, (float) (world.rand.nextGaussian() * 5F), (float) (world.rand.nextGaussian() * 10F), config, false, 0, 0, 0);
 
 		offsetCasing(casing, getOffset(), pitch, yaw, crouched);
 

--- a/src/main/java/com/hbm/handler/guncfg/GunCannonFactory.java
+++ b/src/main/java/com/hbm/handler/guncfg/GunCannonFactory.java
@@ -13,7 +13,7 @@ public class GunCannonFactory {
 	protected static SpentCasing CASINNG240MM;
 	
 	static {
-		CASINNG240MM = new SpentCasing(CasingType.BOTTLENECK).setScale(7.5F).setBounceMotion(0.02F, 0.05F).setColor(SpentCasing.COLOR_CASE_BRASS).setupSmoke(1F, 0.5D, 60, 20);
+		CASINNG240MM = new SpentCasing(CasingType.BOTTLENECK).setScale(7.5F).setBounceMotion(0.5F, 0.5F).setColor(SpentCasing.COLOR_CASE_BRASS).setupSmoke(1F, 0.5D, 60, 20);
 	}
 
 	public static BulletConfiguration getShellConfig() {

--- a/src/main/java/com/hbm/handler/guncfg/GunDGKFactory.java
+++ b/src/main/java/com/hbm/handler/guncfg/GunDGKFactory.java
@@ -8,7 +8,7 @@ public class GunDGKFactory {
 	public static final SpentCasing CASINGDGK;
 
 	static {
-		CASINGDGK = new SpentCasing(CasingType.STRAIGHT).setScale(1.5F).setBounceMotion(0.05F, 0.02F).setColor(SpentCasing.COLOR_CASE_BRASS).register("DGK").setupSmoke(0.02F, 0.5D, 60, 20).setMaxAge(60); //3 instead of 12 seconds
+		CASINGDGK = new SpentCasing(CasingType.STRAIGHT).setScale(1.5F).setBounceMotion(1F, 0.5F).setColor(SpentCasing.COLOR_CASE_BRASS).register("DGK").setupSmoke(0.02F, 0.5D, 60, 20).setMaxAge(60); //3 instead of 12 seconds
 	}
 
 	/*public static BulletConfiguration getDGKConfig() {

--- a/src/main/java/com/hbm/items/weapon/ItemAmmoArty.java
+++ b/src/main/java/com/hbm/items/weapon/ItemAmmoArty.java
@@ -184,7 +184,7 @@ public class ItemAmmoArty extends Item {
 		return "item." + itemTypes[Math.abs(stack.getItemDamage()) % itemTypes.length].name;
 	}
 	
-	protected static SpentCasing SIXTEEN_INCH_CASE = new SpentCasing(CasingType.STRAIGHT).setScale(15F, 15F, 10F).setupSmoke(1F, 1D, 200, 60).setMaxAge(300);
+	protected static SpentCasing SIXTEEN_INCH_CASE = new SpentCasing(CasingType.STRAIGHT).setScale(15F, 15F, 10F).setupSmoke(1F, 1D, 200, 60).setMaxAge(300).setBounceMotion(1F, 0.5F);
 	
 	public abstract class ArtilleryShell {
 		

--- a/src/main/java/com/hbm/items/weapon/sedna/factory/GunFactory.java
+++ b/src/main/java/com/hbm/items/weapon/sedna/factory/GunFactory.java
@@ -21,7 +21,7 @@ public class GunFactory {
 
 	public static BulletConfig ammo_debug;
 	
-	public static SpentCasing CASING44 = new SpentCasing(CasingType.STRAIGHT).setScale(1.5F, 1.0F, 1.5F).setBounceMotion(0.01F, 0.05F).setColor(SpentCasing.COLOR_CASE_44);
+	public static SpentCasing CASING44 = new SpentCasing(CasingType.STRAIGHT).setScale(1.5F, 1.0F, 1.5F).setColor(SpentCasing.COLOR_CASE_44);
 
 	public static void init() {
 		

--- a/src/main/java/com/hbm/items/weapon/sedna/factory/Orchestras.java
+++ b/src/main/java/com/hbm/items/weapon/sedna/factory/Orchestras.java
@@ -173,7 +173,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 14) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.5, -0.125, aiming ? -0.125 : -0.375D, 0, 0.12, -0.12, 0.01, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.5, -0.125, aiming ? -0.125 : -0.375D, 0, 0.12, -0.12, 0.01, 12.5F, 1.5F, casing.getName(), true, 60, 0.5D, 20);
 			}
 			if(timer == 12) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.leverCock", 1F, 1F);
 		}
@@ -244,7 +244,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 14) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, -0.125, aiming ? -0.125 : -0.375D, 0, 0.18, -0.12, 0.01, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, -0.125, aiming ? -0.125 : -0.375D, 0, 0.18, -0.12, 0.01, 12.5F, 2.5F, casing.getName(), true, 60, 0.5D, 20);
 			}
 			if(timer == 8) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.leverCock", 1F, 0.8F);
 		}
@@ -279,7 +279,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 14) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, -0.125, aiming ? -0.125 : -0.375D, 0, -0.08, 0, 0.01, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, -0.125, aiming ? -0.125 : -0.375D, 0, -0.08, 0, 0.01, 17.5F, 2.5F, casing.getName(), true, 60, 0.5D, 20);
 			}
 			if(timer == 8) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.leverCock", 1F, 0.8F);
 		}
@@ -300,7 +300,7 @@ public class Orchestras {
 			if(timer == 14) {
 				int offset = ctx.configIndex == 0 ? -1 : 1;
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, -0.125, aiming ? -0.125 * offset : -0.375D * offset, 0, -0.08, 0, 0.01, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, -0.125, aiming ? -0.125 * offset : -0.375D * offset, 0, -0.08, 0, 0.01, 17.5F, 2.5F, casing.getName(), true, 60, 0.5D, 20);
 			}
 			if(timer == 8) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.leverCock", 1F, 0.8F);
 			return;
@@ -358,7 +358,7 @@ public class Orchestras {
 				Receiver rec = ctx.config.getReceivers(stack)[0];
 				IMagazine mag = rec.getMagazine(stack);
 				SpentCasing casing = mag.getCasing(stack, ctx.inventory);
-				if(casing != null) for(int i = 0; i < mag.getCapacity(stack); i++) CasingCreator.composeEffect(entity.worldObj, entity, 0.25, -0.125, -0.125, -0.05, 0, 0, 0.01, casing.getName());
+				if(casing != null) for(int i = 0; i < mag.getCapacity(stack); i++) CasingCreator.composeEffect(entity.worldObj, entity, 0.25, -0.125, -0.125, -0.05, 0, 0, 0.01, 2.5F, 5F, casing.getName());
 			}
 		}
 		if(type == AnimType.CYCLE) {
@@ -384,7 +384,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 2) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.06, 0.01, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.06, 0.01, -10F, 2F, casing.getName(), true, 60, 0.5D, 20);
 			}
 		}
 		if(type == AnimType.CYCLE_DRY) {
@@ -479,7 +479,7 @@ public class Orchestras {
 				IMagazine mag = ctx.config.getReceivers(stack)[0].getMagazine(stack);
 				int toEject = mag.getAmountAfterReload(stack) - mag.getAmount(stack, ctx.inventory);
 				SpentCasing casing = mag.getCasing(stack, ctx.inventory);
-				if(casing != null) for(int i = 0; i < toEject; i++) CasingCreator.composeEffect(entity.worldObj, entity, 0.625, -0.1875, -0.375D, -0.12, 0.18, 0, 0.01, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) for(int i = 0; i < toEject; i++) CasingCreator.composeEffect(entity.worldObj, entity, 0.625, -0.1875, -0.375D, -0.12, 0.18, 0, 0.01, 15F, 2.5F, casing.getName(), true, 60, 0.5D, 20);
 			}
 			if(timer == 15) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.magSmallInsert", 1F, 1F);
 		}
@@ -503,7 +503,7 @@ public class Orchestras {
 			int toEject = mag.getAmountAfterReload(stack) - mag.getAmount(stack, ctx.inventory);
 			if(timer == 4 && toEject > 0) {
 				SpentCasing casing = mag.getCasing(stack, ctx.inventory);
-				if(casing != null) for(int i = 0; i < toEject; i++) CasingCreator.composeEffect(entity.worldObj, entity, 0.625, -0.1875, -0.375D, -0.12, 0.18, 0, 0.01, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) for(int i = 0; i < toEject; i++) CasingCreator.composeEffect(entity.worldObj, entity, 0.625, -0.1875, -0.375D, -0.12, 0.18, 0, 0.01, 10F, 5F, casing.getName(), true, 60, 0.5D, 20);
 				mag.setAmountAfterReload(stack, 0);
 			}
 			if(timer == 20) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.revolverClose", 1F, 0.9F);
@@ -1266,7 +1266,7 @@ public class Orchestras {
 				IMagazine mag = ctx.config.getReceivers(stack)[0].getMagazine(stack);
 				int toEject = mag.getAmountAfterReload(stack) - mag.getAmount(stack, ctx.inventory);
 				SpentCasing casing = mag.getCasing(stack, ctx.inventory);
-				if(casing != null) for(int i = 0; i < toEject; i++) CasingCreator.composeEffect(entity.worldObj, entity, 0, -0.1875, -0.375D, -0.12, 0.18, 0, 0.01, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) for(int i = 0; i < toEject; i++) CasingCreator.composeEffect(entity.worldObj, entity, 0, -0.1875, -0.375D, -0.12, 0.18, 0, 0.01, 20F, 2.5F, casing.getName(), true, 60, 0.5D, 20);
 			}
 		}
 		
@@ -1297,7 +1297,7 @@ public class Orchestras {
 			if(timer == 1) {
 				int cba = (stack.getItem() == ModItems.gun_aberrator_eott && ctx.configIndex == 0) ? -1 : 1;
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.125, aiming ? -0.0625 : -0.25D * cba, -0.075, 0.25, 0, 0.01, casing.getName());
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.125, aiming ? -0.0625 : -0.25D * cba, -0.075, 0.25, 0, 0.01, -12.5F, 2.5F, casing.getName());
 			}
 		}
 

--- a/src/main/java/com/hbm/items/weapon/sedna/factory/Orchestras.java
+++ b/src/main/java/com/hbm/items/weapon/sedna/factory/Orchestras.java
@@ -173,7 +173,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 14) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.5, -0.125, aiming ? -0.125 : -0.375D, 0, 0.12, -0.12, 0.01, 12.5F, 1.5F, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.5, -0.125, aiming ? -0.125 : -0.375D, 0, 0.12, -0.12, 0.01, -7.5F + (float)entity.getRNG().nextGaussian() * 5F, (float)entity.getRNG().nextGaussian() * 1.5F, casing.getName(), true, 60, 0.5D, 20);
 			}
 			if(timer == 12) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.leverCock", 1F, 1F);
 		}
@@ -196,7 +196,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 2) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.55, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.12, 0.01, casing.getName());
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.55, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.12, 0.01, -7.5F + (float)entity.getRNG().nextGaussian() * 5F, 12F + (float)entity.getRNG().nextGaussian() * 5F, casing.getName());
 			}
 		}
 		if(type == AnimType.CYCLE_DRY) {
@@ -244,7 +244,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 14) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, -0.125, aiming ? -0.125 : -0.375D, 0, 0.18, -0.12, 0.01, 12.5F, 2.5F, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, -0.125, aiming ? -0.125 : -0.375D, 0, 0.18, -0.12, 0.01, -10F + (float)entity.getRNG().nextGaussian() * 5F, (float)entity.getRNG().nextGaussian() * 2.5F, casing.getName(), true, 60, 0.5D, 20);
 			}
 			if(timer == 8) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.leverCock", 1F, 0.8F);
 		}
@@ -279,7 +279,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 14) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, -0.125, aiming ? -0.125 : -0.375D, 0, -0.08, 0, 0.01, 17.5F, 2.5F, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, -0.125, aiming ? -0.125 : -0.375D, 0, -0.08, 0, 0.01, -15F + (float)entity.getRNG().nextGaussian() * 5F, (float)entity.getRNG().nextGaussian() * 2.5F, casing.getName(), true, 60, 0.5D, 20);
 			}
 			if(timer == 8) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.leverCock", 1F, 0.8F);
 		}
@@ -300,7 +300,7 @@ public class Orchestras {
 			if(timer == 14) {
 				int offset = ctx.configIndex == 0 ? -1 : 1;
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, -0.125, aiming ? -0.125 * offset : -0.375D * offset, 0, -0.08, 0, 0.01, 17.5F, 2.5F, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, -0.125, aiming ? -0.125 * offset : -0.375D * offset, 0, -0.08, 0, 0.01, -15F + (float)entity.getRNG().nextGaussian() * 5F, (float)entity.getRNG().nextGaussian() * 2.5F, casing.getName(), true, 60, 0.5D, 20);
 			}
 			if(timer == 8) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.leverCock", 1F, 0.8F);
 			return;
@@ -322,7 +322,7 @@ public class Orchestras {
 				IMagazine mag = ctx.config.getReceivers(stack)[0].getMagazine(stack);
 				if(mag.getAmountAfterReload(stack) > 0) {
 					SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-					if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.625, -0.125, aiming ? -0.125 : -0.375D, -0.12, 0.18, 0, 0.01, casing.getName(), true, 60, 0.5D, 20);
+					if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.625, -0.125, aiming ? -0.125 : -0.375D, -0.12, 0.18, 0, 0.01, -15F + (float)entity.getRNG().nextGaussian() * 7.5F, (float)entity.getRNG().nextGaussian() * 5F, casing.getName(), true, 60, 0.5D, 20);
 					mag.setAmountBeforeReload(stack, 0);
 				}
 			}
@@ -358,7 +358,7 @@ public class Orchestras {
 				Receiver rec = ctx.config.getReceivers(stack)[0];
 				IMagazine mag = rec.getMagazine(stack);
 				SpentCasing casing = mag.getCasing(stack, ctx.inventory);
-				if(casing != null) for(int i = 0; i < mag.getCapacity(stack); i++) CasingCreator.composeEffect(entity.worldObj, entity, 0.25, -0.125, -0.125, -0.05, 0, 0, 0.01, 2.5F, 5F, casing.getName());
+				if(casing != null) for(int i = 0; i < mag.getCapacity(stack); i++) CasingCreator.composeEffect(entity.worldObj, entity, 0.25, -0.125, -0.125, -0.05, 0, 0, 0.01, -6.5F + (float)entity.getRNG().nextGaussian() * 3F, (float)entity.getRNG().nextGaussian() * 5F, casing.getName());
 			}
 		}
 		if(type == AnimType.CYCLE) {
@@ -384,7 +384,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 2) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.06, 0.01, -10F, 2F, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.06, 0.01, -10F + (float)entity.getRNG().nextGaussian() * 2.5F, 2.5F + (float)entity.getRNG().nextGaussian() * 2F, casing.getName(), true, 60, 0.5D, 20);
 			}
 		}
 		if(type == AnimType.CYCLE_DRY) {
@@ -419,7 +419,7 @@ public class Orchestras {
 			if(type == AnimType.CYCLE) {
 				if(timer == 0) {
 					SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-					if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.4375, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, -0.06, 0, 0.01, casing.getName());
+					if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.4375, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, -0.06, 0, 0.01, (float)entity.getRNG().nextGaussian() * 10F, (float)entity.getRNG().nextGaussian() * 10F, casing.getName());
 				}
 			}
 			if(type == AnimType.CYCLE_DRY) {
@@ -443,7 +443,7 @@ public class Orchestras {
 			if(type == AnimType.CYCLE) {
 				if(timer == 0) {
 					SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-					if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.4375, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, -0.06, 0, 0.01, casing.getName());
+					if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.4375, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, -0.06, 0, 0.01, (float)entity.getRNG().nextGaussian() * 10F, (float)entity.getRNG().nextGaussian() * 10F, casing.getName());
 				}
 			}
 			if(type == AnimType.CYCLE_DRY) {
@@ -479,7 +479,7 @@ public class Orchestras {
 				IMagazine mag = ctx.config.getReceivers(stack)[0].getMagazine(stack);
 				int toEject = mag.getAmountAfterReload(stack) - mag.getAmount(stack, ctx.inventory);
 				SpentCasing casing = mag.getCasing(stack, ctx.inventory);
-				if(casing != null) for(int i = 0; i < toEject; i++) CasingCreator.composeEffect(entity.worldObj, entity, 0.625, -0.1875, -0.375D, -0.12, 0.18, 0, 0.01, 15F, 2.5F, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) for(int i = 0; i < toEject; i++) CasingCreator.composeEffect(entity.worldObj, entity, 0.625, -0.1875, -0.375D, -0.12, 0.18, 0, 0.01, -15F + (float)entity.getRNG().nextGaussian() * 7.5F, (float)entity.getRNG().nextGaussian() * 5F, casing.getName(), true, 60, 0.5D, 20);
 			}
 			if(timer == 15) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.magSmallInsert", 1F, 1F);
 		}
@@ -503,7 +503,7 @@ public class Orchestras {
 			int toEject = mag.getAmountAfterReload(stack) - mag.getAmount(stack, ctx.inventory);
 			if(timer == 4 && toEject > 0) {
 				SpentCasing casing = mag.getCasing(stack, ctx.inventory);
-				if(casing != null) for(int i = 0; i < toEject; i++) CasingCreator.composeEffect(entity.worldObj, entity, 0.625, -0.1875, -0.375D, -0.12, 0.18, 0, 0.01, 10F, 5F, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) for(int i = 0; i < toEject; i++) CasingCreator.composeEffect(entity.worldObj, entity, 0.625, -0.1875, -0.375D, -0.12, 0.18, 0, 0.01, -15F * (float)entity.getRNG().nextGaussian() * 7.5F, (float)entity.getRNG().nextGaussian() * 5F, casing.getName(), true, 60, 0.5D, 20);
 				mag.setAmountAfterReload(stack, 0);
 			}
 			if(timer == 20) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.revolverClose", 1F, 0.9F);
@@ -521,7 +521,7 @@ public class Orchestras {
 			if(timer == 15) {
 				IMagazine mag = ctx.config.getReceivers(stack)[0].getMagazine(stack);
 				SpentCasing casing = mag.getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.625, aiming ? -0.0625 : -0.25, aiming ? 0 : -0.375D, 0, 0.18, 0.12, 0.01, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.625, aiming ? -0.0625 : -0.25, aiming ? 0 : -0.375D, 0, 0.18, 0.12, 0.01, -5F + (float)entity.getRNG().nextGaussian() * 3.5F, -10F + entity.getRNG().nextFloat() * 5F, casing.getName(), true, 60, 0.5D, 20);
 			}
 		}
 		if(type == AnimType.RELOAD || type == AnimType.RELOAD_CYCLE) {
@@ -599,7 +599,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 1) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.0625, aiming ? 0 : -0.25D, 0, 0.18, -0.12, 0.01, casing.getName());
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.0625, aiming ? 0 : -0.25D, 0, 0.18, -0.12, 0.01, -10F + (float)entity.getRNG().nextGaussian() * 5F, 10F + entity.getRNG().nextFloat() * 10F, casing.getName());
 			}
 		}
 		if(type == AnimType.CYCLE_DRY) {
@@ -632,7 +632,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 1) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.12, 0.01, casing.getName());
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.12, 0.01, -2.5F + (float)entity.getRNG().nextGaussian() * 5F, 10F + (float)entity.getRNG().nextFloat() * 15F, casing.getName());
 			}
 		}
 		if(type == AnimType.CYCLE_DRY) {
@@ -664,7 +664,7 @@ public class Orchestras {
 			if(timer == 1) {
 				int mult = ctx.configIndex == 0 ? -1 : 1;
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, -0.125, -0.375D * mult, 0, 0.18, -0.12 * mult, 0.01, casing.getName());
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, -0.125, -0.375D * mult, 0, 0.18, -0.12 * mult, 0.01, -2.5F + (float)entity.getRNG().nextGaussian() * 5F, (10F + (float)entity.getRNG().nextFloat() * 15F) * mult, casing.getName());
 			}
 		}
 		if(type == AnimType.CYCLE_DRY) {
@@ -693,8 +693,8 @@ public class Orchestras {
 		if(type == AnimType.CYCLE || type == AnimType.ALT_CYCLE) {
 			if(timer == 8) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.shotgunCock", 1F, 1F);
 			if(timer == 10) {
-				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.12, 0.01, casing.getName());
+				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory); //turns out there's a reason why stovepipes look like that
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.12, 0.01, -3F + (float)entity.getRNG().nextGaussian() * 2.5F, -15F + entity.getRNG().nextFloat() * -5F, casing.getName());
 			}
 		}
 		if(type == AnimType.CYCLE_DRY) {
@@ -744,7 +744,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 0) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.5, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.12, 0.01, casing.getName());
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.5, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.12, 0.01, (float)entity.getRNG().nextGaussian() * 5F, 12.5F + (float)entity.getRNG().nextFloat() * 5F, casing.getName());
 			}
 		}
 		if(type == AnimType.CYCLE_DRY) {
@@ -846,7 +846,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 0) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.125, aiming ? 0 : -0.3125D, 0, 0.06, -0.18, 0.01, casing.getName());
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.125, aiming ? 0 : -0.3125D, 0, 0.06, -0.18, 0.01, (float)entity.getRNG().nextGaussian() * 20F, 12.5F + (float)entity.getRNG().nextGaussian() * 7.5F, casing.getName());
 			}
 		}
 	};
@@ -920,7 +920,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 0) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, aiming ? 0.125 : 0.5, aiming ? -0.125 : -0.25, aiming ? -0.25 : -0.5D, 0, 0.18, -0.12, 0.01, casing.getName());
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, aiming ? 0.125 : 0.5, aiming ? -0.125 : -0.25, aiming ? -0.25 : -0.5D, 0, 0.18, -0.12, 0.01, (float)entity.getRNG().nextGaussian() * 15F, (float)entity.getRNG().nextGaussian() * 15F, casing.getName());
 			}
 			if(timer == 1) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.revolverSpin", 1F, 0.75F);
 		}
@@ -986,7 +986,7 @@ public class Orchestras {
 			if(type == AnimType.CYCLE) {
 				if(timer == 0) {
 					SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-					if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, aiming ? 0.125 : 0.125, aiming ? -0.125 : -0.25, aiming ? -0.125 : -0.25D, 0, 0.18, -0.12, 0.01, casing.getName());
+					if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, aiming ? 0.125 : 0.125, aiming ? -0.125 : -0.25, aiming ? -0.125 : -0.25D, 0, 0.18, -0.12, 0.01, (float)entity.getRNG().nextGaussian() * 5F, 7.5F + entity.getRNG().nextFloat() * 5F, casing.getName());
 				}
 				if(timer == 40) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.dryFireClick", 0.25F, 1.25F);
 			}
@@ -1012,7 +1012,7 @@ public class Orchestras {
 			if(type == AnimType.CYCLE) {
 				if(timer == 0) {
 					SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-					if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, aiming ? 0.125 : 0.25, aiming ? -0.125 : -0.25, aiming ? -0.125 : -0.25D, 0, 0.18, -0.12, 0.01, casing.getName());
+					if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, aiming ? 0.125 : 0.25, aiming ? -0.125 : -0.25, aiming ? -0.125 : -0.25D, 0, 0.18, -0.12, 0.01, (float)entity.getRNG().nextGaussian() * 5F, 7.5F + entity.getRNG().nextFloat() * 5F, casing.getName());
 				}
 				if(timer == 40) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.dryFireClick", 0.25F, 1.25F);
 			}
@@ -1187,7 +1187,7 @@ public class Orchestras {
 				Receiver rec = ctx.config.getReceivers(stack)[0];
 				IMagazine mag = rec.getMagazine(stack);
 				SpentCasing casing = mag.getCasing(stack, ctx.inventory);
-				if(casing != null) for(int i = 0; i < mag.getCapacity(stack); i++) CasingCreator.composeEffect(entity.worldObj, entity, 0.25, -0.25, -0.125, -0.05, 0, 0, 0.01, casing.getName());
+				if(casing != null) for(int i = 0; i < mag.getCapacity(stack); i++) CasingCreator.composeEffect(entity.worldObj, entity, 0.25, -0.25, -0.125, -0.05, 0, 0, 0.01, -6.5F + (float)entity.getRNG().nextGaussian() * 3F, (float)entity.getRNG().nextGaussian() * 5F, casing.getName());
 			}
 		}
 		
@@ -1228,7 +1228,7 @@ public class Orchestras {
 		if(type == AnimType.CYCLE) {
 			if(timer == 1) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.5, aiming ? 0 : -0.125, aiming ? -0.0625 : -0.25D, 0, 0.18, -0.12, 0.01, casing.getName());
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.5, aiming ? 0 : -0.125, aiming ? -0.0625 : -0.25D, 0, 0.18, -0.12, 0.01, -10F + (float)entity.getRNG().nextGaussian() * 5F, 10F + entity.getRNG().nextFloat() * 10F, casing.getName());
 			}
 		}
 		
@@ -1266,7 +1266,7 @@ public class Orchestras {
 				IMagazine mag = ctx.config.getReceivers(stack)[0].getMagazine(stack);
 				int toEject = mag.getAmountAfterReload(stack) - mag.getAmount(stack, ctx.inventory);
 				SpentCasing casing = mag.getCasing(stack, ctx.inventory);
-				if(casing != null) for(int i = 0; i < toEject; i++) CasingCreator.composeEffect(entity.worldObj, entity, 0, -0.1875, -0.375D, -0.12, 0.18, 0, 0.01, 20F, 2.5F, casing.getName(), true, 60, 0.5D, 20);
+				if(casing != null) for(int i = 0; i < toEject; i++) CasingCreator.composeEffect(entity.worldObj, entity, 0, -0.1875, -0.375D, -0.24, 0.18, 0, 0.01, -20F + (float)entity.getRNG().nextGaussian() * 5F, (float)entity.getRNG().nextGaussian() * 2.5F, casing.getName(), true, 60, 0.5D, 20);
 			}
 		}
 		
@@ -1297,7 +1297,7 @@ public class Orchestras {
 			if(timer == 1) {
 				int cba = (stack.getItem() == ModItems.gun_aberrator_eott && ctx.configIndex == 0) ? -1 : 1;
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
-				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.125, aiming ? -0.0625 : -0.25D * cba, -0.075, 0.25, 0, 0.01, -12.5F, 2.5F, casing.getName());
+				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.125, aiming ? -0.0625 : -0.25D * cba, -0.075, 0.25, 0, 0.01, -10F + (float)entity.getRNG().nextGaussian() * 10F, (float)entity.getRNG().nextGaussian() * 12.5F, casing.getName());
 			}
 		}
 

--- a/src/main/java/com/hbm/main/ResourceManager.java
+++ b/src/main/java/com/hbm/main/ResourceManager.java
@@ -1151,7 +1151,7 @@ public class ResourceManager {
 	//Projectiles
 	public static final IModelCustom projectiles = new HFRWavefrontObject(new ResourceLocation(RefStrings.MODID, "models/projectiles/projectiles.obj"));
 	public static final IModelCustom leadburster = new HFRWavefrontObject(new ResourceLocation(RefStrings.MODID, "models/projectiles/leadburster.obj"));
-	public static final IModelCustom casings = new HFRWavefrontObject(new ResourceLocation(RefStrings.MODID, "models/effect/casings.obj"));
+	public static final IModelCustom casings = new HFRWavefrontObject(new ResourceLocation(RefStrings.MODID, "models/effect/casings.obj")).asVBO();
 
 	//Bomber
 	public static final IModelCustom dornier = AdvancedModelLoader.loadModel(new ResourceLocation(RefStrings.MODID, "models/dornier.obj"));

--- a/src/main/java/com/hbm/particle/ParticleSpentCasing.java
+++ b/src/main/java/com/hbm/particle/ParticleSpentCasing.java
@@ -14,21 +14,15 @@ import com.hbm.util.Tuple.Pair;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import net.minecraft.block.Block;
-import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.EntityFX;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.texture.TextureManager;
-import net.minecraft.crash.CrashReport;
-import net.minecraft.crash.CrashReportCategory;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Blocks;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.MathHelper;
-import net.minecraft.util.ReportedException;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 

--- a/src/main/java/com/hbm/particle/ParticleSpentCasing.java
+++ b/src/main/java/com/hbm/particle/ParticleSpentCasing.java
@@ -222,15 +222,6 @@ public class ParticleSpentCasing extends EntityFX {
 				momentumYaw = (float) rand.nextGaussian() * 10F * this.config.getBounceYaw();
 		}
 		
-		try {
-			this.func_145775_I();
-		} catch (Throwable throwable) {
-			CrashReport crashreport = CrashReport.makeCrashReport(throwable, "Checking entity block collision");
-			CrashReportCategory crashreportcategory = crashreport.makeCategory("Entity being checked for collision");
-			this.addEntityCrashInfo(crashreportcategory);
-		throw new ReportedException(crashreport);
-		}
-		
 		this.worldObj.theProfiler.endSection();
 	}
 

--- a/src/main/java/com/hbm/particle/ParticleSpentCasing.java
+++ b/src/main/java/com/hbm/particle/ParticleSpentCasing.java
@@ -13,14 +13,21 @@ import com.hbm.util.Tuple.Pair;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.EntityFX;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.crash.CrashReport;
+import net.minecraft.crash.CrashReportCategory;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.MathHelper;
+import net.minecraft.util.ReportedException;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
@@ -49,8 +56,10 @@ public class ParticleSpentCasing extends EntityFX {
 		this.momentumPitch = momentumPitch;
 		this.momentumYaw = momentumYaw;
 		this.config = config;
-
+		
 		this.particleMaxAge = config.getMaxAge();
+		this.setSize(2 * dScale * Math.max(config.getScaleX(), config.getScaleZ()), dScale * config.getScaleY());
+		this.yOffset = this.height / 2F;
 		
 		this.isSmoking = smoking;
 		this.maxSmokeGen = smokeLife;
@@ -85,26 +94,20 @@ public class ParticleSpentCasing extends EntityFX {
 		}
 
 		this.motionY -= 0.04D * (double) this.particleGravity;
-		double prevMotionY = this.motionY;
 		this.moveEntity(this.motionX, this.motionY, this.motionZ);
 		this.motionX *= 0.98D;
 		this.motionY *= 0.98D;
 		this.motionZ *= 0.98D;
-
+		
 		if(this.onGround) {
 			this.motionX *= 0.7D;
 			this.motionZ *= 0.7D;
-		}
-
-		if(onGround) {
-			this.onGround = false;
-			motionY = prevMotionY * -0.5;
-			this.rotationPitch = 0;
-			//momentumPitch = (float) rand.nextGaussian() * config.getBouncePitch();
-			//momentumYaw = (float) rand.nextGaussian() * config.getBounceYaw();
 			
+			this.rotationPitch = 0;
+			this.momentumYaw *= 0.7F;
+			this.onGround = false;
 		}
-
+		
 		if(particleAge > maxSmokeGen && !smokeNodes.isEmpty())
 			smokeNodes.clear();
 
@@ -124,16 +127,106 @@ public class ParticleSpentCasing extends EntityFX {
 				smokeNodes.add(new Pair<Vec3, Double>(Vec3.createVectorHelper(0, 0, 0), smokeNodes.isEmpty() ? 0.0D : 1D));
 			}
 		}
-
+		
 		prevRotationPitch = rotationPitch;
 		prevRotationYaw = rotationYaw;
-
-		if(onGround) {
-			rotationPitch = 0;
-		} else {
-			rotationPitch += momentumPitch;
-			rotationYaw += momentumYaw;
+		
+		rotationPitch += momentumPitch;
+		rotationYaw += momentumYaw;
+	}
+	
+	public void moveEntity(double motionX, double motionY, double motionZ) {
+		this.worldObj.theProfiler.startSection("move");
+		this.ySize *= 0.4F;
+		
+		if (this.isInWeb) {
+			this.isInWeb = false;
+			motionX *= 0.25D;
+			motionY *= 0.05000000074505806D;
+			motionZ *= 0.25D;
+			this.motionX = 0.0D;
+			this.motionY = 0.0D;
+			this.motionZ = 0.0D;
 		}
+		
+		//Handle block collision
+		double initMoX = motionX;
+		double initMoY = motionY;
+		double initMoZ = motionZ;
+		AxisAlignedBB axisalignedbb = this.boundingBox.copy();
+		
+		List list = this.worldObj.getCollidingBoundingBoxes(this, this.boundingBox.addCoord(motionX, motionY, motionZ));
+		
+		for (int i = 0; i < list.size(); ++i) {
+			motionY = ((AxisAlignedBB)list.get(i)).calculateYOffset(this.boundingBox, motionY);
+		}
+		
+		this.boundingBox.offset(0.0D, motionY, 0.0D);
+		
+		int j;
+		
+		for (j = 0; j < list.size(); ++j) {
+			motionX = ((AxisAlignedBB)list.get(j)).calculateXOffset(this.boundingBox, motionX);
+		}
+		
+		this.boundingBox.offset(motionX, 0.0D, 0.0D);
+		
+		for (j = 0; j < list.size(); ++j) {
+			motionZ = ((AxisAlignedBB)list.get(j)).calculateZOffset(this.boundingBox, motionZ);
+		}
+		
+		this.boundingBox.offset(0.0D, 0.0D, motionZ);
+		
+		this.worldObj.theProfiler.endSection();
+		this.worldObj.theProfiler.startSection("rest");
+		this.posX = (this.boundingBox.minX + this.boundingBox.maxX) / 2.0D;
+		this.posY = this.boundingBox.minY + (double)this.yOffset - (double)this.ySize;
+		this.posZ = (this.boundingBox.minZ + this.boundingBox.maxZ) / 2.0D;
+		this.isCollidedHorizontally = initMoX != motionX || initMoZ != motionZ;
+		this.isCollidedVertically = initMoY != motionY;
+		this.onGround = initMoY != motionY && initMoY < 0.0D;
+		this.isCollided = this.isCollidedHorizontally || this.isCollidedVertically;
+		this.updateFallState(motionY, this.onGround);
+		
+		//Handles bounces
+		if (initMoX != motionX) {
+			this.motionX *= -0.25D;
+			
+			if(Math.abs(momentumYaw) > 1e-7)
+				momentumYaw *= -0.75F;
+			else
+				momentumYaw = (float) rand.nextGaussian() * 10F * this.config.getBounceYaw();
+		}
+		
+		if (initMoY != motionY) {
+			this.motionY *= -0.5D;
+			
+			if(momentumPitch == 0 && this.motionY > 1e-7) {
+				momentumPitch = (float) rand.nextGaussian() * 10F * this.config.getBouncePitch();
+				momentumYaw = (float) rand.nextGaussian() * 10F * this.config.getBounceYaw();
+			} else if(Math.abs(momentumPitch) > 1e-7)
+				momentumPitch *= -0.75F;
+		}
+		
+		if (initMoZ != motionZ) {
+			this.motionZ *= -0.25D;
+			
+			if(Math.abs(momentumYaw) > 1e-7)
+				momentumYaw *= -0.75F;
+			else
+				momentumYaw = (float) rand.nextGaussian() * 10F * this.config.getBounceYaw();
+		}
+		
+		try {
+			this.func_145775_I();
+		} catch (Throwable throwable) {
+			CrashReport crashreport = CrashReport.makeCrashReport(throwable, "Checking entity block collision");
+			CrashReportCategory crashreportcategory = crashreport.makeCategory("Entity being checked for collision");
+			this.addEntityCrashInfo(crashreportcategory);
+		throw new ReportedException(crashreport);
+		}
+		
+		this.worldObj.theProfiler.endSection();
 	}
 
 	/** Used for frame-perfect translation of smoke */

--- a/src/main/java/com/hbm/particle/ParticleSpentCasing.java
+++ b/src/main/java/com/hbm/particle/ParticleSpentCasing.java
@@ -9,6 +9,7 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
 import com.hbm.main.ResourceManager;
+import com.hbm.util.BobMathUtil;
 import com.hbm.util.Tuple.Pair;
 
 import cpw.mods.fml.relauncher.Side;
@@ -103,7 +104,7 @@ public class ParticleSpentCasing extends EntityFX {
 			this.motionX *= 0.7D;
 			this.motionZ *= 0.7D;
 			
-			this.rotationPitch = 0;
+			this.rotationPitch = (float) (Math.floor(this.rotationPitch / 180F + 0.5F)) * 180F;
 			this.momentumYaw *= 0.7F;
 			this.onGround = false;
 		}
@@ -201,11 +202,15 @@ public class ParticleSpentCasing extends EntityFX {
 		if (initMoY != motionY) {
 			this.motionY *= -0.5D;
 			
-			if(momentumPitch == 0 && this.motionY > 1e-7) {
-				momentumPitch = (float) rand.nextGaussian() * 10F * this.config.getBouncePitch();
-				momentumYaw = (float) rand.nextGaussian() * 10F * this.config.getBounceYaw();
-			} else if(Math.abs(momentumPitch) > 1e-7)
+			boolean rotFromSpeed = Math.abs(this.motionY) > 0.04;
+			if(rotFromSpeed || Math.abs(momentumPitch) > 1e-7) {
 				momentumPitch *= -0.75F;
+				if(rotFromSpeed) {
+					float mult = (float) BobMathUtil.safeClamp(initMoY / 0.2F, -1F, 1F);
+					momentumPitch += rand.nextGaussian() * 10F * this.config.getBouncePitch() * mult;
+					momentumYaw += (float) rand.nextGaussian() * 10F * this.config.getBounceYaw() * mult;
+				}
+			}
 		}
 		
 		if (initMoZ != motionZ) {

--- a/src/main/java/com/hbm/particle/SpentCasing.java
+++ b/src/main/java/com/hbm/particle/SpentCasing.java
@@ -40,8 +40,8 @@ public class SpentCasing implements Cloneable {
 	private int[] colors;
 	private CasingType type;
 	private String bounceSound;
-	private float bounceYaw = 0F;
-	private float bouncePitch = 0F;
+	private float bounceYaw = 1F;
+	private float bouncePitch = 1F;
 	private int maxAge = 240;
 	
 	public SpentCasing(CasingType type) {

--- a/src/main/java/com/hbm/particle/SpentCasing.java
+++ b/src/main/java/com/hbm/particle/SpentCasing.java
@@ -86,6 +86,7 @@ public class SpentCasing implements Cloneable {
 		return casingMap.get(name);
 	}
 	
+	/** Multiplier for default standard deviation of 10deg per tick, per bounce w/ full y speed */
 	public SpentCasing setBounceMotion(float yaw, float pitch) {
 		this.bounceYaw = yaw;
 		this.bouncePitch = pitch;

--- a/src/main/java/com/hbm/particle/helper/CasingCreator.java
+++ b/src/main/java/com/hbm/particle/helper/CasingCreator.java
@@ -17,12 +17,23 @@ import net.minecraft.world.World;
 
 public class CasingCreator implements IParticleCreator {
 	
-	/** Casing without smoke */
+	//TODO give these + orchestra hardcoding a little bit of randomness cuz it looks off otherwise
+	/** Default casing without smoke */
 	public static void composeEffect(World world, EntityLivingBase player, double frontOffset, double heightOffset, double sideOffset, double frontMotion, double heightMotion, double sideMotion, double motionVariance, String casing) {
-		composeEffect(world, player, frontOffset, heightOffset, sideOffset, frontMotion, heightMotion, sideMotion, motionVariance, casing, false, 0, 0, 0);
+		composeEffect(world, player, frontOffset, heightOffset, sideOffset, frontMotion, heightMotion, sideMotion, motionVariance, 5F, 10F, casing, false, 0, 0, 0);
+	}
+	
+	/** Casing without smoke */
+	public static void composeEffect(World world, EntityLivingBase player, double frontOffset, double heightOffset, double sideOffset, double frontMotion, double heightMotion, double sideMotion, double motionVariance, float multPitch, float multYaw, String casing) {
+		composeEffect(world, player, frontOffset, heightOffset, sideOffset, frontMotion, heightMotion, sideMotion, motionVariance, 5F, 10F, casing, false, 0, 0, 0);
+	}
+	
+	/** Default casing, but with smoke*/
+	public static void composeEffect(World world, EntityLivingBase player, double frontOffset, double heightOffset, double sideOffset, double frontMotion, double heightMotion, double sideMotion, double motionVariance, String casing, boolean smoking, int smokeLife, double smokeLift, int nodeLife) {
+		composeEffect(world, player, frontOffset, heightOffset, sideOffset, frontMotion, heightMotion, sideMotion, motionVariance, 5F, 10F, casing, false, 0, 0, 0);
 	}
 
-	public static void composeEffect(World world, EntityLivingBase player, double frontOffset, double heightOffset, double sideOffset, double frontMotion, double heightMotion, double sideMotion, double motionVariance, String casing, boolean smoking, int smokeLife, double smokeLift, int nodeLife) {
+	public static void composeEffect(World world, EntityLivingBase player, double frontOffset, double heightOffset, double sideOffset, double frontMotion, double heightMotion, double sideMotion, double motionVariance, float mPitch, float mYaw, String casing, boolean smoking, int smokeLife, double smokeLift, int nodeLife) {
 		
 		if(player.isSneaking()) heightOffset -= 0.075F;
 		
@@ -51,6 +62,8 @@ public class CasingCreator implements IParticleCreator {
 		data.setDouble("mZ", mZ);
 		data.setFloat("yaw", player.rotationYaw);
 		data.setFloat("pitch", player.rotationPitch);
+		data.setFloat("mPitch", mPitch);
+		data.setFloat("mYaw", mYaw);
 		data.setString("name", casing);
 		data.setBoolean("smoking", smoking);
 		data.setInteger("smokeLife", smokeLife);
@@ -71,11 +84,13 @@ public class CasingCreator implements IParticleCreator {
 		double mZ = data.getDouble("mZ");
 		float yaw = data.getFloat("yaw");
 		float pitch = data.getFloat("pitch");
+		float mPitch = data.getFloat("mPitch");
+		float mYaw = data.getFloat("mYaw");
 		boolean smoking = data.getBoolean("smoking");
 		int smokeLife = data.getInteger("smokeLife");
 		double smokeLift = data.getDouble("smokeLift");
 		int nodeLife = data.getInteger("nodeLife");
-		ParticleSpentCasing casing = new ParticleSpentCasing(texman, world, x, y, z, mX, mY, mZ, (float) (world.rand.nextGaussian() * 10F), (float) (world.rand.nextGaussian() * 5F), casingConfig, smoking, smokeLife, smokeLift, nodeLife);
+		ParticleSpentCasing casing = new ParticleSpentCasing(texman, world, x, y, z, mX, mY, mZ, mPitch, mYaw, casingConfig, smoking, smokeLife, smokeLift, nodeLife);
 		casing.prevRotationYaw = casing.rotationYaw = yaw;
 		casing.prevRotationPitch = casing.rotationPitch = pitch;
 		Minecraft.getMinecraft().effectRenderer.addEffect(casing);

--- a/src/main/java/com/hbm/particle/helper/CasingCreator.java
+++ b/src/main/java/com/hbm/particle/helper/CasingCreator.java
@@ -17,7 +17,6 @@ import net.minecraft.world.World;
 
 public class CasingCreator implements IParticleCreator {
 	
-	//TODO give these + orchestra hardcoding a little bit of randomness cuz it looks off otherwise
 	/** Default casing without smoke */
 	public static void composeEffect(World world, EntityLivingBase player, double frontOffset, double heightOffset, double sideOffset, double frontMotion, double heightMotion, double sideMotion, double motionVariance, String casing) {
 		composeEffect(world, player, frontOffset, heightOffset, sideOffset, frontMotion, heightMotion, sideMotion, motionVariance, 5F, 10F, casing, false, 0, 0, 0);
@@ -25,7 +24,7 @@ public class CasingCreator implements IParticleCreator {
 	
 	/** Casing without smoke */
 	public static void composeEffect(World world, EntityLivingBase player, double frontOffset, double heightOffset, double sideOffset, double frontMotion, double heightMotion, double sideMotion, double motionVariance, float multPitch, float multYaw, String casing) {
-		composeEffect(world, player, frontOffset, heightOffset, sideOffset, frontMotion, heightMotion, sideMotion, motionVariance, 5F, 10F, casing, false, 0, 0, 0);
+		composeEffect(world, player, frontOffset, heightOffset, sideOffset, frontMotion, heightMotion, sideMotion, motionVariance, multPitch, multYaw, casing, false, 0, 0, 0);
 	}
 	
 	/** Default casing, but with smoke*/

--- a/src/main/java/com/hbm/particle/helper/CasingCreator.java
+++ b/src/main/java/com/hbm/particle/helper/CasingCreator.java
@@ -75,7 +75,7 @@ public class CasingCreator implements IParticleCreator {
 		int smokeLife = data.getInteger("smokeLife");
 		double smokeLift = data.getDouble("smokeLift");
 		int nodeLife = data.getInteger("nodeLife");
-		ParticleSpentCasing casing = new ParticleSpentCasing(texman, world, x, y, z, mX, mY, mZ, 0, 0, casingConfig, smoking, smokeLife, smokeLift, nodeLife);
+		ParticleSpentCasing casing = new ParticleSpentCasing(texman, world, x, y, z, mX, mY, mZ, (float) (world.rand.nextGaussian() * 10F), (float) (world.rand.nextGaussian() * 5F), casingConfig, smoking, smokeLife, smokeLift, nodeLife);
 		casing.prevRotationYaw = casing.rotationYaw = yaw;
 		casing.prevRotationPitch = casing.rotationPitch = pitch;
 		Minecraft.getMinecraft().effectRenderer.addEffect(casing);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAberrator.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAberrator.java
@@ -219,6 +219,7 @@ public class ItemRenderAberrator extends ItemRenderWeaponBase {
 			double lengthOffset = -1.125;
 			Minecraft.getMinecraft().renderEngine.bindTexture(flash_plume);
 			tess.startDrawingQuads();
+			tess.setBrightness(240);
 			tess.setNormal(0F, 1F, 0F);
 			tess.setColorRGBA_F(1F, 1F, 1F, 1F);
 

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderEOTT.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderEOTT.java
@@ -260,6 +260,7 @@ public class ItemRenderEOTT extends ItemRenderWeaponBase {
 			double lengthOffset = -1.125;
 			Minecraft.getMinecraft().renderEngine.bindTexture(flash_plume);
 			tess.startDrawingQuads();
+			tess.setBrightness(240);
 			tess.setNormal(0F, 1F, 0F);
 			tess.setColorRGBA_F(1F, 1F, 1F, 1F);
 

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderWeaponBase.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderWeaponBase.java
@@ -331,6 +331,7 @@ public abstract class ItemRenderWeaponBase implements IItemRenderer {
 			double inset = 2;
 			Minecraft.getMinecraft().renderEngine.bindTexture(flash_plume);
 			tess.startDrawingQuads();
+			tess.setBrightness(240);
 			tess.setNormal(0F, 1F, 0F);
 			tess.setColorRGBA_F(1F, 1F, 1F, 1F);
 			
@@ -379,6 +380,7 @@ public abstract class ItemRenderWeaponBase implements IItemRenderer {
 			double lengthOffset = 0.125;
 			Minecraft.getMinecraft().renderEngine.bindTexture(flash_plume);
 			tess.startDrawingQuads();
+			tess.setBrightness(240);
 			tess.setNormal(0F, 1F, 0F);
 			tess.setColorRGBA_F(1F, 1F, 1F, 1F);
 			


### PR DESCRIPTION
CoC:
 - Gave ParticleSpentCasings rotational velocity and randomized bounces
   - Uses a slimmed version of MoveEntity, with special code handling bounces, loss of rotvel, etc.
   - messed with setSize to prevent casings from hovering a great distance - seems to work fine even with the larger shells
   - setBounceMotion now serves as a multiplier for the bounces, meaning e.g. artillery shells won't spin nearly as fast as handgun casings
 - Gave CasingCreator and CasingEjector initial rotational velocities
   - added it as an argument for the former, plus all of them set in the orchestras that hopefully make sense
   - added as default for turrets cuz CasingEjector kinda sucks
 - the most important change of all: muzzle/gap flashes now have fullbright. ur all welcome