### PR TITLE
Automatic custom recipe sync for servers

### DIFF
--- a/src/main/java/com/hbm/config/GeneralConfig.java
+++ b/src/main/java/com/hbm/config/GeneralConfig.java
@@ -38,7 +38,7 @@ public class GeneralConfig {
 	public static boolean enableGuideBook = true;
 	public static boolean enableSoundExtension = true;
 	public static boolean enableMekanismChanges = true;
-	public static boolean enableServerRecipeSync = true;
+	public static boolean enableServerRecipeSync = false;
 	public static int normalSoundChannels = 200;
 
 	public static boolean enableExpensiveMode = false;
@@ -82,7 +82,7 @@ public class GeneralConfig {
 		packetThreadingMaxCount = config.get(CATEGORY_GENERAL, "0.03_packetThreadingMaxCount", 1, "Maximum number of threads to create for packet threading. Must be greater than or equal to 0.02_packetThreadingCoreCount.").getInt(1);
 		packetThreadingErrorBypass = config.get(CATEGORY_GENERAL, "0.04_packetThreadingErrorBypass", false, "Forces the bypassing of most packet threading errors, only enable this if directed to or if you know what you're doing.").getBoolean(false);
 
-		enableServerRecipeSync = config.get(CATEGORY_GENERAL, "0.05_enableServerRecipeSync", true, "Syncs any recipes customised via JSON to clients connecting to the server.").getBoolean(true);
+		enableServerRecipeSync = config.get(CATEGORY_GENERAL, "0.05_enableServerRecipeSync", false, "Syncs any recipes customised via JSON to clients connecting to the server.").getBoolean(false);
 
 		enableDebugMode = config.get(CATEGORY_GENERAL, "1.00_enableDebugMode", false, "Enable debugging mode").getBoolean(false);
 		enableMycelium = config.get(CATEGORY_GENERAL, "1.01_enableMyceliumSpread", false, "Allows glowing mycelium to spread").getBoolean(false);

--- a/src/main/java/com/hbm/config/GeneralConfig.java
+++ b/src/main/java/com/hbm/config/GeneralConfig.java
@@ -38,6 +38,7 @@ public class GeneralConfig {
 	public static boolean enableGuideBook = true;
 	public static boolean enableSoundExtension = true;
 	public static boolean enableMekanismChanges = true;
+	public static boolean enableServerRecipeSync = true;
 	public static int normalSoundChannels = 200;
 
 	public static boolean enableExpensiveMode = false;
@@ -80,6 +81,8 @@ public class GeneralConfig {
 		packetThreadingCoreCount = config.get(CATEGORY_GENERAL, "0.02_packetThreadingCoreCount", 1, "Number of core threads to create for packets (recommended 1).").getInt(1);
 		packetThreadingMaxCount = config.get(CATEGORY_GENERAL, "0.03_packetThreadingMaxCount", 1, "Maximum number of threads to create for packet threading. Must be greater than or equal to 0.02_packetThreadingCoreCount.").getInt(1);
 		packetThreadingErrorBypass = config.get(CATEGORY_GENERAL, "0.04_packetThreadingErrorBypass", false, "Forces the bypassing of most packet threading errors, only enable this if directed to or if you know what you're doing.").getBoolean(false);
+
+		enableServerRecipeSync = config.get(CATEGORY_GENERAL, "0.05_enableServerRecipeSync", true, "Syncs any recipes customised via JSON to clients connecting to the server.").getBoolean(true);
 
 		enableDebugMode = config.get(CATEGORY_GENERAL, "1.00_enableDebugMode", false, "Enable debugging mode").getBoolean(false);
 		enableMycelium = config.get(CATEGORY_GENERAL, "1.01_enableMyceliumSpread", false, "Allows glowing mycelium to spread").getBoolean(false);

--- a/src/main/java/com/hbm/inventory/recipes/loader/SerializableRecipe.java
+++ b/src/main/java/com/hbm/inventory/recipes/loader/SerializableRecipe.java
@@ -1,15 +1,12 @@
 package com.hbm.inventory.recipes.loader;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -35,17 +32,19 @@ import net.minecraft.item.ItemStack;
 
 //the anti-spaghetti. this class provides so much functionality and saves so much time, i just love you, SerializableRecipe <3
 public abstract class SerializableRecipe {
-	
+
 	public static final Gson gson = new Gson();
-	public static List<SerializableRecipe> recipeHandlers = new ArrayList();
-	public static List<IRecipeRegisterListener> additionalListeners = new ArrayList();
-	
+	public static List<SerializableRecipe> recipeHandlers = new ArrayList<>();
+	public static List<IRecipeRegisterListener> additionalListeners = new ArrayList<>();
+
+	public static Map<String, InputStream> recipeSyncHandlers = new HashMap<>();
+
 	public boolean modified = false;
-	
+
 	/*
 	 * INIT
 	 */
-	
+
 	public static void registerAllHandlers() {
 		recipeHandlers.add(new PressRecipes());
 		recipeHandlers.add(new BlastFurnaceRecipes());
@@ -82,67 +81,90 @@ public abstract class SerializableRecipe {
 		//AFTER Assembler
 		recipeHandlers.add(new AnvilRecipes());
 		recipeHandlers.add(new PedestalRecipes());
-		
+
 		recipeHandlers.add(new MatDistribution());
 		recipeHandlers.add(new CustomMachineRecipes());
 		//AFTER MatDistribution
 		recipeHandlers.add(new ArcFurnaceRecipes());
 	}
-	
+
 	public static void initialize() {
 		File recDir = new File(MainRegistry.configDir.getAbsolutePath() + File.separatorChar + "hbmRecipes");
-		
+
 		if(!recDir.exists()) {
 			if(!recDir.mkdir()) {
 				throw new IllegalStateException("Unable to make recipe directory " + recDir.getAbsolutePath());
 			}
 		}
-		
+
 		File info = new File(recDir.getAbsolutePath() + File.separatorChar + "REMOVE UNDERSCORE TO ENABLE RECIPE LOADING - RECIPES WILL RESET TO DEFAULT OTHERWISE");
 		try { info.createNewFile(); } catch(IOException e) { }
-		
+
 		MainRegistry.logger.info("Starting recipe init!");
-		
+
 		for(SerializableRecipe recipe : recipeHandlers) {
-			
+
 			recipe.deleteRecipes();
-			
+
 			File recFile = new File(recDir.getAbsolutePath() + File.separatorChar + recipe.getFileName());
-			if(recFile.exists() && recFile.isFile()) {
+			if(recipeSyncHandlers.containsKey(recipe.getFileName())) {
+				MainRegistry.logger.info("Reading synced recipe file " + recipe.getFileName());
+				InputStream stream = recipeSyncHandlers.get(recipe.getFileName());
+
+				try {
+					stream.reset();
+					Reader reader = new InputStreamReader(stream);
+					recipe.readRecipeStream(reader);
+					recipe.modified = true;
+				} catch(IOException ex) {
+					MainRegistry.logger.error("Failed to reset synced recipe stream", ex);
+				}
+			} else if(recFile.exists() && recFile.isFile()) {
 				MainRegistry.logger.info("Reading recipe file " + recFile.getName());
 				recipe.readRecipeFile(recFile);
 				recipe.modified = true;
 			} else {
 				MainRegistry.logger.info("No recipe file found, registering defaults for " + recipe.getFileName());
 				recipe.registerDefaults();
-				
+
 				for(IRecipeRegisterListener listener : additionalListeners) {
 					listener.onRecipeLoad(recipe.getClass().getSimpleName());
 				}
-				
+
 				File recTemplate = new File(recDir.getAbsolutePath() + File.separatorChar + "_" + recipe.getFileName());
 				MainRegistry.logger.info("Writing template file " + recTemplate.getName());
 				recipe.writeTemplateFile(recTemplate);
 				recipe.modified = false;
 			}
-			
+
 			recipe.registerPost();
 		}
-		
+
 		MainRegistry.logger.info("Finished recipe init!");
+	}
+
+	public static void receiveRecipes(String filename, byte[] data) {
+		recipeSyncHandlers.put(filename, new ByteArrayInputStream(data));
+	}
+
+	public static void clearReceivedRecipes() {
+		boolean hasCleared = !recipeSyncHandlers.isEmpty();
+		recipeSyncHandlers.clear();
+
+		if(hasCleared) initialize();
 	}
 
 	/*
 	 * ABSTRACT
 	 */
-	
+
 	/** The machine's (or process') name used for the recipe file */
 	public abstract String getFileName();
 	/** Return the list object holding all the recipes, usually an ArrayList or HashMap */
 	public abstract Object getRecipeObject();
 	/** Will use the supplied JsonElement (usually casts to JsonArray) from the over arching recipe array and adds the recipe to the recipe list object */
 	public abstract void readRecipe(JsonElement recipe);
-	/** Is given a single recipe from the recipe list object (a wrapper, Tuple, array, HashMap Entry, etc) and writes it to the current ongoing GSON stream 
+	/** Is given a single recipe from the recipe list object (a wrapper, Tuple, array, HashMap Entry, etc) and writes it to the current ongoing GSON stream
 	 * @throws IOException */
 	public abstract void writeRecipe(Object recipe, JsonWriter writer) throws IOException;
 	/** Registers the default recipes */
@@ -155,45 +177,45 @@ public abstract class SerializableRecipe {
 	public String getComment() {
 		return null;
 	}
-	
+
 	/*
 	 * JSON R/W WRAPPERS
 	 */
-	
+
 	public void writeTemplateFile(File template) {
-		
+
 		try {
 			/* Get the recipe list object */
 			Object recipeObject = this.getRecipeObject();
 			List recipeList = new ArrayList();
-			
+
 			/* Try to pry all recipes from our list */
 			if(recipeObject instanceof Collection) {
 				recipeList.addAll((Collection) recipeObject);
-				
+
 			} else if(recipeObject instanceof HashMap) {
 				recipeList.addAll(((HashMap) recipeObject).entrySet());
 			}
-			
+
 			if(recipeList.isEmpty())
 				throw new IllegalStateException("Error while writing recipes for " + this.getClass().getSimpleName() + ": Recipe list is either empty or in an unsupported format!");
-			
+
 			JsonWriter writer = new JsonWriter(new FileWriter(template));
 			writer.setIndent("  ");					//pretty formatting
 			writer.beginObject();					//initial '{'
-			
+
 			if(this.getComment() != null) {
 				writer.name("comment").value(this.getComment());
 			}
-			
+
 			writer.name("recipes").beginArray();	//all recipes are stored in an array called "recipes"
-			
+
 			for(Object recipe : recipeList) {
 				writer.beginObject();				//begin object for a single recipe
 				this.writeRecipe(recipe, writer);	//serialize here
 				writer.endObject();					//end recipe object
 			}
-			
+
 			writer.endArray();						//end recipe array
 			writer.endObject();						//final '}'
 			writer.close();
@@ -201,22 +223,25 @@ public abstract class SerializableRecipe {
 			ex.printStackTrace();
 		}
 	}
-	
+
 	public void readRecipeFile(File file) {
-		
 		try {
-			JsonObject json = gson.fromJson(new FileReader(file), JsonObject.class);
-			JsonArray recipes = json.get("recipes").getAsJsonArray();
-			for(JsonElement recipe : recipes) {
-				this.readRecipe(recipe);
-			}
+			readRecipeStream(new FileReader(file));
 		} catch(FileNotFoundException ex) { }
 	}
-	
+
+	public void readRecipeStream(Reader reader) {
+		JsonObject json = gson.fromJson(reader, JsonObject.class);
+		JsonArray recipes = json.get("recipes").getAsJsonArray();
+		for(JsonElement recipe : recipes) {
+			this.readRecipe(recipe);
+		}
+	}
+
 	/*
 	 * JSON IO UTIL
 	 */
-	
+
 	public static AStack readAStack(JsonArray array) {
 		try {
 			String type = array.get(0).getAsString();
@@ -234,7 +259,7 @@ public abstract class SerializableRecipe {
 		MainRegistry.logger.error("Error reading stack array " + array.toString());
 		return new ComparableStack(ModItems.nothing);
 	}
-	
+
 	public static AStack[] readAStackArray(JsonArray array) {
 		try {
 			AStack[] items = new AStack[array.size()];
@@ -244,7 +269,7 @@ public abstract class SerializableRecipe {
 		MainRegistry.logger.error("Error reading stack array " + array.toString());
 		return new AStack[0];
 	}
-	
+
 	public static void writeAStack(AStack astack, JsonWriter writer) throws IOException {
 		writer.beginArray();
 		writer.setIndent("");
@@ -264,7 +289,7 @@ public abstract class SerializableRecipe {
 		writer.endArray();
 		writer.setIndent("  ");
 	}
-	
+
 	public static ItemStack readItemStack(JsonArray array) {
 		try {
 			Item item = (Item) Item.itemRegistry.getObject(array.get(0).getAsString());
@@ -275,7 +300,7 @@ public abstract class SerializableRecipe {
 		MainRegistry.logger.error("Error reading stack array " + array.toString() + " - defaulting to NOTHING item!");
 		return new ItemStack(ModItems.nothing);
 	}
-	
+
 	public static Pair<ItemStack, Float> readItemStackChance(JsonArray array) {
 		try {
 			Item item = (Item) Item.itemRegistry.getObject(array.get(0).getAsString());
@@ -287,7 +312,7 @@ public abstract class SerializableRecipe {
 		MainRegistry.logger.error("Error reading stack array " + array.toString() + " - defaulting to NOTHING item!");
 		return new Pair(new ItemStack(ModItems.nothing), 1F);
 	}
-	
+
 	public static ItemStack[] readItemStackArray(JsonArray array) {
 		try {
 			ItemStack[] items = new ItemStack[array.size()];
@@ -297,7 +322,7 @@ public abstract class SerializableRecipe {
 		MainRegistry.logger.error("Error reading stack array " + array.toString());
 		return new ItemStack[0];
 	}
-	
+
 	public static Pair<ItemStack, Float>[] readItemStackArrayChance(JsonArray array) {
 		try {
 			Pair<ItemStack, Float>[] items = new Pair[array.size()];
@@ -307,7 +332,7 @@ public abstract class SerializableRecipe {
 		MainRegistry.logger.error("Error reading stack array " + array.toString());
 		return new Pair[0];
 	}
-	
+
 	public static void writeItemStack(ItemStack stack, JsonWriter writer) throws IOException {
 		writer.beginArray();
 		writer.setIndent("");
@@ -317,7 +342,7 @@ public abstract class SerializableRecipe {
 		writer.endArray();
 		writer.setIndent("  ");
 	}
-	
+
 	public static void writeItemStackChance(Pair<ItemStack, Float> stack, JsonWriter writer) throws IOException {
 		writer.beginArray();
 		writer.setIndent("");
@@ -328,7 +353,7 @@ public abstract class SerializableRecipe {
 		writer.endArray();
 		writer.setIndent("  ");
 	}
-	
+
 	public static FluidStack readFluidStack(JsonArray array) {
 		try {
 			FluidType type = Fluids.fromName(array.get(0).getAsString());
@@ -339,7 +364,7 @@ public abstract class SerializableRecipe {
 		MainRegistry.logger.error("Error reading fluid array " + array.toString());
 		return new FluidStack(Fluids.NONE, 0);
 	}
-	
+
 	public static FluidStack[] readFluidArray(JsonArray array) {
 		try {
 			FluidStack[] fluids = new FluidStack[array.size()];
@@ -349,7 +374,7 @@ public abstract class SerializableRecipe {
 		MainRegistry.logger.error("Error reading fluid array " + array.toString());
 		return new FluidStack[0];
 	}
-	
+
 	public static void writeFluidStack(FluidStack stack, JsonWriter writer) throws IOException {
 		writer.beginArray();
 		writer.setIndent("");
@@ -359,12 +384,12 @@ public abstract class SerializableRecipe {
 		writer.endArray();
 		writer.setIndent("  ");
 	}
-	
+
 	public static boolean matchesIngredients(ItemStack[] inputs, AStack[] recipe) {
 
 		List<AStack> recipeList = new ArrayList();
 		for(AStack ingredient : recipe) recipeList.add(ingredient);
-		
+
 		for(int i = 0; i < inputs.length; i++) {
 			ItemStack inputStack = inputs[i];
 

--- a/src/main/java/com/hbm/items/ItemInventory.java
+++ b/src/main/java/com/hbm/items/ItemInventory.java
@@ -38,7 +38,7 @@ public abstract class ItemInventory implements IInventory {
 	}
 
 	public NBTTagCompound checkNBT(NBTTagCompound nbt) {
-		if(nbt == null || !nbt.hasNoTags()) {
+		if(nbt != null && !nbt.hasNoTags()) {
 			Random random = new Random();
 
 			try {

--- a/src/main/java/com/hbm/packet/PacketDispatcher.java
+++ b/src/main/java/com/hbm/packet/PacketDispatcher.java
@@ -69,6 +69,8 @@ public class PacketDispatcher {
 		wrapper.registerMessage(BiomeSyncPacket.Handler.class, BiomeSyncPacket.class, i++, Side.CLIENT);
 		//The not-so-convenient but not laggy one
 		wrapper.registerMessage(BufPacket.Handler.class, BufPacket.class, i++, Side.CLIENT);
+		//Syncs server recipe configs to the client
+		wrapper.registerMessage(SerializableRecipePacket.Handler.class, SerializableRecipePacket.class, i++, Side.CLIENT);
 	}
 
 }

--- a/src/main/java/com/hbm/packet/toclient/SerializableRecipePacket.java
+++ b/src/main/java/com/hbm/packet/toclient/SerializableRecipePacket.java
@@ -1,0 +1,76 @@
+package com.hbm.packet.toclient;
+
+import java.io.*;
+import java.nio.file.Files;
+
+import com.hbm.inventory.recipes.loader.SerializableRecipe;
+import com.hbm.util.BufferUtil;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+
+public class SerializableRecipePacket implements IMessage {
+
+	private String filename;
+	private byte[] fileBytes;
+
+	private boolean reinit;
+
+	public SerializableRecipePacket() {}
+
+	public SerializableRecipePacket(File recipeFile) {
+		try {
+			filename = recipeFile.getName();
+			fileBytes = Files.readAllBytes(recipeFile.toPath());
+		} catch(IOException ex) {}
+	}
+
+	public SerializableRecipePacket(boolean reinit) {
+		this.reinit = reinit;
+	}
+
+	@Override
+	public void fromBytes(ByteBuf buf) {
+		reinit = buf.readBoolean();
+		if(reinit) return;
+
+		filename = BufferUtil.readString(buf);
+		fileBytes = new byte[buf.readInt()];
+		buf.readBytes(fileBytes);
+	}
+
+	@Override
+	public void toBytes(ByteBuf buf) {
+		buf.writeBoolean(reinit);
+		if(reinit) return;
+
+		BufferUtil.writeString(buf, filename);
+		buf.writeInt(fileBytes.length);
+		buf.writeBytes(fileBytes);
+	}
+
+	public static class Handler implements IMessageHandler<SerializableRecipePacket, IMessage> {
+
+		@Override
+		@SideOnly(Side.CLIENT)
+		public IMessage onMessage(SerializableRecipePacket m, MessageContext ctx) {
+			try {
+
+				// Only reinitialize after receiving all recipes
+				if(m.reinit) {
+					SerializableRecipe.initialize();
+					return null;
+				}
+
+				SerializableRecipe.receiveRecipes(m.filename, m.fileBytes);
+
+			} catch (Exception x) { }
+			return null;
+		}
+	}
+
+}


### PR DESCRIPTION
Does what tin says on: when enabled on servers (disabled by default), it'll automatically send any custom recipe configs to the client, allowing servers to change recipes without having to recreate modpacks, or even include the recipes in modpacks at all!

Does not affect any vanilla recipes like crafting tables or smelting, only our custom machines.

Also fixes:
* Detailed hitboxes for multiblock machines like chemplant, assembler, etc. now work for mouseclick interactions too, meaning you will no longer accidentally interact with your chemplant while trying to open a chest or similar
* Fix crash with crate NBT 6kb checking (the wrong guard was used