### PR TITLE
Prevents the automatic buzz saw from cutting saplings

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineAutosaw.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineAutosaw.java
@@ -216,6 +216,9 @@ public class TileEntityMachineAutosaw extends TileEntityLoadedBase implements IB
 		if(b == ModBlocks.plant_tall) {
 			return meta == EnumTallFlower.CD2.ordinal() + 8 || meta == EnumTallFlower.CD3.ordinal() + 8;
 		}
+		if(b == Blocks.sapling) {
+			return true;
+		}
 
 		return false;
 	}


### PR DESCRIPTION
The automatic buzz saw can't be used to create automated tree farms because it detects and cuts down saplings. Adding a case for saplings to the shouldIgnore function fixes this behaviour.