### PR TITLE
Fixed crate item movement prevention applying to all held items

### DIFF
--- a/src/main/java/com/hbm/inventory/container/ContainerCrateBase.java
+++ b/src/main/java/com/hbm/inventory/container/ContainerCrateBase.java
@@ -1,5 +1,6 @@
 package com.hbm.inventory.container;
 
+import com.hbm.items.block.ItemBlockStorageCrate;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
@@ -18,8 +19,15 @@ public class ContainerCrateBase extends ContainerBase {
 	@Override
 	public ItemStack slotClick(int index, int button, int mode, EntityPlayer player) {
 		// prevents the player from moving around the currently open box
-		if(mode == 2 && button == player.inventory.currentItem) return null;
-		if(index == player.inventory.currentItem + 27 + this.tile.getSizeInventory()) return null;
+		if(player.inventory.getStackInSlot(player.inventory.currentItem) != null &&
+			player.inventory.getStackInSlot(player.inventory.currentItem).getItem() instanceof ItemBlockStorageCrate) {
+			if (mode == 2 && button == player.inventory.currentItem) {
+				return null;
+			}
+			if (index == player.inventory.currentItem + 27 + this.tile.getSizeInventory()) {
+				return null;
+			}
+		}
 		return super.slotClick(index, button, mode, player);
 	}
 


### PR DESCRIPTION
Fixes an issue where when you open a placed crate you cannot move the item in your hand. This PR allows movement of non crate items but will still have the issue of not allowing to move a crate held in hand while opening a placed crate.