### PR TITLE
Strand caster fix

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineStrandCaster.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineStrandCaster.java
@@ -11,6 +11,7 @@ import com.hbm.inventory.material.Mats;
 import com.hbm.items.ModItems;
 import com.hbm.items.machine.ItemMold;
 import com.hbm.items.machine.ItemScraps;
+import com.hbm.main.MainRegistry;
 import com.hbm.tileentity.IGUIProvider;
 import com.hbm.util.fauxpointtwelve.DirPos;
 import cpw.mods.fml.relauncher.Side;
@@ -77,7 +78,7 @@ public class TileEntityMachineStrandCaster extends TileEntityFoundryCastingBase 
 			int moldsToCast = maxProcessable();
 		
 			// Makes it flush the buffers after 10 seconds of inactivity, or when they're full
-			if (moldsToCast > 0 && (moldsToCast == 10 || worldObj.getWorldTime() >= lastCastTick + 200)) {
+			if (moldsToCast > 0 && (moldsToCast >= 9 || worldObj.getWorldTime() >= lastCastTick + 200)) {
 
 				ItemMold.Mold mold = this.getInstalledMold();
 				
@@ -107,9 +108,9 @@ public class TileEntityMachineStrandCaster extends TileEntityFoundryCastingBase 
 
 				water.setFill(water.getFill() - getWaterRequired() * moldsToCast);
 				steam.setFill(steam.getFill() + getWaterRequired() * moldsToCast);
-			}
 
-			lastCastTick = worldObj.getWorldTime();
+				lastCastTick = worldObj.getWorldTime();
+			}
 
 			networkPackNT(150);
 		}
@@ -117,7 +118,7 @@ public class TileEntityMachineStrandCaster extends TileEntityFoundryCastingBase 
 
 	private int maxProcessable() {
 		ItemMold.Mold mold = this.getInstalledMold();
-		if (type == null || mold == null || mold.getOutput(type) != null) {
+		if (type == null || mold == null || mold.getOutput(type) == null) {
 			return 0;
 		}
 

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineStrandCaster.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineStrandCaster.java
@@ -85,7 +85,7 @@ public class TileEntityMachineStrandCaster extends TileEntityFoundryCastingBase 
 
 				ItemStack out = mold.getOutput(type);
 				int remaining = out.stackSize * moldsToCast;
-				out.stackSize = out.getMaxStackSize();
+				final int maxStackSize = out.getMaxStackSize();
 
 				for (int i = 1; i < 7; i++) {
 					if (remaining <= 0) {
@@ -97,7 +97,7 @@ public class TileEntityMachineStrandCaster extends TileEntityFoundryCastingBase 
 					}
 
 					if (slots[i].isItemEqual(out)) {
-						int toDeposit = Math.min(remaining, out.stackSize - slots[i].stackSize);
+						int toDeposit = Math.min(remaining, maxStackSize - slots[i].stackSize);
 						slots[i].stackSize += toDeposit;
 						remaining -= toDeposit;
 					}


### PR DESCRIPTION
Per popular demand, the strand caster doesn't get over-full of steam anymore. (There was a bug report in discord)

Also, slot usage is now more efficient -- previously the caster wouldn't attempt to split an output between several slots if it couldn't fit it entirely into one of them.