### PR TITLE
Performance boost for RBMKs (thanks DEKO)

### DIFF
--- a/src/main/java/com/hbm/handler/neutron/NeutronNodeWorld.java
+++ b/src/main/java/com/hbm/handler/neutron/NeutronNodeWorld.java
@@ -17,11 +17,6 @@ public class NeutronNodeWorld {
 		return streamWorld != null ? streamWorld.nodeCache.get(pos) : null;
 	}
 
-	public static void addNode(World world, NeutronNode node) {
-		StreamWorld streamWorld = getOrAddWorld(world);
-		streamWorld.nodeCache.put(node.pos, node);
-	}
-
 	public static void removeNode(World world, BlockPos pos) {
 		StreamWorld streamWorld = streamWorlds.get(world);
 		if(streamWorld == null) return;
@@ -58,7 +53,7 @@ public class NeutronNodeWorld {
 
 		public void runStreamInteractions(World world) {
 			for(NeutronStream stream : streams) {
-				stream.runStreamInteraction(world);
+				stream.runStreamInteraction(world, this);
 			}
 		}
 
@@ -75,7 +70,7 @@ public class NeutronNodeWorld {
 			for(NeutronNode cachedNode : nodeCache.values()) {
 				if(cachedNode.type == NeutronStream.NeutronType.RBMK) {
 					RBMKNeutronHandler.RBMKNeutronNode node = (RBMKNeutronHandler.RBMKNeutronNode) cachedNode;
-					toRemove.addAll(node.checkNode());
+					toRemove.addAll(node.checkNode(this));
 				}
 				/* TODO: actually do this and uncache pile nodes
 				if(cachedNode.type == NeutronStream.NeutronType.PILE) {
@@ -88,6 +83,14 @@ public class NeutronNodeWorld {
 			for(BlockPos pos : toRemove) {
 				nodeCache.remove(pos);
 			}
+		}
+
+		public NeutronNode getNode(BlockPos pos) {
+			return nodeCache.get(pos);
+		}
+
+		public void addNode(NeutronNode node) {
+			nodeCache.put(node.pos, node);
 		}
 
 		public void removeNode(BlockPos pos) {

--- a/src/main/java/com/hbm/handler/neutron/NeutronStream.java
+++ b/src/main/java/com/hbm/handler/neutron/NeutronStream.java
@@ -1,5 +1,6 @@
 package com.hbm.handler.neutron;
 
+import com.hbm.handler.neutron.NeutronNodeWorld.StreamWorld;
 import com.hbm.util.fauxpointtwelve.BlockPos;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
@@ -72,5 +73,5 @@ public abstract class NeutronStream {
 		};
 	}
 
-	public abstract void runStreamInteraction(World worldObj);
+	public abstract void runStreamInteraction(World worldObj, StreamWorld streamWorld);
 }

--- a/src/main/java/com/hbm/handler/neutron/PileNeutronHandler.java
+++ b/src/main/java/com/hbm/handler/neutron/PileNeutronHandler.java
@@ -2,6 +2,7 @@ package com.hbm.handler.neutron;
 
 import api.hbm.block.IPileNeutronReceiver;
 import com.hbm.blocks.ModBlocks;
+import com.hbm.handler.neutron.NeutronNodeWorld.StreamWorld;
 import com.hbm.tileentity.machine.pile.TileEntityPileBase;
 import com.hbm.util.ContaminationUtil;
 import com.hbm.util.fauxpointtwelve.BlockPos;
@@ -26,9 +27,9 @@ public class PileNeutronHandler {
 
 	}
 
-	public static PileNeutronNode makeNode(TileEntityPileBase tile) {
+	public static PileNeutronNode makeNode(StreamWorld streamWorld, TileEntityPileBase tile) {
 		BlockPos pos = new BlockPos(tile);
-		PileNeutronNode node = (PileNeutronNode) NeutronNodeWorld.getNode(tile.getWorldObj(), pos);
+		PileNeutronNode node = (PileNeutronNode) streamWorld.getNode(pos);
 		return node != null ? node : new PileNeutronNode(tile);
 	}
 
@@ -44,7 +45,7 @@ public class PileNeutronHandler {
 
 		@SuppressWarnings("unchecked")
 		@Override
-		public void runStreamInteraction(World worldObj) {
+		public void runStreamInteraction(World worldObj, StreamWorld streamWorld) {
 
 			TileEntityPileBase originTE = (TileEntityPileBase) origin.tile;
 			BlockPos pos = new BlockPos(originTE);
@@ -64,7 +65,7 @@ public class PileNeutronHandler {
 
 				TileEntity tile;
 
-				NeutronNode node = NeutronNodeWorld.getNode(worldObj, nodePos);
+				NeutronNode node = streamWorld.getNode(nodePos);
 				if(node != null && node instanceof PileNeutronNode) {
 					tile = node.tile;
 				} else {
@@ -72,7 +73,7 @@ public class PileNeutronHandler {
 					if(tile == null) return;
 
 					if(tile instanceof TileEntityPileBase) {
-						NeutronNodeWorld.addNode(worldObj, new PileNeutronNode((TileEntityPileBase) tile));
+						streamWorld.addNode(new PileNeutronNode((TileEntityPileBase) tile));
 					}
 				}
 

--- a/src/main/java/com/hbm/tileentity/machine/pile/TileEntityPileBase.java
+++ b/src/main/java/com/hbm/tileentity/machine/pile/TileEntityPileBase.java
@@ -1,6 +1,7 @@
 package com.hbm.tileentity.machine.pile;
 
 import com.hbm.handler.neutron.NeutronNodeWorld;
+import com.hbm.handler.neutron.NeutronNodeWorld.StreamWorld;
 import com.hbm.handler.neutron.PileNeutronHandler;
 import com.hbm.handler.neutron.PileNeutronHandler.PileNeutronStream;
 import com.hbm.handler.neutron.PileNeutronHandler.PileNeutronNode;
@@ -36,11 +37,12 @@ public abstract class TileEntityPileBase extends TileEntity {
 			return;
 		}
 
-		PileNeutronNode node = (PileNeutronNode) NeutronNodeWorld.getNode(worldObj, pos);
+		StreamWorld streamWorld = NeutronNodeWorld.getOrAddWorld(worldObj);
+		PileNeutronNode node = (PileNeutronNode) streamWorld.getNode(pos);
 
 		if(node == null) {
-			node = PileNeutronHandler.makeNode(this);
-			NeutronNodeWorld.addNode(worldObj, node);
+			node = PileNeutronHandler.makeNode(streamWorld, this);
+			streamWorld.addNode(node);
 		}
 
 		Vec3 neutronVector = Vec3.createVectorHelper(1, 0, 0);

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKRod.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKRod.java
@@ -6,6 +6,7 @@ import com.hbm.blocks.machine.rbmk.RBMKRod;
 import com.hbm.entity.projectile.EntityRBMKDebris.DebrisType;
 import com.hbm.handler.CompatHandler;
 import com.hbm.handler.neutron.NeutronNodeWorld;
+import com.hbm.handler.neutron.NeutronNodeWorld.StreamWorld;
 import com.hbm.handler.neutron.RBMKNeutronHandler;
 import com.hbm.handler.radiation.ChunkRadiationManager;
 import com.hbm.handler.neutron.RBMKNeutronHandler.RBMKNeutronNode;
@@ -203,11 +204,12 @@ public class TileEntityRBMKRod extends TileEntityRBMKSlottedBase implements IRBM
 			return;
 		}
 
-		RBMKNeutronNode node = (RBMKNeutronNode) NeutronNodeWorld.getNode(worldObj, pos);
+		StreamWorld streamWorld = NeutronNodeWorld.getOrAddWorld(worldObj);
+		RBMKNeutronNode node = (RBMKNeutronNode) streamWorld.getNode(pos);
 
 		if(node == null) {
-			node = RBMKNeutronHandler.makeNode(this);
-			NeutronNodeWorld.addNode(worldObj, node);
+			node = RBMKNeutronHandler.makeNode(streamWorld, this);
+			streamWorld.addNode(node);
 		}
 
 		for(ForgeDirection dir : fluxDirs) {

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKRodReaSim.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKRodReaSim.java
@@ -2,6 +2,7 @@ package com.hbm.tileentity.machine.rbmk;
 
 import com.hbm.handler.neutron.NeutronNodeWorld;
 import com.hbm.handler.neutron.RBMKNeutronHandler;
+import com.hbm.handler.neutron.NeutronNodeWorld.StreamWorld;
 import com.hbm.tileentity.machine.rbmk.TileEntityRBMKConsole.ColumnType;
 
 import com.hbm.util.fauxpointtwelve.BlockPos;
@@ -34,11 +35,12 @@ public class TileEntityRBMKRodReaSim extends TileEntityRBMKRod {
 			return;
 		}
 
-		RBMKNeutronNode node = (RBMKNeutronNode) NeutronNodeWorld.getNode(worldObj, pos);
+		StreamWorld streamWorld = NeutronNodeWorld.getOrAddWorld(worldObj);
+		RBMKNeutronNode node = (RBMKNeutronNode) streamWorld.getNode(pos);
 
 		if(node == null) {
-			node = makeNode(this);
-			NeutronNodeWorld.addNode(worldObj, node);
+			node = makeNode(streamWorld, this);
+			streamWorld.addNode(node);
 		}
 
 		int count = RBMKDials.getReaSimCount(worldObj);
@@ -48,7 +50,7 @@ public class TileEntityRBMKRodReaSim extends TileEntityRBMKRod {
 
 			neutronVector.rotateAroundY((float)(Math.PI * 2D * worldObj.rand.nextDouble()));
 
-			new RBMKNeutronHandler.RBMKNeutronStream(makeNode(this), neutronVector, flux, ratio);
+			new RBMKNeutronHandler.RBMKNeutronStream(makeNode(streamWorld, this), neutronVector, flux, ratio);
 			// Create new neutron streams
 		}
 	}


### PR DESCRIPTION
In making the RBMK neutron system more robust in cases of reactors in many dimensions, more hashmap lookups than necessary were added. This PR should cut it down to size by passing by reference instead where appropriate.

Performance improvement: 68ms over 60 seconds -> 8ms over 60 seconds