### PR TITLE
Reduce calls to System.currentTimeMillis

### DIFF
--- a/src/main/java/com/hbm/main/ModEventHandlerClient.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerClient.java
@@ -133,7 +133,7 @@ public class ModEventHandlerClient {
 		EntityPlayer player = Minecraft.getMinecraft().thePlayer;
 
 		/// NUKE FLASH ///
-		if(event.type == ElementType.CROSSHAIRS && (flashTimestamp + flashDuration - System.currentTimeMillis()) > 0 && ClientConfig.NUKE_HUD_FLASH.get()) {
+		if(event.type == ElementType.CROSSHAIRS && (flashTimestamp + flashDuration - Clock.get_ms()) > 0 && ClientConfig.NUKE_HUD_FLASH.get()) {
 			int width = event.resolution.getScaledWidth();
 			int height = event.resolution.getScaledHeight();
 			Tessellator tess = Tessellator.instance;
@@ -143,7 +143,7 @@ public class ModEventHandlerClient {
 			GL11.glAlphaFunc(GL11.GL_GEQUAL, 0.0F);
 			GL11.glDepthMask(false);
 			tess.startDrawingQuads();
-			float brightness = (flashTimestamp + flashDuration - System.currentTimeMillis()) / (float) flashDuration;
+			float brightness = (flashTimestamp + flashDuration - Clock.get_ms()) / (float) flashDuration;
 			tess.setColorRGBA_F(1F, 1F, 1F, brightness * 1F);
 			tess.addVertex(width, 0, 0);
 			tess.addVertex(0, 0, 0);
@@ -333,7 +333,7 @@ public class ModEventHandlerClient {
 				if(animation.holdLastFrame)
 					continue;
 
-				long time = System.currentTimeMillis() - animation.startMillis;
+				long time = Clock.get_ms() - animation.startMillis;
 
 				if(time > animation.animation.getDuration())
 					HbmAnimations.hotbar[i][j] = null;
@@ -804,7 +804,7 @@ public class ModEventHandlerClient {
 			if(cannery != null) {
 				list.add(EnumChatFormatting.GREEN + I18nUtil.resolveKey("cannery.f1"));
 				lastCannery = comp;
-				canneryTimestamp = System.currentTimeMillis();
+				canneryTimestamp = Clock.get_ms();
 			}
 		} catch(Exception ex) {
 			list.add(EnumChatFormatting.RED + "Error loading cannery: " + ex.getLocalizedMessage());
@@ -849,7 +849,7 @@ public class ModEventHandlerClient {
 
 		int w = resolution.getScaledWidth();
 		int h = resolution.getScaledHeight();
-		double off = System.currentTimeMillis() / -10000D % 10000D;
+		double off = Clock.get_ms() / -10000D % 10000D;
 		double aw = 25;
 
 		Tessellator tessellator = Tessellator.instance;
@@ -938,7 +938,7 @@ public class ModEventHandlerClient {
 
 		if(Keyboard.isKeyDown(Keyboard.KEY_F1) && Minecraft.getMinecraft().currentScreen != null) {
 
-			ComparableStack comp = canneryTimestamp > System.currentTimeMillis() - 100 ? lastCannery : null;
+			ComparableStack comp = canneryTimestamp > Clock.get_ms() - 100 ? lastCannery : null;
 
 			if(comp == null) {
 				ItemStack stack = getMouseOverStack();
@@ -1114,7 +1114,7 @@ public class ModEventHandlerClient {
 			}
 
 			EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-			long millis = System.currentTimeMillis();
+			long millis = Clock.get_ms();
 
 			if(lastStarCheck + 200 < millis) {
 				renderLodeStar = false; // GENUINELY shut the fuck up i'm not kidding
@@ -1222,6 +1222,8 @@ public class ModEventHandlerClient {
 	@SubscribeEvent
 	public void onRenderWorldLastEvent(RenderWorldLastEvent event) {
 
+		Clock.update();
+
 		GL11.glPushMatrix();
 
 		EntityPlayer player = Minecraft.getMinecraft().thePlayer;
@@ -1248,8 +1250,8 @@ public class ModEventHandlerClient {
 			GL11.glRotated(80, 0, 0, 1);
 			GL11.glRotated(30, 0, 1, 0);
 
-			double sine = Math.sin(System.currentTimeMillis() * 0.0005) * 5;
-			double sin3 = Math.sin(System.currentTimeMillis() * 0.0005 + Math.PI * 0.5) * 5;
+			double sine = Math.sin(Clock.get_ms() * 0.0005) * 5;
+			double sin3 = Math.sin(Clock.get_ms() * 0.0005 + Math.PI * 0.5) * 5;
 			GL11.glRotated(sine, 0, 0, 1);
 			GL11.glRotated(sin3, 1, 0, 0);
 
@@ -1257,7 +1259,7 @@ public class ModEventHandlerClient {
 			OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 6500F, 30F);
 			SoyuzPronter.prontCapsule();
 
-			GL11.glRotated(System.currentTimeMillis() * 0.025 % 360, 0, -1, 0);
+			GL11.glRotated(Clock.get_ms() * 0.025 % 360, 0, -1, 0);
 
 			int rand = new Random(MainRegistry.startupTime).nextInt(HTTPHandler.capsule.size());
 			String msg = HTTPHandler.capsule.get(rand);

--- a/src/main/java/com/hbm/main/ModEventHandlerRenderer.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerRenderer.java
@@ -10,6 +10,7 @@ import com.hbm.items.weapon.sedna.ItemGunBaseNT;
 import com.hbm.packet.PermaSyncHandler;
 import com.hbm.render.item.weapon.sedna.ItemRenderWeaponBase;
 import com.hbm.render.model.ModelMan;
+import com.hbm.util.Clock;
 import com.hbm.world.biome.BiomeGenCraterBase;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -544,11 +545,11 @@ public class ModEventHandlerRenderer {
 	/** Same procedure as getting the blended sky color but for fog */
 	public static Vec3 getFogBlendColor(World world, int playerX, int playerZ, float red, float green, float blue, double partialTicks) {
 
-		long millis = System.currentTimeMillis() - fogTimer;
+		long millis = Clock.get_ms() - fogTimer;
 		if(playerX == fogX && playerZ == fogZ && fogInit && millis < 3000) return fogRGBMultiplier;
 
 		fogInit = true;
-		fogTimer = System.currentTimeMillis();
+		fogTimer = Clock.get_ms();
 		GameSettings settings = Minecraft.getMinecraft().gameSettings;
 		int[] ranges = ForgeModContainer.blendRanges;
 		int distance = 0;

--- a/src/main/java/com/hbm/render/anim/HbmAnimations.java
+++ b/src/main/java/com/hbm/render/anim/HbmAnimations.java
@@ -1,5 +1,6 @@
 package com.hbm.render.anim;
 
+import com.hbm.util.Clock;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -98,7 +99,7 @@ public class HbmAnimations {
 		if(anim != null) {
 			
 			BusAnimation buses = anim.animation;
-			int millis = (int)(System.currentTimeMillis() - anim.startMillis);
+			int millis = (int)(Clock.get_ms() - anim.startMillis);
 
 			BusAnimationSequence seq = buses.getBus(bus);
 			

--- a/src/main/java/com/hbm/render/loader/HbmFace.java
+++ b/src/main/java/com/hbm/render/loader/HbmFace.java
@@ -14,13 +14,13 @@ public class HbmFace {
     public TextureCoordinate[] textureCoordinates;
 
     @SideOnly(Side.CLIENT)
-    public void addFaceForRender(Tessellator tessellator)
+    public void addFaceForRender(float currentTime, Tessellator tessellator)
     {
-        addFaceForRender(tessellator, 0.0005F);
+        addFaceForRender(currentTime, tessellator, 0.0005F);
     }
 
     @SideOnly(Side.CLIENT)
-    public void addFaceForRender(Tessellator tessellator, float textureOffset)
+    public void addFaceForRender(float currentTime, Tessellator tessellator, float textureOffset)
     {
         if (faceNormal == null)
         {
@@ -31,6 +31,7 @@ public class HbmFace {
 
         float averageU = 0F;
         float averageV = 0F;
+	float animOffset = 0F;
 
         if ((textureCoordinates != null) && (textureCoordinates.length > 0))
         {
@@ -42,6 +43,7 @@ public class HbmFace {
 
             averageU = averageU / textureCoordinates.length;
             averageV = averageV / textureCoordinates.length;
+	    animOffset = (float)(((double)currentTime % HmfController.modoloMod) / HmfController.quotientMod);
         }
 
         float offsetU, offsetV;
@@ -63,7 +65,7 @@ public class HbmFace {
                     offsetV = -offsetV;
                 }
 
-                tessellator.addVertexWithUV(vertices[i].x, vertices[i].y, vertices[i].z, textureCoordinates[i].u + offsetU, textureCoordinates[i].v + offsetV + (((double)System.currentTimeMillis() % HmfController.modoloMod) / HmfController.quotientMod));
+                tessellator.addVertexWithUV(vertices[i].x, vertices[i].y, vertices[i].z, textureCoordinates[i].u + offsetU, textureCoordinates[i].v + offsetV + animOffset);
             }
             else
             {

--- a/src/main/java/com/hbm/render/loader/HbmGroupObject.java
+++ b/src/main/java/com/hbm/render/loader/HbmGroupObject.java
@@ -29,25 +29,25 @@ public class HbmGroupObject {
     }
 
     @SideOnly(Side.CLIENT)
-    public void render()
+    public void render(float currentTime)
     {
         if (faces.size() > 0)
         {
             Tessellator tessellator = Tessellator.instance;
             tessellator.startDrawing(glDrawingMode);
-            render(tessellator);
+            render(currentTime, tessellator);
             tessellator.draw();
         }
     }
 
     @SideOnly(Side.CLIENT)
-    public void render(Tessellator tessellator)
+    public void render(float currentTime, Tessellator tessellator)
     {
         if (faces.size() > 0)
         {
             for (HbmFace face : faces)
             {
-                face.addFaceForRender(tessellator);
+                face.addFaceForRender(currentTime, tessellator);
             }
         }
     }

--- a/src/main/java/com/hbm/render/loader/HbmModelObject.java
+++ b/src/main/java/com/hbm/render/loader/HbmModelObject.java
@@ -21,6 +21,8 @@ import net.minecraftforge.client.model.ModelFormatException;
 import net.minecraftforge.client.model.obj.TextureCoordinate;
 import net.minecraftforge.client.model.obj.Vertex;
 
+import com.hbm.util.Clock;
+
 public class HbmModelObject implements IModelCustom {
     private static Pattern vertexPattern = Pattern.compile("(v( (\\-){0,1}\\d+(\\.\\d+)?){3,4} *\\n)|(v( (\\-){0,1}\\d+(\\.\\d+)?){3,4} *$)");
     private static Pattern vertexNormalPattern = Pattern.compile("(vn( (\\-){0,1}\\d+(\\.\\d+)?){3,4} *\\n)|(vn( (\\-){0,1}\\d+(\\.\\d+)?){3,4} *$)");
@@ -188,7 +190,7 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void tessellateAll(Tessellator tessellator)
     {
-	float currentTime = System.currentTimeMillis();
+	float currentTime = Clock.get_ms();
         for (HbmGroupObject groupObject : groupObjects)
         {
             groupObject.render(currentTime, tessellator);
@@ -199,7 +201,7 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void renderOnly(String... groupNames)
     {
-	float currentTime = System.currentTimeMillis();
+	float currentTime = Clock.get_ms();
         for (HbmGroupObject groupObject : groupObjects)
         {
             for (String groupName : groupNames)
@@ -214,7 +216,7 @@ public class HbmModelObject implements IModelCustom {
 
     @SideOnly(Side.CLIENT)
     public void tessellateOnly(Tessellator tessellator, String... groupNames) {
-	float currentTime = System.currentTimeMillis();
+	float currentTime = Clock.get_ms();
         for (HbmGroupObject groupObject : groupObjects)
         {
             for (String groupName : groupNames)
@@ -231,7 +233,7 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void renderPart(String partName)
     {
-	float currentTime = System.currentTimeMillis();
+	float currentTime = Clock.get_ms();
         for (HbmGroupObject groupObject : groupObjects)
         {
             if (partName.equalsIgnoreCase(groupObject.name))
@@ -243,7 +245,7 @@ public class HbmModelObject implements IModelCustom {
 
     @SideOnly(Side.CLIENT)
     public void tessellatePart(Tessellator tessellator, String partName) {
-	float currentTime = System.currentTimeMillis();
+	float currentTime = Clock.get_ms();
         for (HbmGroupObject groupObject : groupObjects)
         {
             if (partName.equalsIgnoreCase(groupObject.name))
@@ -257,7 +259,7 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void renderAllExcept(String... excludedGroupNames)
     {
-	float currentTime = System.currentTimeMillis();
+	float currentTime = Clock.get_ms();
         for (HbmGroupObject groupObject : groupObjects)
         {
             boolean skipPart=false;
@@ -278,7 +280,7 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void tessellateAllExcept(Tessellator tessellator, String... excludedGroupNames)
     {
-	float currentTime = System.currentTimeMillis();
+	float currentTime = Clock.get_ms();
         boolean exclude;
         for (HbmGroupObject groupObject : groupObjects)
         {

--- a/src/main/java/com/hbm/render/loader/HbmModelObject.java
+++ b/src/main/java/com/hbm/render/loader/HbmModelObject.java
@@ -188,9 +188,10 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void tessellateAll(Tessellator tessellator)
     {
+	float currentTime = System.currentTimeMillis();
         for (HbmGroupObject groupObject : groupObjects)
         {
-            groupObject.render(tessellator);
+            groupObject.render(currentTime, tessellator);
         }
     }
 
@@ -198,13 +199,14 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void renderOnly(String... groupNames)
     {
+	float currentTime = System.currentTimeMillis();
         for (HbmGroupObject groupObject : groupObjects)
         {
             for (String groupName : groupNames)
             {
                 if (groupName.equalsIgnoreCase(groupObject.name))
                 {
-                    groupObject.render();
+                    groupObject.render(currentTime);
                 }
             }
         }
@@ -212,13 +214,14 @@ public class HbmModelObject implements IModelCustom {
 
     @SideOnly(Side.CLIENT)
     public void tessellateOnly(Tessellator tessellator, String... groupNames) {
+	float currentTime = System.currentTimeMillis();
         for (HbmGroupObject groupObject : groupObjects)
         {
             for (String groupName : groupNames)
             {
                 if (groupName.equalsIgnoreCase(groupObject.name))
                 {
-                    groupObject.render(tessellator);
+                    groupObject.render(currentTime, tessellator);
                 }
             }
         }
@@ -228,22 +231,24 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void renderPart(String partName)
     {
+	float currentTime = System.currentTimeMillis();
         for (HbmGroupObject groupObject : groupObjects)
         {
             if (partName.equalsIgnoreCase(groupObject.name))
             {
-                groupObject.render();
+                groupObject.render(currentTime);
             }
         }
     }
 
     @SideOnly(Side.CLIENT)
     public void tessellatePart(Tessellator tessellator, String partName) {
+	float currentTime = System.currentTimeMillis();
         for (HbmGroupObject groupObject : groupObjects)
         {
             if (partName.equalsIgnoreCase(groupObject.name))
             {
-                groupObject.render(tessellator);
+                groupObject.render(currentTime, tessellator);
             }
         }
     }
@@ -252,6 +257,7 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void renderAllExcept(String... excludedGroupNames)
     {
+	float currentTime = System.currentTimeMillis();
         for (HbmGroupObject groupObject : groupObjects)
         {
             boolean skipPart=false;
@@ -264,7 +270,7 @@ public class HbmModelObject implements IModelCustom {
             }
             if(!skipPart)
             {
-                groupObject.render();
+                groupObject.render(currentTime);
             }
         }
     }
@@ -272,6 +278,7 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void tessellateAllExcept(Tessellator tessellator, String... excludedGroupNames)
     {
+	float currentTime = System.currentTimeMillis();
         boolean exclude;
         for (HbmGroupObject groupObject : groupObjects)
         {
@@ -285,7 +292,7 @@ public class HbmModelObject implements IModelCustom {
             }
             if(!exclude)
             {
-                groupObject.render(tessellator);
+                groupObject.render(currentTime, tessellator);
             }
         }
     }

--- a/src/main/java/com/hbm/render/tileentity/RenderChemplant.java
+++ b/src/main/java/com/hbm/render/tileentity/RenderChemplant.java
@@ -5,6 +5,7 @@ import org.lwjgl.opengl.GL11;
 import com.hbm.blocks.BlockDummyable;
 import com.hbm.inventory.fluid.Fluids;
 import com.hbm.main.ResourceManager;
+import com.hbm.util.Clock;
 import com.hbm.render.loader.HmfController;
 import com.hbm.tileentity.machine.TileEntityMachineChemplant;
 
@@ -77,7 +78,7 @@ public class RenderChemplant extends TileEntitySpecialRenderer {
 		
 		bindTexture(ResourceManager.chemplant_spinner_tex);
 
-		int rotation = (int) (System.currentTimeMillis() % (360 * 5)) / 5;
+		int rotation = (int) (Clock.get_ms() % (360 * 5)) / 5;
 
 		GL11.glPushMatrix();
 		GL11.glTranslated(-0.625, 0, 0.625);
@@ -101,7 +102,7 @@ public class RenderChemplant extends TileEntitySpecialRenderer {
 		ResourceManager.chemplant_spinner.renderAll();
 		GL11.glPopMatrix();
 
-		double push = Math.sin((System.currentTimeMillis() % 2000) / 1000D * Math.PI) * 0.25 - 0.25;
+		double push = Math.sin((Clock.get_ms() % 2000) / 1000D * Math.PI) * 0.25 - 0.25;
 
 		bindTexture(ResourceManager.chemplant_piston_tex);
 

--- a/src/main/java/com/hbm/render/util/RenderOverhead.java
+++ b/src/main/java/com/hbm/render/util/RenderOverhead.java
@@ -10,6 +10,7 @@ import org.lwjgl.opengl.GL11;
 
 import com.hbm.util.fauxpointtwelve.BlockPos;
 import com.hbm.wiaj.WorldInAJar;
+import com.hbm.util.Clock;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
@@ -272,7 +273,7 @@ public class RenderOverhead {
 
 			tagList.add(entry);
 
-			if(marker.expire > 0 && System.currentTimeMillis() > marker.expire) {
+			if(marker.expire > 0 && Clock.get_ms() > marker.expire) {
 				it.remove();
 			} else if(marker.maxDist > 0) {
 				double aX = pX + (maxX - minX) / 2D;

--- a/src/main/java/com/hbm/render/util/RenderScreenOverlay.java
+++ b/src/main/java/com/hbm/render/util/RenderScreenOverlay.java
@@ -10,6 +10,7 @@ import com.hbm.interfaces.Untested;
 import com.hbm.items.weapon.sedna.Crosshair;
 import com.hbm.items.weapon.sedna.impl.ItemGunStinger;
 import com.hbm.lib.RefStrings;
+import com.hbm.util.Clock;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
@@ -47,8 +48,8 @@ public class RenderScreenOverlay {
 
 		radiation = lastResult - prevResult;
 
-		if(System.currentTimeMillis() >= lastSurvey + 1000) {
-			lastSurvey = System.currentTimeMillis();
+		if(Clock.get_ms() >= lastSurvey + 1000) {
+			lastSurvey = Clock.get_ms();
 			prevResult = lastResult;
 			lastResult = in;
 		}

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineChemplant.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineChemplant.java
@@ -173,7 +173,7 @@ public class TileEntityMachineChemplant extends TileEntityMachineBase implements
 			if(isProgressing && volume > 0) {
 
 				if(audio == null) {
-					audio = this.createAudioLoop();
+					audio = createAudioLoop();
 					audio.updateVolume(volume);
 					audio.startSound();
 				} else if(!audio.isPlaying()) {

--- a/src/main/java/com/hbm/util/Clock.java
+++ b/src/main/java/com/hbm/util/Clock.java
@@ -1,0 +1,11 @@
+package com.hbm.util;
+
+public class Clock {
+    private static long time_ms;
+    public static void update(){
+	time_ms = System.currentTimeMillis();
+    }
+    public static long get_ms(){
+	return time_ms;
+    }
+}


### PR DESCRIPTION
This change makes scenes that use animated textures much faster to render as it only needs to call System.currentTimeMillis once per frame instead of once per vertex. This has a much bigger impact on my machine than Spark (a profiler) would suggest, and I believe that this is because it uses a system call and so spends much of its time executing kernel code, which is presumably not counted by Spark.

I remember hearing about people changing their BIOSes or kernel configs to use a less accurate (but faster) timer, things like this are probably why.