### PR TITLE
Update dead Readme.MD Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 
 * NTM Reloaded: https://github.com/TheOriginalGolem/Hbm-s-Nuclear-Tech-GIT/releases
 * NTM Extended Edition (Alcater): https://github.com/Alcatergit/Hbm-s-Nuclear-Tech-GIT/releases
-* NTM WarFactory: https://github.com/MisterNorwood/Hbm-s-Nuclear-Tech-GIT/releases
 
 For 1.18, try Martin's remake: https://codeberg.org/MartinTheDragon/Nuclear-Tech-Mod-Remake/releases
 


### PR DESCRIPTION
Removed the link to NTM WarFactory as the project no longer exists on GitHub and the specific GitHub account associated with the project no longer exists.