### PR TITLE
Sliding blast door rail support

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@
   * Identical to the regular ammo bag, but ammo is never depleted
   * Provides 9,999 units of ammo for the purposes of reloading/belts, meaning that even a single bullet in the bag allows a full reload
   * Obviously creative-only
+* Sliding blast door can have rails placed on them and replaces them back when opening
 
 ## Changed
 * Nerfed AP and DU round damage multiplier

--- a/changelog
+++ b/changelog
@@ -32,3 +32,4 @@
 * Fixed dupe regarding breaking transport drones
 * Fixed 12 gauge flechette DT negation not being the intended value
 * Fixed carbine mistakenly showing a round being chambered even after firing the last loaded round
+* Fixed huge log spam due to a block not being saved correctly

--- a/src/main/java/com/hbm/blocks/machine/BlastDoor.java
+++ b/src/main/java/com/hbm/blocks/machine/BlastDoor.java
@@ -13,7 +13,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 
 public class BlastDoor extends BlockContainer implements IBomb, IMultiblock {
 
@@ -25,17 +27,17 @@ public class BlastDoor extends BlockContainer implements IBomb, IMultiblock {
 	public TileEntity createNewTileEntity(World p_149915_1_, int p_149915_2_) {
 		return new TileEntityBlastDoor();
 	}
-	
+
 	@Override
 	public int getRenderType(){
 		return -1;
 	}
-	
+
 	@Override
 	public boolean isOpaqueCube() {
 		return false;
 	}
-	
+
 	@Override
 	public boolean renderAsNormalBlock() {
 		return false;
@@ -43,23 +45,23 @@ public class BlastDoor extends BlockContainer implements IBomb, IMultiblock {
 
 	@Override
 	public BombReturnCode explode(World world, int x, int y, int z) {
-		
+
 		if(!world.isRemote) {
 			TileEntityBlastDoor entity = (TileEntityBlastDoor) world.getTileEntity(x, y, z);
 			if(entity != null) {
-				
+
 				if(!entity.isLocked()) {
 					entity.tryToggle();
 					return BombReturnCode.TRIGGERED;
 				}
-				
+
 				return BombReturnCode.ERROR_INCOMPATIBLE;
 			}
 		}
-		
+
 		return BombReturnCode.UNDEFINED;
 	}
-	
+
 	@Override
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
 		if(world.isRemote)
@@ -67,9 +69,9 @@ public class BlastDoor extends BlockContainer implements IBomb, IMultiblock {
 			return true;
 		} else if(player.getHeldItem() != null && (player.getHeldItem().getItem() instanceof ItemLock || player.getHeldItem().getItem() == ModItems.key_kit)) {
 			return false;
-			
+
 		} if(!player.isSneaking()) {
-			
+
 			TileEntityBlastDoor entity = (TileEntityBlastDoor) world.getTileEntity(x, y, z);
 			if(entity != null)
 			{
@@ -80,20 +82,20 @@ public class BlastDoor extends BlockContainer implements IBomb, IMultiblock {
 					entity.tryToggle();
 				}
 			}
-			
+
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	@Override
 	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase player, ItemStack itemStack) {
-		
+
 		TileEntityBlastDoor te = (TileEntityBlastDoor) world.getTileEntity(x, y, z);
-		
+
 		int i = MathHelper.floor_double(player.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
-		
+
 		if(i == 0)
 		{
 			world.setBlockMetadataWithNotify(x, y, z, 2, 2);
@@ -110,7 +112,7 @@ public class BlastDoor extends BlockContainer implements IBomb, IMultiblock {
 		{
 			world.setBlockMetadataWithNotify(x, y, z, 3, 2);
 		}
-		
+
 		//frame
 		if(!(te.placeDummy(x, y + 1, z) &&
 			te.placeDummy(x, y + 2, z) &&
@@ -121,4 +123,8 @@ public class BlastDoor extends BlockContainer implements IBomb, IMultiblock {
 			world.func_147480_a(x, y, z, true);
 	}
 
+	@Override
+	public boolean isSideSolid(IBlockAccess world, int x, int y, int z, ForgeDirection side) {
+		return side == ForgeDirection.UP || super.isSideSolid(world, x, y, z, side);
+	}
 }

--- a/src/main/java/com/hbm/tileentity/machine/albion/TileEntityPASource.java
+++ b/src/main/java/com/hbm/tileentity/machine/albion/TileEntityPASource.java
@@ -236,6 +236,8 @@ public class TileEntityPASource extends TileEntityCooledBase implements IGUIProv
 	@Override
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
+		if(particle == null) return;
+
 		NBTTagCompound particleTag = new NBTTagCompound();
 		particleTag.setInteger("x", particle.x);
 		particleTag.setInteger("y", particle.y);


### PR DESCRIPTION
This PR allows rails to be placed on the Sliding blast door base. When the door closes, it breaks the rail, so it's still blast proof. When the door reopens, the rail is placed back (preserved rail block name and metadata).

Feature testing:
- Singleplayer
  - Normal, special (powered, activator) and HBM's rails (high speed, wooden, etc) removed and placed
  - Rail rotation preserved
- Multiplayer
  - Same tests, everything seems to work

The PR also includes the small fix of a tileentity not being saved, as this fix was already implemented. Feel free to tell if it's already on your local repository so i can remove it to avoid merging issues.