### PR TITLE
fix interaction max distance issue with detailed hitboxes

### DIFF
--- a/src/main/java/com/hbm/blocks/BlockDummyable.java
+++ b/src/main/java/com/hbm/blocks/BlockDummyable.java
@@ -443,8 +443,10 @@ public abstract class BlockDummyable extends BlockContainer implements ICustomBl
 		y = pos[1];
 		z = pos[2];
 
-		for(AxisAlignedBB aabb :this.bounding) {
-			AxisAlignedBB boxlet = getAABBRotationOffset(aabb, x + 0.5, y, z + 0.5, ForgeDirection.getOrientation(world.getBlockMetadata(x, y, z) - offset).getRotation(ForgeDirection.UP));
+		ForgeDirection rot = ForgeDirection.getOrientation(world.getBlockMetadata(x, y, z) - offset).getRotation(ForgeDirection.UP);
+
+		for(AxisAlignedBB aabb : this.bounding) {
+			AxisAlignedBB boxlet = getAABBRotationOffset(aabb, x + 0.5, y, z + 0.5, rot);
 
 			if(entityBounding.intersectsWith(boxlet)) {
 				list.add(boxlet);
@@ -469,6 +471,7 @@ public abstract class BlockDummyable extends BlockContainer implements ICustomBl
 		return AxisAlignedBB.getBoundingBox(aabb.minX, aabb.minY, aabb.minZ, aabb.maxX, aabb.maxY, aabb.maxZ).offset(x + 0.5, y + 0.5, z + 0.5);
 	}
 
+	// Don't mutate the xyz parameters, or the interaction max distance will bite you
 	@Override
 	public MovingObjectPosition collisionRayTrace(World world, int x, int y, int z, Vec3 startVec, Vec3 endVec) {
 		if(!this.useDetailedHitbox()) {
@@ -480,12 +483,10 @@ public abstract class BlockDummyable extends BlockContainer implements ICustomBl
 		if(pos == null)
 			return super.collisionRayTrace(world, x, y, z, startVec, endVec);
 
-		x = pos[0];
-		y = pos[1];
-		z = pos[2];
+		ForgeDirection rot = ForgeDirection.getOrientation(world.getBlockMetadata(pos[0], pos[1], pos[2]) - offset).getRotation(ForgeDirection.UP);
 
-		for(AxisAlignedBB aabb :this.bounding) {
-			AxisAlignedBB boxlet = getAABBRotationOffset(aabb, x + 0.5, y, z + 0.5, ForgeDirection.getOrientation(world.getBlockMetadata(x, y, z) - offset).getRotation(ForgeDirection.UP));
+		for(AxisAlignedBB aabb : this.bounding) {
+			AxisAlignedBB boxlet = getAABBRotationOffset(aabb, pos[0] + 0.5, pos[1], pos[2] + 0.5, rot);
 
 			MovingObjectPosition intercept = boxlet.calculateIntercept(startVec, endVec);
 			if(intercept != null) {
@@ -529,10 +530,10 @@ public abstract class BlockDummyable extends BlockContainer implements ICustomBl
 		double dZ = player.lastTickPosZ + (player.posZ - player.lastTickPosZ) * (double)interp;
 		float exp = 0.002F;
 
-		int meta = world.getBlockMetadata(x, y, z);
+		ForgeDirection rot = ForgeDirection.getOrientation(world.getBlockMetadata(x, y, z) - offset).getRotation(ForgeDirection.UP);
 
 		ICustomBlockHighlight.setup();
-		for(AxisAlignedBB aabb : this.bounding) RenderGlobal.drawOutlinedBoundingBox(getAABBRotationOffset(aabb.expand(exp, exp, exp), 0, 0, 0, ForgeDirection.getOrientation(meta - offset).getRotation(ForgeDirection.UP)).getOffsetBoundingBox(x - dX + 0.5, y - dY, z - dZ + 0.5), -1);
+		for(AxisAlignedBB aabb : this.bounding) RenderGlobal.drawOutlinedBoundingBox(getAABBRotationOffset(aabb.expand(exp, exp, exp), 0, 0, 0, rot).getOffsetBoundingBox(x - dX + 0.5, y - dY, z - dZ + 0.5), -1);
 		ICustomBlockHighlight.cleanup();
 	}
 


### PR DESCRIPTION
`collisionRayTrace` was returning the collision as if it occurred at the core of a `BlockDummyable`, causing the interaction max distance to cancel the interaction on large multiblocks.