### PR TITLE
Mass Storage AE2 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,18 @@ repositories {
 	//	name = "CurseForge"
 	//	url = "https://minecraft.curseforge.com/api/maven/"
 	//}
+	maven {
+		name = "Jitpack"
+		url = "https://jitpack.io"
+	}
+	maven {
+		name = "CurseMaven"
+		url = "https://cursemaven.com"
+	}
+	maven {
+        name = "OpenComputers"
+        url = "https://maven.cil.li/"
+    }
 }
 
 dependencies {
@@ -94,6 +106,9 @@ dependencies {
 	compileOnly "inventorytweaks:InventoryTweaks:1.59-dev:deobf"
 
 	implementation "li.cil.oc:OpenComputers:MC1.7.10-1.5.+:api"
+
+	implementation "com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta.56-GTNH:dev"
+	compileOnly "com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta.56-GTNH:sources"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -107,8 +107,7 @@ dependencies {
 
 	implementation "li.cil.oc:OpenComputers:MC1.7.10-1.5.+:api"
 
-	implementation "com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta.56-GTNH:dev"
-	compileOnly "com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta.56-GTNH:sources"
+	compileOnly "com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta.56-GTNH:dev"
 }
 
 processResources {

--- a/src/main/java/com/hbm/handler/ae2/AE2CompatHandler.java
+++ b/src/main/java/com/hbm/handler/ae2/AE2CompatHandler.java
@@ -2,11 +2,17 @@ package com.hbm.handler.ae2;
 
 import appeng.api.AEApi;
 import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Optional;
 
 public class AE2CompatHandler {
     public static void init() {
         if (Loader.isModLoaded("appliedenergistics2")) {
-            AEApi.instance().registries().externalStorage().addExternalStorageInterface(new MSUExternalStorageHandler());
+            registerHandler();
         }
+    }
+
+    @Optional.Method(modid = "appliedenergistics2")
+    private static void registerHandler() {
+        AEApi.instance().registries().externalStorage().addExternalStorageInterface(new MSUExternalStorageHandler());
     }
 }

--- a/src/main/java/com/hbm/handler/ae2/AE2CompatHandler.java
+++ b/src/main/java/com/hbm/handler/ae2/AE2CompatHandler.java
@@ -1,0 +1,12 @@
+package com.hbm.handler.ae2;
+
+import appeng.api.AEApi;
+import cpw.mods.fml.common.Loader;
+
+public class AE2CompatHandler {
+    public static void init() {
+        if (Loader.isModLoaded("appliedenergistics2")) {
+            AEApi.instance().registries().externalStorage().addExternalStorageInterface(new MSUExternalStorageHandler());
+        }
+    }
+}

--- a/src/main/java/com/hbm/handler/ae2/MSUExternalStorageHandler.java
+++ b/src/main/java/com/hbm/handler/ae2/MSUExternalStorageHandler.java
@@ -1,0 +1,44 @@
+package com.hbm.handler.ae2;
+
+import com.hbm.tileentity.machine.storage.TileEntityMassStorage;
+import com.hbm.util.ItemStackUtil;
+
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.storage.IExternalStorageHandler;
+import appeng.api.storage.IMEInventory;
+import appeng.api.storage.StorageChannel;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.me.storage.MEMonitorIInventory;
+import appeng.util.inv.IMEAdaptor;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class MSUExternalStorageHandler implements IExternalStorageHandler {
+
+    public MSUExternalStorageHandler() {}
+
+    @Override
+    public boolean canHandle(TileEntity te, ForgeDirection d, StorageChannel channel, BaseActionSource mySrc) {
+        return channel == StorageChannel.ITEMS && te instanceof TileEntityMassStorage;
+    }
+
+    @Override
+    public IMEInventory getInventory(TileEntity te, ForgeDirection d, StorageChannel channel, BaseActionSource src) {
+        if (!canHandle(te, d, channel, src))
+            return null;
+        
+        // Note: apparently I need this, though I'm not sure why. Storage drawers does it.
+        // Here's a relevant discussion, if anyone wants to dive into that rabbit hole:
+        // https://github.com/AppliedEnergistics/Applied-Energistics-2/issues/418
+        return new MEMonitorIInventory(new IMEAdaptor(new MassStorageMEInventory((TileEntityMassStorage)te), src)) {
+            @Override
+            public boolean isPrioritized(IAEItemStack stack) {
+                ItemStack type = ((TileEntityMassStorage)te).getType();
+
+                return type != null && ItemStackUtil.areStacksCompatible(stack.getItemStack(), type);
+            }
+        };
+    }
+    
+}

--- a/src/main/java/com/hbm/handler/ae2/MSUExternalStorageHandler.java
+++ b/src/main/java/com/hbm/handler/ae2/MSUExternalStorageHandler.java
@@ -15,7 +15,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
-@Optional.Interface(iface = "appeng.api.storage.IExternalStorageHandler", modid = "appliedenergistics2")
+@Optional.InterfaceList({@Optional.Interface(iface = "appeng.api.storage.IExternalStorageHandler", modid = "appliedenergistics2")})
 public class MSUExternalStorageHandler implements IExternalStorageHandler {
 
     public MSUExternalStorageHandler() {}

--- a/src/main/java/com/hbm/handler/ae2/MSUExternalStorageHandler.java
+++ b/src/main/java/com/hbm/handler/ae2/MSUExternalStorageHandler.java
@@ -2,6 +2,7 @@ package com.hbm.handler.ae2;
 
 import com.hbm.tileentity.machine.storage.TileEntityMassStorage;
 import com.hbm.util.ItemStackUtil;
+import cpw.mods.fml.common.Optional;
 
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.IExternalStorageHandler;
@@ -14,6 +15,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
+@Optional.Interface(iface = "appeng.api.storage.IExternalStorageHandler", modid = "appliedenergistics2")
 public class MSUExternalStorageHandler implements IExternalStorageHandler {
 
     public MSUExternalStorageHandler() {}

--- a/src/main/java/com/hbm/handler/ae2/MassStorageMEInventory.java
+++ b/src/main/java/com/hbm/handler/ae2/MassStorageMEInventory.java
@@ -14,7 +14,7 @@ import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
 import net.minecraft.item.ItemStack;
 
-@Optional.Interface(iface = "appeng.api.storage.IMEInventory", modid = "appliedenergistics2")
+@Optional.InterfaceList({@Optional.Interface(iface = "appeng.api.storage.IMEInventory", modid = "appliedenergistics2")})
 public class MassStorageMEInventory implements IMEInventory<IAEItemStack> {
 
     private TileEntityMassStorage tile;

--- a/src/main/java/com/hbm/handler/ae2/MassStorageMEInventory.java
+++ b/src/main/java/com/hbm/handler/ae2/MassStorageMEInventory.java
@@ -1,0 +1,84 @@
+package com.hbm.handler.ae2;
+
+import static com.hbm.inventory.OreDictManager.I;
+
+import com.hbm.tileentity.machine.storage.TileEntityMassStorage;
+import com.hbm.util.ItemStackUtil;
+
+import appeng.api.AEApi;
+import appeng.api.config.Actionable;
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.storage.IMEInventory;
+import appeng.api.storage.StorageChannel;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IItemList;
+import net.minecraft.item.ItemStack;
+
+public class MassStorageMEInventory implements IMEInventory<IAEItemStack> {
+
+    private TileEntityMassStorage tile;
+
+    public MassStorageMEInventory(TileEntityMassStorage tile) {
+        this.tile = tile;
+    }
+
+    @Override
+    public IAEItemStack injectItems(IAEItemStack input, Actionable type, BaseActionSource src) {
+        ItemStack typeStack = tile.getType();
+
+        if (typeStack == null || !ItemStackUtil.areStacksCompatible(input.getItemStack(), typeStack))
+            return input;
+        
+        // If you're working with amounts greater than MAX_INT, you shouldn't use MSUs in the first place
+        int remaining = tile.increaseTotalStockpile((int)input.getStackSize(), type == Actionable.MODULATE);
+    
+        if (remaining == 0) {
+            return null;
+        }
+        
+        return AEApi.instance().storage()
+            .createItemStack(typeStack)
+            .setStackSize(remaining);
+    }
+
+    @Override
+    public IAEItemStack extractItems(IAEItemStack request, Actionable mode, BaseActionSource src) {
+        ItemStack typeStack = tile.getType();
+
+        if (typeStack == null || !ItemStackUtil.areStacksCompatible(request.getItemStack(), typeStack))
+            return null;
+
+        // If you're working with amounts greater than MAX_INT, you shouldn't use MSUs in the first place
+        int missing = tile.decreaseTotalStockpile((int)request.getStackSize(), mode == Actionable.MODULATE);
+        long fulfilled = request.getStackSize() - missing;
+
+        if (fulfilled == 0) {
+            return null;
+        }
+
+        return AEApi.instance().storage()
+            .createItemStack(typeStack)
+            .setStackSize(fulfilled);
+    }
+
+    @Override
+    public IItemList<IAEItemStack> getAvailableItems(IItemList<IAEItemStack> out) {
+        ItemStack typeStack = tile.getType();
+
+        if (typeStack != null) {
+            out.add(
+                AEApi.instance().storage()
+                .createItemStack(typeStack)
+                .setStackSize(tile.getTotalStockpile())
+            );
+        }
+
+        return out;
+    }
+
+    @Override
+    public StorageChannel getChannel() {
+        return StorageChannel.ITEMS;
+    }
+    
+}

--- a/src/main/java/com/hbm/handler/ae2/MassStorageMEInventory.java
+++ b/src/main/java/com/hbm/handler/ae2/MassStorageMEInventory.java
@@ -1,9 +1,9 @@
 package com.hbm.handler.ae2;
 
-import static com.hbm.inventory.OreDictManager.I;
-
 import com.hbm.tileentity.machine.storage.TileEntityMassStorage;
 import com.hbm.util.ItemStackUtil;
+
+import cpw.mods.fml.common.Optional;
 
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
@@ -14,6 +14,7 @@ import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
 import net.minecraft.item.ItemStack;
 
+@Optional.Interface(iface = "appeng.api.storage.IMEInventory", modid = "appliedenergistics2")
 public class MassStorageMEInventory implements IMEInventory<IAEItemStack> {
 
     private TileEntityMassStorage tile;

--- a/src/main/java/com/hbm/main/MainRegistry.java
+++ b/src/main/java/com/hbm/main/MainRegistry.java
@@ -13,6 +13,7 @@ import com.hbm.entity.grenade.*;
 import com.hbm.entity.logic.IChunkLoader;
 import com.hbm.entity.mob.siege.SiegeTier;
 import com.hbm.handler.*;
+import com.hbm.handler.ae2.AE2CompatHandler;
 import com.hbm.handler.imc.IMCBlastFurnace;
 import com.hbm.handler.imc.IMCCentrifuge;
 import com.hbm.handler.imc.IMCCrystallizer;
@@ -880,6 +881,9 @@ public class MainRegistry {
 
 		// Load compatibility for OC.
 		CompatHandler.init();
+
+		// Load compatibility for AE2.
+		AE2CompatHandler.init();
 
 		//expand for the largest entity we have (currently Quackos who is 17.5m in diameter, that's one fat duck)
 		World.MAX_ENTITY_RADIUS = Math.max(World.MAX_ENTITY_RADIUS, 8.75);


### PR DESCRIPTION
What the title says. Inspired by the solution implemented in StorageDrawers. Accounts for both the IO-slots and the actual stockpile (the default handling only looked at the slots). I tested this with and without the mod, and it seems to work fine. The new maven repos are for GTNH AE2 (the original is nowhere to be found, and the API is the same), as well as its own compile-time dependencies.