### PR TITLE
Fix interaction between conveyor ejector and conveyor splitter

### DIFF
--- a/src/main/java/com/hbm/tileentity/network/TileEntityCraneExtractor.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityCraneExtractor.java
@@ -1,6 +1,8 @@
 package com.hbm.tileentity.network;
 
 import api.hbm.conveyor.IConveyorBelt;
+import api.hbm.conveyor.IEnterableBlock;
+
 import com.hbm.entity.item.EntityMovingItem;
 import com.hbm.inventory.container.ContainerCraneExtractor;
 import com.hbm.inventory.gui.GUICraneExtractor;
@@ -123,6 +125,11 @@ public class TileEntityCraneExtractor extends TileEntityCraneBase implements IGU
 									moving.setPosition(snap.xCoord, snap.yCoord, snap.zCoord);
 									moving.setItemStack(stack);
 									worldObj.spawnEntityInWorld(moving);
+
+									if (b instanceof IEnterableBlock) {
+										((IEnterableBlock)b).onItemEnter(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, outputSide, moving);
+									}
+
 									hasSent = true;
 									break;
 								}

--- a/src/main/java/com/hbm/tileentity/network/TileEntityCraneExtractor.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityCraneExtractor.java
@@ -129,8 +129,8 @@ public class TileEntityCraneExtractor extends TileEntityCraneBase implements IGU
 									if (b instanceof IEnterableBlock) {
 										IEnterableBlock enterable = (IEnterableBlock) b;
 
-										if(enterable.canItemEnter(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, outputSide, moving)) {
-											enterable.onItemEnter(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, outputSide, moving);
+										if(enterable.canItemEnter(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, outputSide.getOpposite(), moving)) {
+											enterable.onItemEnter(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, outputSide.getOpposite(), moving);
 											moving.setDead();
 										}
 									}

--- a/src/main/java/com/hbm/tileentity/network/TileEntityCraneExtractor.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityCraneExtractor.java
@@ -127,7 +127,12 @@ public class TileEntityCraneExtractor extends TileEntityCraneBase implements IGU
 									worldObj.spawnEntityInWorld(moving);
 
 									if (b instanceof IEnterableBlock) {
-										((IEnterableBlock)b).onItemEnter(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, outputSide, moving);
+										IEnterableBlock enterable = (IEnterableBlock) b;
+
+										if(enterable.canItemEnter(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, outputSide, moving)) {
+											enterable.onItemEnter(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, outputSide, moving);
+											moving.setDead();
+										}
 									}
 
 									hasSent = true;

--- a/src/main/java/com/hbm/tileentity/network/TileEntityCraneExtractor.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityCraneExtractor.java
@@ -119,22 +119,7 @@ public class TileEntityCraneExtractor extends TileEntityCraneBase implements IGU
 									inv.decrStackSize(index, toSend);
 									stack.stackSize = toSend;
 									
-									EntityMovingItem moving = new EntityMovingItem(worldObj);
-									Vec3 pos = Vec3.createVectorHelper(xCoord + 0.5 + outputSide.offsetX * 0.55, yCoord + 0.5 + outputSide.offsetY * 0.55, zCoord + 0.5 + outputSide.offsetZ * 0.55);
-									Vec3 snap = belt.getClosestSnappingPosition(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, pos);
-									moving.setPosition(snap.xCoord, snap.yCoord, snap.zCoord);
-									moving.setItemStack(stack);
-									worldObj.spawnEntityInWorld(moving);
-
-									if (b instanceof IEnterableBlock) {
-										IEnterableBlock enterable = (IEnterableBlock) b;
-
-										if(enterable.canItemEnter(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, outputSide.getOpposite(), moving)) {
-											enterable.onItemEnter(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, outputSide.getOpposite(), moving);
-											moving.setDead();
-										}
-									}
-
+									sendItem(stack, belt, outputSide);
 									hasSent = true;
 									break;
 								}
@@ -154,12 +139,7 @@ public class TileEntityCraneExtractor extends TileEntityCraneBase implements IGU
 								decrStackSize(i, toSend);
 								stack.stackSize = toSend;
 								
-								EntityMovingItem moving = new EntityMovingItem(worldObj);
-								Vec3 pos = Vec3.createVectorHelper(xCoord + 0.5 + outputSide.offsetX * 0.55, yCoord + 0.5 + outputSide.offsetY * 0.55, zCoord + 0.5 + outputSide.offsetZ * 0.55);
-								Vec3 snap = belt.getClosestSnappingPosition(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, pos);
-								moving.setPosition(snap.xCoord, snap.yCoord, snap.zCoord);
-								moving.setItemStack(stack);
-								worldObj.spawnEntityInWorld(moving);
+								sendItem(stack, belt, outputSide);
 								break;
 							}
 						}
@@ -168,6 +148,24 @@ public class TileEntityCraneExtractor extends TileEntityCraneBase implements IGU
 			}
 
 			this.networkPackNT(15);
+		}
+	}
+
+	private void sendItem(ItemStack stack, IConveyorBelt belt, ForgeDirection outputSide) {
+		EntityMovingItem moving = new EntityMovingItem(worldObj);
+		Vec3 pos = Vec3.createVectorHelper(xCoord + 0.5 + outputSide.offsetX * 0.55, yCoord + 0.5 + outputSide.offsetY * 0.55, zCoord + 0.5 + outputSide.offsetZ * 0.55);
+		Vec3 snap = belt.getClosestSnappingPosition(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, pos);
+		moving.setPosition(snap.xCoord, snap.yCoord, snap.zCoord);
+		moving.setItemStack(stack);
+		worldObj.spawnEntityInWorld(moving);
+
+		if (belt instanceof IEnterableBlock) {
+			IEnterableBlock enterable = (IEnterableBlock) belt;
+
+			if(enterable.canItemEnter(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, outputSide.getOpposite(), moving)) {
+				enterable.onItemEnter(worldObj, xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ, outputSide.getOpposite(), moving);
+				moving.setDead();
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, placing a splitter directly in front of an ejector seems to put the items onto the output belt of a splitter, effectively bypassing its effect. This patch makes the splitting take place.

Note that it doesn't enable chaining an ejector directly into an inserter (or any other similar setups), because the `IEnterableBlock` check only takes place if it satisfies `IConveyorBelt` in the first place.