### PR TITLE
Fix armor arm offset

### DIFF
--- a/src/main/java/com/hbm/render/loader/ModelRendererObj.java
+++ b/src/main/java/com/hbm/render/loader/ModelRendererObj.java
@@ -85,7 +85,7 @@ public class ModelRendererObj {
 		if(this.rotateAngleY != 0.0F) GL11.glRotatef(this.rotateAngleY * (180F / (float) Math.PI), 0.0F, 1.0F, 0.0F);
 		if(this.rotateAngleX != 0.0F) GL11.glRotatef(this.rotateAngleX * (180F / (float) Math.PI), 1.0F, 0.0F, 0.0F);
 
-		GL11.glTranslatef(-this.rotationPointX * scale, -this.originPointY * scale, -this.originPointZ * scale);
+		GL11.glTranslatef(-this.originPointX * scale, -this.originPointY * scale, -this.originPointZ * scale);
 		GL11.glTranslatef(-this.offsetX * scale, -this.offsetY * scale, -this.offsetZ * scale);
 
 		GL11.glScalef(scale, scale, scale);

--- a/src/main/java/com/hbm/render/model/ModelArmorAJR.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorAJR.java
@@ -14,8 +14,8 @@ public class ModelArmorAJR extends ModelArmorBase {
 
 		this.head = new ModelRendererObj(ResourceManager.armor_ajr, "Head");
 		this.body = new ModelRendererObj(ResourceManager.armor_ajr, "Body");
-		this.leftArm = new ModelRendererObj(ResourceManager.armor_ajr, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.armor_ajr, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.armor_ajr, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.armor_ajr, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.armor_ajr, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.armor_ajr, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.armor_ajr, "LeftBoot").setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelArmorAJRO.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorAJRO.java
@@ -14,8 +14,8 @@ public class ModelArmorAJRO extends ModelArmorBase {
 
 		this.head = new ModelRendererObj(ResourceManager.armor_ajr, "Head");
 		this.body = new ModelRendererObj(ResourceManager.armor_ajr, "Body");
-		this.leftArm = new ModelRendererObj(ResourceManager.armor_ajr, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.armor_ajr, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.armor_ajr, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.armor_ajr, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.armor_ajr, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.armor_ajr, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.armor_ajr, "LeftBoot").setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelArmorBJ.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorBJ.java
@@ -17,8 +17,8 @@ public class ModelArmorBJ extends ModelArmorBase {
 		this.head = new ModelRendererObj(ResourceManager.armor_bj, "Head");
 		this.body = new ModelRendererObj(ResourceManager.armor_bj, "Body");
 		this.jetpack = new ModelRendererObj(ResourceManager.armor_bj, "Jetpack");
-		this.leftArm = new ModelRendererObj(ResourceManager.armor_bj, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.armor_bj, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.armor_bj, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.armor_bj, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.armor_bj, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.armor_bj, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.armor_bj, "LeftFoot").setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelArmorBase.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorBase.java
@@ -30,8 +30,8 @@ public class ModelArmorBase extends ModelBiped {
 		// Generate null defaults to prevent major breakage from using incomplete models
 		this.head = new ModelRendererObj(null);
 		this.body = new ModelRendererObj(null);
-		this.leftArm = new ModelRendererObj(null).setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(null).setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(null).setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(null).setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(null).setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(null).setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(null).setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelArmorBismuth.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorBismuth.java
@@ -14,8 +14,8 @@ public class ModelArmorBismuth extends ModelArmorBase {
 
 		this.head = new ModelRendererObj(ResourceManager.armor_bismuth, "Head");
 		this.body = new ModelRendererObj(ResourceManager.armor_bismuth, "Body");
-		this.leftArm = new ModelRendererObj(ResourceManager.armor_bismuth, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.armor_bismuth, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.armor_bismuth, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.armor_bismuth, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.armor_bismuth, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.armor_bismuth, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.armor_bismuth, "LeftFoot").setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelArmorDNT.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorDNT.java
@@ -14,8 +14,8 @@ public class ModelArmorDNT extends ModelArmorBase {
 
 		this.head = new ModelRendererObj(ResourceManager.armor_dnt, "Head");
 		this.body = new ModelRendererObj(ResourceManager.armor_dnt, "Body");
-		this.leftArm = new ModelRendererObj(ResourceManager.armor_dnt, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.armor_dnt, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.armor_dnt, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.armor_dnt, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.armor_dnt, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.armor_dnt, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.armor_dnt, "LeftBoot").setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelArmorDesh.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorDesh.java
@@ -14,8 +14,8 @@ public class ModelArmorDesh extends ModelArmorBase {
 
 		this.head = new ModelRendererObj(ResourceManager.armor_steamsuit, "Head");
 		this.body = new ModelRendererObj(ResourceManager.armor_steamsuit, "Body");
-		this.leftArm = new ModelRendererObj(ResourceManager.armor_steamsuit, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.armor_steamsuit, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.armor_steamsuit, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.armor_steamsuit, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.armor_steamsuit, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.armor_steamsuit, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.armor_steamsuit, "LeftBoot").setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelArmorDiesel.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorDiesel.java
@@ -14,8 +14,8 @@ public class ModelArmorDiesel extends ModelArmorBase {
 
 		this.head = new ModelRendererObj(ResourceManager.armor_dieselsuit, "Head");
 		this.body = new ModelRendererObj(ResourceManager.armor_dieselsuit, "Body");
-		this.leftArm = new ModelRendererObj(ResourceManager.armor_dieselsuit, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.armor_dieselsuit, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.armor_dieselsuit, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.armor_dieselsuit, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.armor_dieselsuit, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.armor_dieselsuit, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.armor_dieselsuit, "LeftBoot").setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelArmorDigamma.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorDigamma.java
@@ -18,8 +18,8 @@ public class ModelArmorDigamma extends ModelArmorBase {
 		this.head = new ModelRendererObj(ResourceManager.armor_fau, "Head");
 		this.body = new ModelRendererObj(ResourceManager.armor_fau, "Body");
 		this.cassette = new ModelRendererObj(ResourceManager.armor_fau, "Cassette");
-		this.leftArm = new ModelRendererObj(ResourceManager.armor_fau, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.armor_fau, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.armor_fau, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.armor_fau, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.armor_fau, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.armor_fau, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.armor_fau, "LeftBoot").setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelArmorEnvsuit.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorEnvsuit.java
@@ -18,8 +18,8 @@ public class ModelArmorEnvsuit extends ModelArmorBase {
 		this.head = new ModelRendererObj(ResourceManager.armor_envsuit, "Helmet");
 		this.lamps = new ModelRendererObj(ResourceManager.armor_envsuit, "Lamps");
 		this.body = new ModelRendererObj(ResourceManager.armor_envsuit, "Chest");
-		this.leftArm = new ModelRendererObj(ResourceManager.armor_envsuit, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.armor_envsuit, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.armor_envsuit, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.armor_envsuit, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.armor_envsuit, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.armor_envsuit, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.armor_envsuit, "LeftFoot").setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelArmorHEV.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorHEV.java
@@ -14,8 +14,8 @@ public class ModelArmorHEV extends ModelArmorBase {
 
 		this.head = new ModelRendererObj(ResourceManager.armor_hev, "Head");
 		this.body = new ModelRendererObj(ResourceManager.armor_hev, "Body");
-		this.leftArm = new ModelRendererObj(ResourceManager.armor_hev, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.armor_hev, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.armor_hev, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.armor_hev, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.armor_hev, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.armor_hev, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.armor_hev, "LeftFoot").setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelArmorRPA.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorRPA.java
@@ -20,8 +20,8 @@ public class ModelArmorRPA extends ModelArmorBase {
 		this.body = new ModelRendererObj(ResourceManager.armor_remnant, "Body");
 		this.fan = new ModelRendererObj(ResourceManager.armor_remnant, "Fan");
 		this.glow = new ModelRendererObj(ResourceManager.armor_remnant, "Glow");
-		this.leftArm = new ModelRendererObj(ResourceManager.armor_remnant, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.armor_remnant, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.armor_remnant, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.armor_remnant, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.armor_remnant, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.armor_remnant, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.armor_remnant, "LeftBoot").setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelArmorTaurun.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorTaurun.java
@@ -14,8 +14,8 @@ public class ModelArmorTaurun extends ModelArmorBase {
 
 		this.head = new ModelRendererObj(ResourceManager.armor_taurun, "Helmet");
 		this.body = new ModelRendererObj(ResourceManager.armor_taurun, "Chest");
-		this.leftArm = new ModelRendererObj(ResourceManager.armor_taurun, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.armor_taurun, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.armor_taurun, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.armor_taurun, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.armor_taurun, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.armor_taurun, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.armor_taurun, "LeftBoot").setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelArmorTrenchmaster.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorTrenchmaster.java
@@ -18,8 +18,8 @@ public class ModelArmorTrenchmaster extends ModelArmorBase {
 		this.head = new ModelRendererObj(ResourceManager.armor_trenchmaster, "Helmet");
 		this.light = new ModelRendererObj(ResourceManager.armor_trenchmaster, "Light");
 		this.body = new ModelRendererObj(ResourceManager.armor_trenchmaster, "Chest");
-		this.leftArm = new ModelRendererObj(ResourceManager.armor_trenchmaster, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.armor_trenchmaster, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.armor_trenchmaster, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.armor_trenchmaster, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.armor_trenchmaster, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.armor_trenchmaster, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.armor_trenchmaster, "LeftBoot").setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelArmorWings.java
+++ b/src/main/java/com/hbm/render/model/ModelArmorWings.java
@@ -26,8 +26,8 @@ public class ModelArmorWings extends ModelArmorBase {
 		//i should really stop doing that
 		this.head = new ModelRendererObj(ResourceManager.anvil);
 		this.body = new ModelRendererObj(ResourceManager.anvil);
-		this.leftArm = new ModelRendererObj(ResourceManager.anvil).setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.anvil).setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.anvil).setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.anvil).setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.anvil).setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.anvil).setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.anvil).setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelGlasses.java
+++ b/src/main/java/com/hbm/render/model/ModelGlasses.java
@@ -14,8 +14,8 @@ public class ModelGlasses extends ModelArmorBase {
 
 		this.head = new ModelRendererObj(ResourceManager.armor_goggles);
 		this.body = new ModelRendererObj(ResourceManager.armor_bj, "Body");
-		this.leftArm = new ModelRendererObj(ResourceManager.armor_bj, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.armor_bj, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.armor_bj, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.armor_bj, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.armor_bj, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.armor_bj, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(ResourceManager.armor_bj, "LeftFoot").setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelHat.java
+++ b/src/main/java/com/hbm/render/model/ModelHat.java
@@ -14,8 +14,8 @@ public class ModelHat extends ModelArmorBase {
 
 		this.head = new ModelRendererObj(ResourceManager.armor_hat);
 		this.body = new ModelRendererObj(null);
-		this.leftArm = new ModelRendererObj(null).setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(null).setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(null).setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(null).setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(null).setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(null).setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(null).setRotationPoint(1.9F, 12.0F, 0.0F);

--- a/src/main/java/com/hbm/render/model/ModelMan.java
+++ b/src/main/java/com/hbm/render/model/ModelMan.java
@@ -15,8 +15,8 @@ public class ModelMan extends ModelArmorBase {
 
 		this.head = new ModelRendererObj(ResourceManager.player_manly_af, "Head");
 		this.body = new ModelRendererObj(ResourceManager.player_manly_af, "Body");
-		this.leftArm = new ModelRendererObj(ResourceManager.player_manly_af, "LeftArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(ResourceManager.player_manly_af, "RightArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(ResourceManager.player_manly_af, "LeftArm").setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(ResourceManager.player_manly_af, "RightArm").setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(ResourceManager.player_manly_af, "LeftLeg").setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(ResourceManager.player_manly_af, "RightLeg").setRotationPoint(-1.9F, 12.0F, 0.0F);
 	}

--- a/src/main/java/com/hbm/render/model/ModelNo9.java
+++ b/src/main/java/com/hbm/render/model/ModelNo9.java
@@ -22,8 +22,8 @@ public class ModelNo9 extends ModelArmorBase {
 		this.insig = new ModelRendererObj(ResourceManager.armor_no9, "Insignia");
 		this.lamp = new ModelRendererObj(ResourceManager.armor_no9, "Flame");
 		this.body = new ModelRendererObj(null);
-		this.leftArm = new ModelRendererObj(null).setRotationPoint(-5.0F, 2.0F, 0.0F);
-		this.rightArm = new ModelRendererObj(null).setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.leftArm = new ModelRendererObj(null).setRotationPoint(5.0F, 2.0F, 0.0F);
+		this.rightArm = new ModelRendererObj(null).setRotationPoint(-5.0F, 2.0F, 0.0F);
 		this.leftLeg = new ModelRendererObj(null).setRotationPoint(1.9F, 12.0F, 0.0F);
 		this.rightLeg = new ModelRendererObj(null).setRotationPoint(-1.9F, 12.0F, 0.0F);
 		this.leftFoot = new ModelRendererObj(null).setRotationPoint(1.9F, 12.0F, 0.0F);


### PR DESCRIPTION
### **Reason for PR**: Improve compatibility with mods that change limb positions, such as [Customizable Player Models](https://modrinth.com/plugin/custom-player-models)

### Changes:

* ModelRendererObj:
   + Change `-this.rotationPointX` to `-this.originPointX` in `GL11.glTranslatef(-this.rotationPointX * scale, -this.originPointY * scale, -this.originPointZ * scale);`
   - **Reason**: this `glTranslatef` should do translation around the original rotation point, but on the x axis, it does it for the current

* ModelArmor*:
   + Change `setRotationPoint(-5.0F...)` to `setRotationPoint(5.0F...)` in the `this.leftArm` init
   + Change `setRotationPoint(5.0F...)` to `setRotationPoint(-5.0F...)` in the `this.rightArm` init
   - **Reason**: looking at the vanilla `ModelBiped.class`:
      + `this.bipedRightArm.setRotationPoint(-5.0F, 2.0F + p_i1149_2_, 0.0F);`
      + `this.bipedLeftArm.setRotationPoint(5.0F, 2.0F + p_i1149_2_, 0.0F);`
      + bipedRightArm uses -5.0F in x, and bipedLeftArm uses 5.0F, which is exactly the opposite in the NTM armor code





<details>

<summary>Demos that nobody needs</summary>


### Before
https://github.com/user-attachments/assets/7fd8e27c-e3ab-41e6-ac63-0ad554c5763d

### After
https://github.com/user-attachments/assets/bec3ac52-7a12-4b94-ab82-d2091da822f3

https://github.com/user-attachments/assets/b4393df7-5d1f-4c11-815a-a1dadf22a844

</details>

![2025-04-19_13 02 17](https://github.com/user-attachments/assets/34d9aaa0-f30b-4cfc-8022-2323c646a6d2)


