### PR TITLE
Geiger counter comparator integration

### DIFF
--- a/src/main/java/com/hbm/blocks/machine/GeigerCounter.java
+++ b/src/main/java/com/hbm/blocks/machine/GeigerCounter.java
@@ -131,4 +131,22 @@ public class GeigerCounter extends BlockContainer {
 			return false;
 		}
 	}
+
+	@Override
+	public boolean hasComparatorInputOverride() {
+		return true;
+	}
+
+	@Override
+	public int getComparatorInputOverride(World world, int x, int y, int z, int side) {
+		TileEntityGeiger te = (TileEntityGeiger)world.getTileEntity(x, y, z);
+		if (te == null) return 0;
+
+		float rad = te.check();
+
+		// 0 at exactly 0 rads/sec
+		// +1 per 5 rads/sec
+		// 15 at 75+ rads/sec
+		return Math.min((int)Math.ceil(rad / 5f), 15);
+	}
 }

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityGeiger.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityGeiger.java
@@ -65,6 +65,7 @@ public class TileEntityGeiger extends TileEntity implements SimpleComponent, IIn
 	public float check() {
 		return ChunkRadiationManager.proxy.getRadiation(worldObj, xCoord, yCoord, zCoord);
 	}
+	
 	@Override
 	@Optional.Method(modid = "OpenComputers")
 	public String getComponentName() {

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityGeiger.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityGeiger.java
@@ -35,6 +35,9 @@ public class TileEntityGeiger extends TileEntity implements SimpleComponent, IIn
 		if(timer == 10) {
 			timer = 0;
 			ticker = check();
+
+			// To update the adjacent comparators
+			worldObj.notifyBlocksOfNeighborChange(this.xCoord, this.yCoord, this.zCoord, this.getBlockType());
 		}
 
 		if(timer % 5 == 0) {


### PR DESCRIPTION
A comparator can now read the level of radiation a Geiger counter is detecting:
- 0 at exactly 0 rads/sec
- +1 per 5 rads/sec (the division is rounded up, so 2 rads/sec still gives a signal of 1)
- 15 at 75+ rads/sec

While making this, I noticed there was already ROR-reader compatibility, but I decided to pull through with it anyway. Considering the Geiger counter only really has one value, it makes sense to me to make it work with a comparator without the need for a radio frequency.

This was requested by `@gamerlancer` on discord.
