### PR TITLE
Make RBMK Rods actually be a SimpleComponent

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKRod.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKRod.java
@@ -29,6 +29,7 @@ import io.netty.buffer.ByteBuf;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.SimpleComponent;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
@@ -42,7 +43,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Optional.InterfaceList({@Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers")})
-public class TileEntityRBMKRod extends TileEntityRBMKSlottedBase implements IRBMKFluxReceiver, IRBMKLoadable, IInfoProviderEC, CompatHandler.OCComponent {
+public class TileEntityRBMKRod extends TileEntityRBMKSlottedBase implements IRBMKFluxReceiver, IRBMKLoadable, IInfoProviderEC, SimpleComponent, CompatHandler.OCComponent {
 
 	// New system!!
 	// Used for receiving flux (calculating outbound flux/burning rods)


### PR DESCRIPTION
I was wondering why I couldn't connect OC cables to a rbmk rod, turns out the tile entity didn't implement SimpleComponent. Tested, works.