### PR TITLE
PA Dipole tweaks and particle serialisation

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/albion/TileEntityPADipole.java
+++ b/src/main/java/com/hbm/tileentity/machine/albion/TileEntityPADipole.java
@@ -31,9 +31,9 @@ public class TileEntityPADipole extends TileEntityCooledBase implements IGUIProv
 	public int dirUpper;
 	public int dirRedstone;
 	public int threshold;
-	
+
 	public static final long usage = 100_000;
-	
+
 	public TileEntityPADipole() {
 		super(2);
 	}
@@ -66,7 +66,7 @@ public class TileEntityPADipole extends TileEntityCooledBase implements IGUIProv
 	@Override
 	public void onEnter(Particle particle, ForgeDirection dir) {
 		EnumCoilType type = null;
-		
+
 		int mult = 1;
 		if(slots[1] != null && slots[1].getItem() == ModItems.pa_coil) {
 			type = EnumUtil.grabEnumSafely(EnumCoilType.class, slots[1].getItemDamage());
@@ -78,9 +78,9 @@ public class TileEntityPADipole extends TileEntityCooledBase implements IGUIProv
 		if(this.power < this.usage * mult)					particle.crash(PAState.CRASH_NOPOWER);
 		if(type == null)									particle.crash(PAState.CRASH_NOCOIL);
 		if(type != null && type.diMax < particle.momentum)	particle.crash(PAState.CRASH_OVERSPEED);
-		
+
 		if(particle.invalid) return;
-		
+
 		particle.resetDistance();
 		this.power -= this.usage * mult;
 	}
@@ -96,7 +96,7 @@ public class TileEntityPADipole extends TileEntityCooledBase implements IGUIProv
 		particle.dir = dir;
 		return new BlockPos(xCoord, yCoord, zCoord).offset(dir, 2);
 	}
-	
+
 	public boolean checkRedstone() {
 		for(DirPos pos : getConPos()) {
 			if(worldObj.isBlockIndirectlyGettingPowered(pos.getX(), pos.getY(), pos.getZ())) return true;
@@ -106,11 +106,11 @@ public class TileEntityPADipole extends TileEntityCooledBase implements IGUIProv
 
 	@Override
 	public void updateEntity() {
-		
+
 		if(!worldObj.isRemote) {
 			this.power = Library.chargeTEFromItems(slots, 0, power, this.getMaxPower());
 		}
-		
+
 		super.updateEntity();
 	}
 
@@ -151,12 +151,12 @@ public class TileEntityPADipole extends TileEntityCooledBase implements IGUIProv
 		nbt.setInteger("dirRedstone", dirRedstone);
 		nbt.setInteger("threshold", threshold);
 	}
-	
+
 	AxisAlignedBB bb = null;
-	
+
 	@Override
 	public AxisAlignedBB getRenderBoundingBox() {
-		
+
 		if(bb == null) {
 			bb = AxisAlignedBB.getBoundingBox(
 					xCoord - 1,
@@ -167,10 +167,10 @@ public class TileEntityPADipole extends TileEntityCooledBase implements IGUIProv
 					zCoord + 2
 					);
 		}
-		
+
 		return bb;
 	}
-	
+
 	@Override
 	@SideOnly(Side.CLIENT)
 	public double getMaxRenderDistanceSquared() {
@@ -216,10 +216,10 @@ public class TileEntityPADipole extends TileEntityCooledBase implements IGUIProv
 		if(this.dirLower > 3) this.dirLower -= 4;
 		if(this.dirUpper > 3) this.dirUpper -= 4;
 		if(this.dirRedstone > 3) this.dirRedstone -= 4;
-		
+
 		this.threshold = MathHelper.clamp_int(threshold, 0, 999_999_999);
 	}
-	
+
 	public static ForgeDirection ditToForgeDir(int dir) {
 		if(dir == 1) return ForgeDirection.EAST;
 		if(dir == 2) return ForgeDirection.SOUTH;

--- a/src/main/java/com/hbm/tileentity/machine/albion/TileEntityPASource.java
+++ b/src/main/java/com/hbm/tileentity/machine/albion/TileEntityPASource.java
@@ -233,6 +233,47 @@ public class TileEntityPASource extends TileEntityCooledBase implements IGUIProv
 		}
 	}
 
+	@Override
+	public void writeToNBT(NBTTagCompound nbt) {
+		super.writeToNBT(nbt);
+		NBTTagCompound particleTag = new NBTTagCompound();
+		particleTag.setInteger("x", particle.x);
+		particleTag.setInteger("y", particle.y);
+		particleTag.setInteger("z", particle.z);
+		particleTag.setByte("dir", (byte) particle.dir.ordinal());
+		particleTag.setInteger("momentum", particle.momentum);
+		particleTag.setInteger("defocus", particle.defocus);
+		particleTag.setInteger("dist", particle.distanceTraveled);
+
+		NBTTagCompound inputTag1 = new NBTTagCompound();
+		NBTTagCompound inputTag2 = new NBTTagCompound();
+		particle.input1.writeToNBT(inputTag1);
+		particle.input2.writeToNBT(inputTag2);
+
+		particleTag.setTag("input1", inputTag1);
+		particleTag.setTag("input2", inputTag2);
+		nbt.setTag("particle", particleTag);
+	}
+
+	@Override
+	public void readFromNBT(NBTTagCompound nbt) {
+		super.readFromNBT(nbt);
+		if(!nbt.hasKey("particle")) return;
+
+		NBTTagCompound particleTag = nbt.getCompoundTag("particle");
+		int x = particleTag.getInteger("x");
+		int y = particleTag.getInteger("y");
+		int z = particleTag.getInteger("z");
+		ForgeDirection dir = EnumUtil.grabEnumSafely(ForgeDirection.class, particleTag.getInteger("dir"));
+		ItemStack input1 = ItemStack.loadItemStackFromNBT(particleTag.getCompoundTag("input1"));
+		ItemStack input2 = ItemStack.loadItemStackFromNBT(particleTag.getCompoundTag("input2"));
+
+		this.particle = new Particle(this, x, y, z, dir, input1, input2);
+		this.particle.momentum = particleTag.getInteger("momentum");
+		this.particle.defocus = particleTag.getInteger("defocus");
+		this.particle.distanceTraveled = particleTag.getInteger("dist");
+	}
+
 	public static class Particle {
 
 		private TileEntityPASource source;


### PR DESCRIPTION
Fixes the particle source not saving the current particle on unload, causing inflight recipes to be deleted.

Changes the behavior of dipole magnets to only apply the coil power penalties when it's redirecting the particle.

This change allows for single loop particle accelerators without having to meet the minimum length requirement while injecting into the loop from the particle source, as long as it's inline with the direction of the loop.

I've seen multiple people confused as to why their particle was immediately crashing upon leaving the particle source, and this should fix that issue.
It also allows slightly more convenient particle routing for more complex accelerator setups :)

Let me know if you need any further clarification or changes made.