### PR TITLE
Slight change to ability GUI handling

### DIFF
--- a/src/main/java/com/hbm/handler/HbmKeybinds.java
+++ b/src/main/java/com/hbm/handler/HbmKeybinds.java
@@ -71,6 +71,7 @@ public class HbmKeybinds {
 	
 	@SubscribeEvent
 	public void mouseEvent(MouseInputEvent event) {
+		EntityPlayer player = MainRegistry.proxy.me();
 		HbmPlayerProps props = HbmPlayerProps.getData(MainRegistry.proxy.me());
 		
 		for(EnumKeybind key : EnumKeybind.values()) {
@@ -80,6 +81,7 @@ public class HbmKeybinds {
 			if(last != current) {
 				PacketDispatcher.wrapper.sendToServer(new KeybindPacket(key, current));
 				props.setKeyPressed(key, current);
+				onPressedClient(player, key, current);
 			}
 		}
 	}
@@ -127,8 +129,8 @@ public class HbmKeybinds {
 		CRANE_LEFT,
 		CRANE_RIGHT,
 		CRANE_LOAD,
-		ABILITY_CYCLE,
 		ABILITY_ALT,
+		ABILITY_CYCLE,
 		TOOL_ALT,
 		TOOL_CTRL,
 		GUN_PRIMARY,

--- a/src/main/java/com/hbm/items/tool/ItemToolAbility.java
+++ b/src/main/java/com/hbm/items/tool/ItemToolAbility.java
@@ -16,6 +16,7 @@ import com.hbm.items.IItemControlReceiver;
 import com.hbm.items.IKeybindReceiver;
 import com.hbm.handler.HbmKeybinds.EnumKeybind;
 import com.hbm.blocks.ModBlocks;
+import com.hbm.extprop.HbmPlayerProps;
 import com.hbm.handler.ability.AvailableAbilities;
 import com.hbm.handler.ability.IBaseAbility;
 import com.hbm.handler.ability.IToolAreaAbility;
@@ -493,14 +494,14 @@ public class ItemToolAbility extends ItemTool implements IDepthRockTool, IGUIPro
 
 	@Override
 	public boolean canHandleKeybind(EntityPlayer player, ItemStack stack, EnumKeybind keybind) {
-		if(player.worldObj.isRemote) return keybind == EnumKeybind.ABILITY_ALT;
+		// if(player.worldObj.isRemote) return keybind == EnumKeybind.ABILITY_ALT;
 		return keybind == EnumKeybind.ABILITY_CYCLE;
 	}
 
 	@Override
 	public void handleKeybind(EntityPlayer player, ItemStack stack, EnumKeybind keybind, boolean state) {
 		
-		if(keybind == EnumKeybind.ABILITY_CYCLE && state) {
+		if(keybind == EnumKeybind.ABILITY_CYCLE && state && !HbmPlayerProps.getData(player).getKeyPressed(EnumKeybind.ABILITY_ALT)) {
 
 			World world = player.worldObj;
 			if(!canOperate(stack)) return;
@@ -522,6 +523,8 @@ public class ItemToolAbility extends ItemTool implements IDepthRockTool, IGUIPro
 
 	@Override
 	public void handleKeybindClient(EntityPlayer player, ItemStack stack, EnumKeybind keybind, boolean state) {
-		if(state) player.openGui(MainRegistry.instance, 0, player.worldObj, 0, 0, 0);
+		if(keybind == EnumKeybind.ABILITY_CYCLE && state && HbmPlayerProps.getData(player).getKeyPressed(EnumKeybind.ABILITY_ALT)) {
+			player.openGui(MainRegistry.instance, 0, player.worldObj, 0, 0, 0);
+		}
 	}
 }


### PR DESCRIPTION
The new single-button approach felt weird, so I made it function as a modifier to the "cycle ability" button instead. I think it feels more natural this way, as well as being consistent with shift-clicking to reset.