### PR TITLE
Tantalum 2

### DIFF
--- a/src/main/java/com/hbm/config/WorldConfig.java
+++ b/src/main/java/com/hbm/config/WorldConfig.java
@@ -177,9 +177,9 @@ public class WorldConfig {
 		bedrockEmeraldSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.B18_bedrockEmeraldWeight", "Spawn weight for emerald bedrock ore", 50);
 
 		bedrockGlowstoneSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.BN00_bedrockGlowstoneWeight", "Spawn weight for glowstone bedrock ore", 100);
-		bedrockPhosphorusSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.BN01_bedrockPhosphorusWeight", "Spawn weight for phosphorus bedrock ore", 100);
+		bedrockPhosphorusSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.BN01_bedrockPhosphorusWeight", "Spawn weight for phosphorus bedrock ore", 60);
 		bedrockQuartzSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.BN02_bedrockQuartzWeight", "Spawn weight for quartz bedrock ore", 100);
-		bedrockNetherColtanSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.BN03_bedrockGlowstoneWeight", "Spawn weight for coltan bedrock ore in the nether", 100);
+		bedrockNetherColtanSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.BN03_bedrockGlowstoneWeight", "Spawn weight for coltan bedrock ore in the nether", 90);
 
 		ironClusterSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.C00_ironClusterSpawn", "Amount of iron cluster veins per chunk", 4);
 		titaniumClusterSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.C01_titaniumClusterSpawn", "Amount of titanium cluster veins per chunk", 2);

--- a/src/main/java/com/hbm/config/WorldConfig.java
+++ b/src/main/java/com/hbm/config/WorldConfig.java
@@ -53,6 +53,7 @@ public class WorldConfig {
 	public static int bedrockBauxiteSpawn = 100;
 	public static int bedrockEmeraldSpawn = 50;
 	public static int bedrockGlowstoneSpawn = 100;
+	public static int bedrockNetherColtanSpawn = 100;
 	public static int bedrockPhosphorusSpawn = 50;
 	public static int bedrockQuartzSpawn = 100;
 
@@ -176,8 +177,9 @@ public class WorldConfig {
 		bedrockEmeraldSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.B18_bedrockEmeraldWeight", "Spawn weight for emerald bedrock ore", 50);
 
 		bedrockGlowstoneSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.BN00_bedrockGlowstoneWeight", "Spawn weight for glowstone bedrock ore", 100);
-		bedrockPhosphorusSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.BN01_bedrockPhosphorusWeight", "Spawn weight for phosphorus bedrock ore", 50);
-		bedrockQuartzSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.BN01_bedrockQuartzWeight", "Spawn weight for quartz bedrock ore", 100);
+		bedrockPhosphorusSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.BN01_bedrockPhosphorusWeight", "Spawn weight for phosphorus bedrock ore", 100);
+		bedrockQuartzSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.BN02_bedrockQuartzWeight", "Spawn weight for quartz bedrock ore", 100);
+		bedrockNetherColtanSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.BN03_bedrockGlowstoneWeight", "Spawn weight for coltan bedrock ore in the nether", 100);
 
 		ironClusterSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.C00_ironClusterSpawn", "Amount of iron cluster veins per chunk", 4);
 		titaniumClusterSpawn = CommonConfig.createConfigInt(config, CATEGORY_OREGEN, "2.C01_titaniumClusterSpawn", "Amount of titanium cluster veins per chunk", 2);

--- a/src/main/java/com/hbm/inventory/recipes/CentrifugeRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/CentrifugeRecipes.java
@@ -469,6 +469,12 @@ public class CentrifugeRecipes extends SerializableRecipe {
 				new ItemStack(ModItems.powder_boron_tiny, 1),
 				new ItemStack(ModItems.dust_tiny, 6)});
 
+		recipes.put(new ComparableStack(ModItems.fragment_coltan, 1), new ItemStack[] {
+			new ItemStack(ModItems.powder_coltan_ore, 3),
+			new ItemStack(ModItems.powder_iron, 2),
+			new ItemStack(ModItems.powder_thorium, 2),
+			new ItemStack(ModItems.powder_calcium, 1)});
+
 		for(EnumBedrockOre ore : EnumBedrockOre.values()) {
 			int i = ore.ordinal();
 

--- a/src/main/java/com/hbm/inventory/recipes/ChemicalPlantRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/ChemicalPlantRecipes.java
@@ -223,7 +223,7 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 
 		/// COLTAN ///
 		this.register(new GenericRecipe("chem.coltancleaning").setup(60, 500)
-				.inputItems(new OreDictStack(COLTAN.dust(), 2))
+				.inputItems(new OreDictStack(COLTAN.dust(), 1))
 				.inputFluids(new FluidStack(Fluids.SULFURIC_ACID, 500), new FluidStack(Fluids.HYDROGEN, 500))
 				.outputItems(new ItemStack(ModItems.powder_coltan), new ItemStack(ModItems.powder_niobium)));
 

--- a/src/main/java/com/hbm/inventory/recipes/ChemicalPlantRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/ChemicalPlantRecipes.java
@@ -25,7 +25,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
-	
+
 	public static final ChemicalPlantRecipes INSTANCE = new ChemicalPlantRecipes();
 
 	@Override public int inputItemLimit() { return 3; }
@@ -38,79 +38,79 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 
 	@Override
 	public void registerDefaults() {
-		
+
 		/// REGULAR FLUIDS ///
 		this.register(new GenericRecipe("chem.hydrogen").setupNamed(20, 400).setIcon(ModItems.gas_full, Fluids.HYDROGEN.getID())
 				.inputItems(new OreDictStack(COAL.gem(), 1))
 				.inputFluids(new FluidStack(Fluids.WATER, 8_000))
 				.outputFluids(new FluidStack(Fluids.HYDROGEN, 500)));
-		
+
 		this.register(new GenericRecipe("chem.hydrogencoke").setupNamed(20, 400).setIcon(ModItems.gas_full, Fluids.HYDROGEN.getID())
 				.inputItems(new OreDictStack(ANY_COKE.gem(), 1))
 				.inputFluids(new FluidStack(Fluids.WATER, 8_000))
 				.outputFluids(new FluidStack(Fluids.HYDROGEN, 500)));
-		
+
 		this.register(new GenericRecipe("chem.oxygen").setupNamed(20, 400).setIcon(ModItems.gas_full, Fluids.OXYGEN.getID())
 				.inputFluids(new FluidStack(Fluids.AIR, 8_000))
 				.outputFluids(new FluidStack(Fluids.OXYGEN, 500)));
-		
+
 		this.register(new GenericRecipe("chem.xenon").setupNamed(300, 1_000).setIcon(ModItems.gas_full, Fluids.XENON.getID())
 				.inputFluids(new FluidStack(Fluids.AIR, 16_000))
 				.outputFluids(new FluidStack(Fluids.XENON, 50)));
-		
+
 		this.register(new GenericRecipe("chem.xenonoxy").setupNamed(20, 1_000).setIcon(ModItems.gas_full, Fluids.XENON.getID())
 				.inputFluids(new FluidStack(Fluids.AIR, 8_000), new FluidStack(Fluids.OXYGEN, 250))
 				.outputFluids(new FluidStack(Fluids.XENON, 50)));
-		
+
 		this.register(new GenericRecipe("chem.helium3").setupNamed(200, 2_000).setIcon(ModItems.gas_full, Fluids.HELIUM3.getID())
 				.inputItems(new ComparableStack(ModBlocks.moon_turf, 8))
 				.outputFluids(new FluidStack(Fluids.HELIUM3, 1_000)));
-		
+
 		this.register(new GenericRecipe("chem.co2").setup(60, 100)
 				.inputFluids(new FluidStack(Fluids.GAS, 1_000))
 				.outputFluids(new FluidStack(Fluids.CARBONDIOXIDE, 1_000)));
-		
+
 		this.register(new GenericRecipe("chem.perfluoromethyl").setup(20, 100)
 				.inputItems(new OreDictStack(F.dust()))
 				.inputFluids(new FluidStack(Fluids.PETROLEUM, 1_000), new FluidStack(Fluids.UNSATURATEDS, 500))
 				.outputFluids(new FluidStack(Fluids.PERFLUOROMETHYL, 1_000)));
-		
+
 		this.register(new GenericRecipe("chem.cccentrifuge").setup(200, 100)
 				.inputFluids(new FluidStack(Fluids.CHLOROCALCITE_CLEANED, 500), new FluidStack(Fluids.SULFURIC_ACID, 8_000))
 				.outputFluids(new FluidStack(Fluids.POTASSIUM_CHLORIDE, 250), new FluidStack(Fluids.CALCIUM_CHLORIDE, 250)));
-		
+
 		/// OILS ///
-		this.register(new GenericRecipe("chem.ethanol").setupNamed(50, 100).setIcon(ModItems.canister_full, Fluids.ETHANOL.getID())
-				.inputItems(new ComparableStack(Items.sugar, 10))
+		this.register(new GenericRecipe("chem.ethanol").setupNamed(50, 50).setIcon(ModItems.canister_full, Fluids.ETHANOL.getID())
+				.inputItems(new ComparableStack(Items.sugar, 9))
 				.outputFluids(new FluidStack(Fluids.ETHANOL, 1000)));
-		
+
 		this.register(new GenericRecipe("chem.biogas").setupNamed(60, 100).setIcon(ModItems.gas_full, Fluids.BIOGAS.getID())
 				.inputItems(new ComparableStack(ModItems.biomass, 16))
 				.inputFluids(new FluidStack(Fluids.AIR, 4_000))
 				.outputFluids(new FluidStack(Fluids.BIOGAS, 2_000)));
-		
+
 		this.register(new GenericRecipe("chem.biofuel").setupNamed(60, 100).setIcon(ModItems.canister_full, Fluids.BIOFUEL.getID())
 				.inputFluids(new FluidStack(Fluids.BIOGAS, 1_500), new FluidStack(Fluids.ETHANOL, 250))
 				.outputFluids(new FluidStack(Fluids.BIOFUEL, 1_000)));
-		
+
 		this.register(new GenericRecipe("chem.reoil").setupNamed(40, 100).setIcon(ModItems.canister_full, Fluids.RECLAIMED.getID())
 				.inputFluids(new FluidStack(Fluids.SMEAR, 1_000))
 				.outputFluids(new FluidStack(Fluids.RECLAIMED, 800)));
-		
+
 		this.register(new GenericRecipe("chem.gasoline").setupNamed(40, 100).setIcon(ModItems.canister_full, Fluids.GASOLINE.getID())
 				.inputFluids(new FluidStack(Fluids.NAPHTHA, 1000))
 				.outputFluids(new FluidStack(Fluids.GASOLINE, 800)));
-		
+
 		this.register(new GenericRecipe("chem.tarsand").setupNamed(200, 100).setIcon(ModBlocks.ore_oil_sand)
 				.inputItems(new ComparableStack(ModBlocks.ore_oil_sand, 16), new OreDictStack(ANY_TAR.any(), 1))
 				.outputItems(new ItemStack(Blocks.sand, 16))
 				.outputFluids(new FluidStack(Fluids.BITUMEN, 1_000)));
-		
+
 		this.register(new GenericRecipe("chem.tel").setup(40, 100)
 				.inputItems(new OreDictStack(ANY_TAR.any()), new OreDictStack(PB.dust()))
 				.inputFluids(new FluidStack(Fluids.PETROLEUM, 100), new FluidStack(Fluids.STEAM, 1000))
 				.outputItems(DictFrame.fromOne(ModItems.fuel_additive, EnumFuelAdditive.ANTIKNOCK)));
-		
+
 		this.register(new GenericRecipe("chem.deicer").setup(40, 100)
 				.inputFluids(new FluidStack(Fluids.GAS, 100), new FluidStack(Fluids.HYDROGEN, 50))
 				.outputItems(DictFrame.fromOne(ModItems.fuel_additive, EnumFuelAdditive.DEICER)));
@@ -120,7 +120,7 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 				.inputItems(new ComparableStack(ModItems.powder_cement, 1), new ComparableStack(Blocks.gravel, 8), new OreDictStack(KEY_SAND, 8))
 				.inputFluids(new FluidStack(Fluids.WATER, 2_000))
 				.outputItems(new ItemStack(ModBlocks.concrete_smooth, 16)));
-		
+
 		this.register(new GenericRecipe("chem.concreteasbestos").setup(100, 100)
 				.inputItems(new ComparableStack(ModItems.powder_cement, 4), new OreDictStack(ASBESTOS.ingot(), (GeneralConfig.enableLBSM && GeneralConfig.enableLBSMSimpleChemsitry) ? 1 : 4), new OreDictStack(KEY_SAND, 8))
 				.inputFluids(new FluidStack(Fluids.WATER, 2_000))
@@ -130,12 +130,12 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 				.inputItems(new ComparableStack(ModItems.powder_cement, 4), new OreDictStack(FERRO.ingot()), new OreDictStack(KEY_SAND, 8))
 				.inputFluids(new FluidStack(Fluids.WATER, 2_000))
 				.outputItems(new ItemStack(ModBlocks.ducrete_smooth, 8)));
-		
+
 		this.register(new GenericRecipe("chem.asphalt").setup(100, 100)
 				.inputItems(new ComparableStack(Blocks.gravel, 2), new OreDictStack(KEY_SAND, 6))
 				.inputFluids(new FluidStack(Fluids.BITUMEN, 1_000))
 				.outputItems(new ItemStack(ModBlocks.asphalt, 16)));
-		
+
 		/// SOLIDS ///
 		this.register(new GenericRecipe("chem.desh").setup(100, 100)
 				.inputItems(new ComparableStack(ModItems.powder_desh_mix))
@@ -143,50 +143,50 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 								new FluidStack[] {new FluidStack(Fluids.LIGHTOIL, 200)} :
 								new FluidStack[] {new FluidStack(Fluids.LIGHTOIL, 200), new FluidStack(Fluids.MERCURY, 200)})
 				.outputItems(new ItemStack(ModItems.ingot_desh)));
-		
+
 		this.register(new GenericRecipe("chem.polymer").setup(100, 100)
 				.inputItems(new OreDictStack(COAL.dust(), 2), new OreDictStack(F.dust()))
 				.inputFluids(new FluidStack(Fluids.PETROLEUM, 500, GeneralConfig.enable528 ? 1 : 0))
 				.outputItems(new ItemStack(ModItems.ingot_polymer)));
-		
+
 		this.register(new GenericRecipe("chem.bakelite").setup(100, 100)
 				.inputFluids(new FluidStack(Fluids.AROMATICS, 500, GeneralConfig.enable528 ? 1 : 0), new FluidStack(Fluids.PETROLEUM, 500, GeneralConfig.enable528 ? 1 : 0))
 				.outputItems(new ItemStack(ModItems.ingot_bakelite)));
-		
+
 		this.register(new GenericRecipe("chem.rubber").setup(100, 200)
 				.inputItems(new OreDictStack(S.dust()))
 				.inputFluids(new FluidStack(Fluids.UNSATURATEDS, 500, GeneralConfig.enable528 ? 2 : 0))
 				.outputItems(new ItemStack(ModItems.ingot_rubber)));
-		
+
 		this.register(new GenericRecipe("chem.hardplastic").setup(100, 1_000)
 				.inputFluids(new FluidStack(Fluids.XYLENE, 500, GeneralConfig.enable528 ? 2 : 0), new FluidStack(Fluids.PHOSGENE, 500, GeneralConfig.enable528 ? 2 : 0))
 				.outputItems(new ItemStack(ModItems.ingot_pc)));
-		
+
 		this.register(new GenericRecipe("chem.pvc").setup(100, 1_000)
 				.inputItems(new OreDictStack(CD.dust()))
 				.inputFluids(new FluidStack(Fluids.UNSATURATEDS, 250, GeneralConfig.enable528 ? 2 : 0), new FluidStack(Fluids.CHLORINE, 250, GeneralConfig.enable528 ? 2 : 0))
 				.outputItems(new ItemStack(ModItems.ingot_pvc, 2)));
-		
+
 		this.register(new GenericRecipe("chem.kevlar").setup(60, 300)
 				.inputFluids(new FluidStack(Fluids.AROMATICS, 200), new FluidStack(Fluids.NITRIC_ACID, 100), new FluidStack(GeneralConfig.enable528 ? Fluids.PHOSGENE : Fluids.CHLORINE, 100))
 				.outputItems(new ItemStack(ModItems.plate_kevlar, 4)));
-		
+
 		this.register(new GenericRecipe("chem.meth").setup(60, 300)
 				.inputItems(new ComparableStack(Items.wheat), new ComparableStack(Items.dye, 2, 3))
 				.inputFluids(new FluidStack(Fluids.LUBRICANT, 400), new FluidStack(Fluids.PEROXIDE, 500))
 				.outputItems(new ItemStack(ModItems.chocolate, 4)));
-		
+
 		this.register(new GenericRecipe("chem.epearl").setup(100, 300)
 				.inputItems(new OreDictStack(DIAMOND.dust(), 1))
 				.inputFluids(new FluidStack(Fluids.XPJUICE, 500))
 				.outputFluids(new FluidStack(Fluids.ENDERJUICE, 100)));
-		
+
 		this.register(new GenericRecipe("chem.meatprocessing").setupNamed(200, 200).setIcon(ModItems.glyphid_meat)
 				.inputItems(new OreDictStack(KEY_GLYPHID_MEAT, 3))
 				.inputFluids(new FluidStack(Fluids.WATER, 1_000))
 				.outputItems(new ItemStack(ModItems.sulfur, 4), new ItemStack(ModItems.niter, 3))
 				.outputFluids(new FluidStack(Fluids.SALIENT, 250)));
-		
+
 		this.register(new GenericRecipe("chem.rustysteel").setup(40, 100)
 				.inputItems(new ComparableStack(ModBlocks.deco_steel, 8))
 				.inputFluids(new FluidStack(Fluids.WATER, 1000))
@@ -196,104 +196,108 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 		this.register(new GenericRecipe("chem.peroxide").setup(50, 100)
 				.inputFluids(new FluidStack(Fluids.WATER, 1_000))
 				.outputFluids(new FluidStack(Fluids.PEROXIDE, 1_000)));
-		
+
 		this.register(new GenericRecipe("chem.sulfuricacid").setup(50, 100)
 				.inputItems(new OreDictStack(S.dust()))
 				.inputFluids(new FluidStack(Fluids.PEROXIDE, 1_000), new FluidStack(Fluids.WATER, 1_000))
 				.outputFluids(new FluidStack(Fluids.SULFURIC_ACID, 2_000)));
-		
+
 		this.register(new GenericRecipe("chem.nitricacid").setup(50, 100)
 				.inputItems(new OreDictStack(KNO.dust()))
 				.inputFluids(new FluidStack(Fluids.SULFURIC_ACID, 500))
 				.outputFluids(new FluidStack(Fluids.NITRIC_ACID, 1_000)));
-		
+
 		this.register(new GenericRecipe("chem.birkeland").setupNamed(200, 5_000)
 				.inputFluids(new FluidStack(Fluids.AIR, 8_000), new FluidStack(Fluids.WATER, 2_000))
 				.outputFluids(new FluidStack(Fluids.NITRIC_ACID, 1_000)));
-		
+
 		this.register(new GenericRecipe("chem.schrabidic").setup(100, 5_000)
 				.inputItems(new ComparableStack(ModItems.pellet_charged))
 				.inputFluids(new FluidStack(Fluids.SAS3, 8000), new FluidStack(Fluids.PEROXIDE, 6000))
 				.outputFluids(new FluidStack(Fluids.SCHRABIDIC, 16000)));
-		
+
 		this.register(new GenericRecipe("chem.schrabidate").setup(150, 5_000)
 				.inputItems(new OreDictStack(IRON.dust()))
 				.inputFluids(new FluidStack(Fluids.SCHRABIDIC, 250))
 				.outputItems(new ItemStack(ModItems.powder_schrabidate)));
-		
-		/// COLTAN ///
-		this.register(new GenericRecipe("chem.coltancleaning").setup(60, 100)
-				.inputItems(new OreDictStack(COLTAN.dust(), 2), new OreDictStack(COAL.dust()))
-				.inputFluids(new FluidStack(Fluids.PEROXIDE, 250), new FluidStack(Fluids.HYDROGEN, 500))
-				.outputItems(new ItemStack(ModItems.powder_coltan), new ItemStack(ModItems.powder_niobium), new ItemStack(ModItems.dust))
-				.outputFluids(new FluidStack(Fluids.WATER, 500)));
 
-		this.register(new GenericRecipe("chem.coltanpain").setup(120, 100)
-				.inputItems(new ComparableStack(ModItems.powder_coltan), new OreDictStack(F.dust()))
-				.inputFluids(new FluidStack(Fluids.GAS, 1000), new FluidStack(Fluids.OXYGEN, 500))
+		/// COLTAN ///
+		this.register(new GenericRecipe("chem.coltancleaning").setup(60, 500)
+				.inputItems(new OreDictStack(COLTAN.dust(), 2))
+				.inputFluids(new FluidStack(Fluids.SULFURIC_ACID, 500), new FluidStack(Fluids.HYDROGEN, 500))
+				.outputItems(new ItemStack(ModItems.powder_coltan), new ItemStack(ModItems.powder_niobium)));
+
+		this.register(new GenericRecipe("chem.coltanpainA").setup(120, 500)
+				.inputItems(new ComparableStack(ModItems.powder_coltan, 2), new OreDictStack(AL.dust()))
+				.inputFluids(new FluidStack(Fluids.ETHANOL, 800))
 				.outputFluids(new FluidStack(Fluids.PAIN, 1000)));
 
-		this.register(new GenericRecipe("chem.coltancrystal").setup(80, 100)
-				.inputFluids(new FluidStack(Fluids.PAIN, 1000), new FluidStack(Fluids.PEROXIDE, 500))
-				.outputItems(new ItemStack(ModItems.gem_tantalium), new ItemStack(ModItems.dust, 3))
-				.outputFluids(new FluidStack(Fluids.WATER, 250)));
-		
+		this.register(new GenericRecipe("chem.coltanpainS").setup(60, 500)
+			.inputItems(new ComparableStack(ModItems.powder_coltan, 1))
+			.inputFluids(new FluidStack(Fluids.ETHANOL, 400), new FluidStack(Fluids.SODIUM, 200))
+			.outputFluids(new FluidStack(Fluids.PAIN, 500)));
+
+		this.register(new GenericRecipe("chem.coltancrystal").setup(60, 500)
+				.inputFluids(new FluidStack(Fluids.PAIN, 500), new FluidStack(Fluids.OXYGEN, 500))
+				.outputItems(new ItemStack(ModItems.gem_tantalium, 1))
+				.outputFluids(new FluidStack(Fluids.VITRIOL, 500)));
+
 		/// EXPLOSIVES ///
 		this.register(new GenericRecipe("chem.cordite").setup(40, 100)
 				.inputItems(new OreDictStack(KNO.dust(), 2), new ComparableStack(ModItems.powder_sawdust, 2))
 				.inputFluids((GeneralConfig.enableLBSM && GeneralConfig.enableLBSMSimpleChemsitry) ? new FluidStack(Fluids.HEATINGOIL, 200) : new FluidStack(Fluids.GAS, 200))
 				.outputItems(new ItemStack(ModItems.cordite, 4)));
-		
+
 		this.register(new GenericRecipe("chem.rocketfuel").setup(200, 100)
 				.inputItems(new ComparableStack(ModItems.solid_fuel, 2))
 				.inputFluids(new FluidStack(Fluids.PETROLEUM, 200, GeneralConfig.enable528 ? 1 : 0), new FluidStack(Fluids.NITRIC_ACID, 100))
 				.outputItems(new ItemStack(ModItems.rocket_fuel, 4)));
-		
+
 		this.register(new GenericRecipe("chem.dynamite").setup(50, 100)
 				.inputItems(new ComparableStack(Items.sugar), new OreDictStack(KNO.dust()), new OreDictStack(KEY_SAND))
 				.outputItems(new ItemStack(ModItems.ball_dynamite, 2)));
-		
+
 		this.register(new GenericRecipe("chem.tnt").setup(100, 1_000)
 				.inputItems(new OreDictStack(KNO.dust()))
 				.inputFluids(new FluidStack(Fluids.AROMATICS, 500, GeneralConfig.enable528 ? 1 : 0))
 				.outputItems(new ItemStack(ModItems.ball_tnt, 4)));
-		
+
 		this.register(new GenericRecipe("chem.tatb").setup(50, 5_000)
 				.inputItems(new ComparableStack(ModItems.ball_tnt))
 				.inputFluids(new FluidStack(Fluids.SOURGAS, 200, 1), new FluidStack(Fluids.NITRIC_ACID, 10))
 				.outputItems(new ItemStack(ModItems.ball_tatb)));
-		
+
 		this.register(new GenericRecipe("chem.c4").setup(100, 1_000)
 				.inputItems(new OreDictStack(KNO.dust()))
 				.inputFluids(new FluidStack(Fluids.UNSATURATEDS, 500, GeneralConfig.enable528 ? 1 : 0))
 				.outputItems(new ItemStack(ModItems.ingot_c4, 4)));
-		
+
 		this.register(new GenericRecipe("chem.shellchlorine").setup(100, 1_000)
 				.inputItems(new ComparableStack(ModItems.ammo_arty, 1, 0), new OreDictStack(ANY_PLASTIC.ingot(), 1))
 				.inputFluids(new FluidStack(Fluids.CHLORINE, 4_000))
 				.outputItems(new ItemStack(ModItems.ammo_arty, 1, 9)));
-		
+
 		this.register(new GenericRecipe("chem.shellphosgene").setup(100, 1_000)
 				.inputItems(new ComparableStack(ModItems.ammo_arty, 1, 0), new OreDictStack(ANY_PLASTIC.ingot(), 1))
 				.inputFluids(new FluidStack(Fluids.PHOSGENE, 4_000))
 				.outputItems(new ItemStack(ModItems.ammo_arty, 1, 10)));
-		
+
 		this.register(new GenericRecipe("chem.shellmustard").setup(100, 1_000)
 				.inputItems(new ComparableStack(ModItems.ammo_arty, 1, 0), new OreDictStack(ANY_PLASTIC.ingot(), 1))
 				.inputFluids(new FluidStack(Fluids.MUSTARDGAS, 4_000))
 				.outputItems(new ItemStack(ModItems.ammo_arty, 1, 11)));
-		
+
 		/// GLASS ///
 		this.register(new GenericRecipe("chem.laminate").setup(20, 100)
 				.inputFluids(new FluidStack(Fluids.XYLENE, 50), new FluidStack(Fluids.PHOSGENE, 50))
 				.inputItems(new OreDictStack(KEY_ANYGLASS), new OreDictStack(STEEL.bolt(), 4))
 				.outputItems(new ItemStack(ModBlocks.reinforced_laminate)));
-		
+
 		this.register(new GenericRecipe("chem.polarized").setup(100, 500)
 				.inputFluids(new FluidStack(Fluids.PETROLEUM, 1_000))
 				.inputItems(new OreDictStack(KEY_ANYPANE))
 				.outputItems(DictFrame.fromOne(ModItems.part_generic, EnumPartType.GLASS_POLARIZED, 16)));
-		
+
 		/// NUCLEAR PROCESSING ///
 		this.register(new GenericRecipe("chem.yellowcake").setup(250, 500)
 				.inputItems(new OreDictStack(U.billet(), 2), new OreDictStack(S.dust(), 2))
@@ -329,33 +333,33 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 				.outputItems(
 						new ChanceOutput(new ItemStack(ModItems.nugget_u233, 1), 0.5F),
 						new ChanceOutput(new ItemStack(ModItems.nuclear_waste_tiny, 1), 0.25F)));
-		
+
 		/// VITRIFICATION ///
 		this.register(new GenericRecipe("chem.vitliquid").setup(100, 1_000)
 				.inputItems(new ComparableStack(ModBlocks.sand_lead))
 				.inputFluids(new FluidStack(Fluids.WASTEFLUID, 1_000))
 				.outputItems(new ItemStack(ModItems.nuclear_waste_vitrified)));
-		
+
 		this.register(new GenericRecipe("chem.vitgaseous").setup(100, 1_000)
 				.inputItems(new ComparableStack(ModBlocks.sand_lead))
 				.inputFluids(new FluidStack(Fluids.WASTEGAS, 1_000))
 				.outputItems(new ItemStack(ModItems.nuclear_waste_vitrified)));
-		
+
 		this.register(new GenericRecipe("chem.vitsolid").setup(300, 1_000)
 				.inputItems(new ComparableStack(ModBlocks.sand_lead), new ComparableStack(ModItems.nuclear_waste, 4))
 				.outputItems(new ItemStack(ModItems.nuclear_waste_vitrified, 4)));
-		
+
 		/// OSMIRIDIUM ///
 		this.register(new GenericRecipe("chem.osmiridiumdeath").setup(240, 1_000)
 				.inputItems(new ComparableStack(ModItems.powder_paleogenite), new OreDictStack(F.dust(), 8), new ComparableStack(ModItems.nugget_bismuth, 4))
 				.inputFluids(new FluidStack(Fluids.PEROXIDE, 1_000, 5))
 				.outputFluids(new FluidStack(Fluids.DEATH, 1_000, 0)));
-		
+
 	}
-	
+
 	public static HashMap getRecipes() {
 		HashMap<Object, Object> recipes = new HashMap<Object, Object>();
-		
+
 		for(GenericRecipe recipe : INSTANCE.recipeOrderedList) {
 			List input = new ArrayList();
 			if(recipe.inputItem != null) for(AStack stack : recipe.inputItem) input.add(stack);
@@ -365,7 +369,7 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 			if(recipe.outputFluid != null) for(FluidStack stack : recipe.outputFluid) output.add(ItemFluidIcon.make(stack));
 			recipes.put(input.toArray(), output.toArray());
 		}
-		
+
 		return recipes;
 	}
 }

--- a/src/main/java/com/hbm/inventory/recipes/CombinationRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/CombinationRecipes.java
@@ -9,6 +9,7 @@ import static com.hbm.inventory.OreDictManager.*;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.stream.JsonWriter;
+import com.hbm.blocks.ModBlocks;
 import com.hbm.inventory.FluidStack;
 import com.hbm.inventory.OreDictManager.DictFrame;
 import com.hbm.inventory.RecipesCommon.AStack;
@@ -28,6 +29,7 @@ import com.hbm.items.special.ItemBedrockOreNew.BedrockOreGrade;
 import com.hbm.items.special.ItemBedrockOreNew.BedrockOreType;
 import com.hbm.util.Tuple.Pair;
 
+import cpw.mods.fml.common.Mod;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -64,7 +66,10 @@ public class CombinationRecipes extends SerializableRecipe {
 		recipes.put(new ComparableStack(DictFrame.fromOne(ModItems.oil_tar, EnumTarType.COAL)),		new Pair(DictFrame.fromOne(ModItems.coke, EnumCokeType.COAL), null));
 		recipes.put(new ComparableStack(DictFrame.fromOne(ModItems.oil_tar, EnumTarType.WOOD)),		new Pair(DictFrame.fromOne(ModItems.coke, EnumCokeType.COAL), null));
 
-		recipes.put(new ComparableStack(Items.reeds), new Pair(new ItemStack(Items.sugar, 2), new FluidStack(Fluids.ETHANOL, 50)));
+		recipes.put(new ComparableStack(Items.reeds), new Pair(new ItemStack(Items.sugar, 3), new FluidStack(Fluids.ETHANOL, 200)));
+		//not a great recipe, is mainly a backup for 528
+		recipes.put(new ComparableStack(ModBlocks.plant_flower, 1, 3), new Pair(null, new FluidStack(Fluids.ETHANOL, 50)));
+
 		recipes.put(new ComparableStack(Blocks.clay), new Pair(new ItemStack(Blocks.brick_block, 1), null));
 
 		for(BedrockOreType type : BedrockOreType.values()) {

--- a/src/main/java/com/hbm/inventory/recipes/ElectrolyserFluidRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/ElectrolyserFluidRecipes.java
@@ -30,6 +30,7 @@ public class ElectrolyserFluidRecipes extends SerializableRecipe {
 		recipes.put(Fluids.SLOP, new ElectrolysisRecipe(1_000, new FluidStack(Fluids.MERCURY, 250), new FluidStack(Fluids.NONE, 0), new ItemStack(ModItems.niter, 2), new ItemStack(ModItems.powder_limestone, 2), new ItemStack(ModItems.sulfur)));
 		recipes.put(Fluids.REDMUD, new ElectrolysisRecipe(450, new FluidStack(Fluids.MERCURY, 150), new FluidStack(Fluids.LYE, 50), new ItemStack(ModItems.powder_titanium, 3), new ItemStack(ModItems.powder_iron, 3), new ItemStack(ModItems.powder_aluminium, 2)));
 		recipes.put(Fluids.ALUMINA, new ElectrolysisRecipe(200, new FluidStack(Fluids.CARBONDIOXIDE, 100), new FluidStack(Fluids.NONE, 0),40, new ItemStack(ModItems.powder_aluminium, 7), new ItemStack(ModItems.fluorite, 2)));
+		recipes.put(Fluids.PAIN, new ElectrolysisRecipe(500, new FluidStack(Fluids.VITRIOL, 500), new FluidStack(Fluids.NONE, 0),40, new ItemStack(ModItems.gem_tantalium, 2), new ItemStack(ModItems.powder_niobium, 1), new ItemStack(ModItems.powder_sodium)));
 
 		recipes.put(Fluids.POTASSIUM_CHLORIDE, new ElectrolysisRecipe(250, new FluidStack(Fluids.CHLORINE, 125), new FluidStack(Fluids.NONE, 0), new ItemStack(ModItems.dust)));
 		recipes.put(Fluids.CALCIUM_CHLORIDE, new ElectrolysisRecipe(250, new FluidStack(Fluids.CHLORINE, 125), new FluidStack(Fluids.CALCIUM_SOLUTION, 125)));

--- a/src/main/java/com/hbm/inventory/recipes/LiquefactionRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/LiquefactionRecipes.java
@@ -31,7 +31,7 @@ public class LiquefactionRecipes extends SerializableRecipe {
 
 	@Override
 	public void registerDefaults() {
-		
+
 		//oil processing
 		recipes.put(COAL.gem(),											new FluidStack(100, Fluids.COALOIL));
 		recipes.put(COAL.dust(),										new FluidStack(100, Fluids.COALOIL));
@@ -59,7 +59,7 @@ public class LiquefactionRecipes extends SerializableRecipe {
 
 		recipes.put(new ComparableStack(Items.sugar),					new FluidStack(100, Fluids.ETHANOL));
 		recipes.put(new ComparableStack(ModBlocks.plant_flower, 1, 3),	new FluidStack(150, Fluids.ETHANOL));
-		recipes.put(new ComparableStack(ModBlocks.plant_flower, 1, 4),	new FluidStack(50, Fluids.ETHANOL));
+		recipes.put(new ComparableStack(ModBlocks.plant_flower, 1, 4),	new FluidStack(150, Fluids.ETHANOL));
 		recipes.put(new ComparableStack(ModItems.biomass),				new FluidStack(125, Fluids.BIOGAS));
 		recipes.put(new ComparableStack(ModItems.glyphid_gland_empty),	new FluidStack(2000, Fluids.BIOGAS));
 		recipes.put(new ComparableStack(Items.fish, 1, OreDictionary.WILDCARD_VALUE), new FluidStack(100, Fluids.FISHOIL));
@@ -70,53 +70,53 @@ public class LiquefactionRecipes extends SerializableRecipe {
 		recipes.put(new ComparableStack(Blocks.tallgrass, 1, 2),		new FluidStack(100, Fluids.SEEDSLURRY));
 		recipes.put(new ComparableStack(Blocks.vine),					new FluidStack(100, Fluids.SEEDSLURRY));
 	}
-	
+
 	public static FluidStack getOutput(ItemStack stack) {
-		
+
 		if(stack == null || stack.getItem() == null)
 			return null;
-		
+
 		ComparableStack comp = new ComparableStack(stack.getItem(), 1, stack.getItemDamage());
-		
+
 		if(recipes.containsKey(comp))
 			return recipes.get(comp);
-		
+
 		String[] dictKeys = comp.getDictKeys();
 		comp = new ComparableStack(stack.getItem(), 1, OreDictionary.WILDCARD_VALUE);
-		
+
 		if(recipes.containsKey(comp))
 			return recipes.get(comp);
-		
+
 		for(String key : dictKeys) {
 
 			if(recipes.containsKey(key))
 				return recipes.get(key);
 		}
-		
+
 		if(stack.getItem() instanceof ItemFood) {
 			ItemFood food = (ItemFood) stack.getItem();
 			float saturation = food.func_150905_g(stack) * food.func_150906_h(stack) * 20; //food val * saturation mod * 2 (constant) * 10 (quanta)
 			return new FluidStack(Fluids.SALIENT, (int) saturation);
 		}
-		
+
 		return null;
 	}
 
 	public static HashMap<Object, ItemStack> getRecipes() {
-		
+
 		HashMap<Object, ItemStack> recipes = new HashMap<Object, ItemStack>();
-		
+
 		for(Entry<Object, FluidStack> entry : LiquefactionRecipes.recipes.entrySet()) {
-			
+
 			FluidStack out = entry.getValue();
-			
+
 			if(entry.getKey() instanceof String) {
 				recipes.put(new OreDictStack((String)entry.getKey()), ItemFluidIcon.make(out.type, out.fill));
 			} else {
 				recipes.put(((ComparableStack)entry.getKey()).toStack(), ItemFluidIcon.make(out.type, out.fill));
 			}
 		}
-		
+
 		return recipes;
 	}
 
@@ -124,7 +124,7 @@ public class LiquefactionRecipes extends SerializableRecipe {
 	public String getFileName() {
 		return "hbmLiquefactor.json";
 	}
-	
+
 	@Override
 	public String getComment() {
 		return "As with most handlers, stacksizes for the inputs are ignored and default to 1.";
@@ -145,7 +145,7 @@ public class LiquefactionRecipes extends SerializableRecipe {
 		JsonObject obj = (JsonObject) recipe;
 		AStack in = this.readAStack(obj.get("input").getAsJsonArray());
 		FluidStack out = this.readFluidStack(obj.get("output").getAsJsonArray());
-		
+
 		if(in instanceof ComparableStack) {
 			recipes.put(((ComparableStack) in).makeSingular(), out);
 		} else if(in instanceof OreDictStack) {
@@ -157,14 +157,14 @@ public class LiquefactionRecipes extends SerializableRecipe {
 	public void writeRecipe(Object recipe, JsonWriter writer) throws IOException {
 		Entry<Object, FluidStack> rec = (Entry<Object, FluidStack>) recipe;
 		Object key = rec.getKey();
-		
+
 		writer.name("input");
 		if(key instanceof String) {
 			this.writeAStack(new OreDictStack((String) key), writer);
 		} else if(key instanceof ComparableStack) {
 			this.writeAStack((ComparableStack) key, writer);
 		}
-		
+
 		writer.name("output");
 		this.writeFluidStack(rec.getValue(), writer);
 	}

--- a/src/main/java/com/hbm/inventory/recipes/SolderingRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/SolderingRecipes.java
@@ -25,18 +25,18 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 public class SolderingRecipes extends SerializableRecipe {
-	
+
 	public static List<SolderingRecipe> recipes = new ArrayList();
 
 	@Override
 	public void registerDefaults() {
-		
+
 		boolean lbsm = GeneralConfig.enableLBSM && GeneralConfig.enableLBSMSimpleCrafting;
-		
+		boolean toggle528 = GeneralConfig.enable528;
 		/*
 		 * CIRCUITS
 		 */
-		
+
 		recipes.add(new SolderingRecipe(new ItemStack(ModItems.circuit, 1, EnumCircuitType.ANALOG.ordinal()), 100, 100,
 				new AStack[] {
 						new ComparableStack(ModItems.circuit, 3, EnumCircuitType.VACUUM_TUBE),
@@ -46,7 +46,7 @@ public class SolderingRecipes extends SerializableRecipe {
 				new AStack[] {
 						new OreDictStack(PB.wireFine(), 4)}
 		));
-		
+
 		recipes.add(new SolderingRecipe(new ItemStack(ModItems.circuit, 1, EnumCircuitType.BASIC.ordinal()), 200, 250,
 				new AStack[] {
 						new ComparableStack(ModItems.circuit, 4, EnumCircuitType.CHIP)},
@@ -55,7 +55,7 @@ public class SolderingRecipes extends SerializableRecipe {
 				new AStack[] {
 						new OreDictStack(PB.wireFine(), 4)}
 		));
-		
+
 		recipes.add(new SolderingRecipe(new ItemStack(ModItems.circuit, 1, EnumCircuitType.ADVANCED.ordinal()), 300, 1_000,
 				new FluidStack(Fluids.SULFURIC_ACID, 1_000),
 				new AStack[] {
@@ -67,7 +67,7 @@ public class SolderingRecipes extends SerializableRecipe {
 				new AStack[] {
 						new OreDictStack(PB.wireFine(), 8)}
 		));
-		
+
 		recipes.add(new SolderingRecipe(new ItemStack(ModItems.circuit, 1, EnumCircuitType.CAPACITOR_BOARD.ordinal()), 200, 300,
 				new FluidStack(Fluids.PEROXIDE, 250),
 				new AStack[] {
@@ -77,7 +77,7 @@ public class SolderingRecipes extends SerializableRecipe {
 				new AStack[] {
 						new OreDictStack(PB.wireFine(), 3)}
 		));
-		
+
 		recipes.add(new SolderingRecipe(new ItemStack(ModItems.circuit, 1, EnumCircuitType.BISMOID.ordinal()), 400, 10_000,
 				new FluidStack(Fluids.SOLVENT, 1_000),
 				new AStack[] {
@@ -90,7 +90,22 @@ public class SolderingRecipes extends SerializableRecipe {
 				new AStack[] {
 						new OreDictStack(PB.wireFine(), 12)}
 		));
-		
+
+		if(!toggle528){
+			recipes.add(new SolderingRecipe(new ItemStack(ModItems.circuit, 2, EnumCircuitType.BISMOID.ordinal()), 400, 10_000,
+				new FluidStack(Fluids.SOLVENT, 1_000),
+				new AStack[] {
+					new ComparableStack(ModItems.circuit, 2, EnumCircuitType.CHIP_BISMOID),
+					new ComparableStack(ModItems.circuit, lbsm ? 4 : 16, EnumCircuitType.CHIP),
+					new ComparableStack(ModItems.circuit, 8, EnumCircuitType.CAPACITOR_TANTALIUM)},
+				new AStack[] {
+					new ComparableStack(ModItems.circuit, 12, EnumCircuitType.PCB),
+					new OreDictStack(ANY_HARDPLASTIC.ingot(), 2)},
+				new AStack[] {
+					new OreDictStack(PB.wireFine(), 12)}
+			));
+		}
+
 		recipes.add(new SolderingRecipe(new ItemStack(ModItems.circuit, 1, EnumCircuitType.QUANTUM.ordinal()), 400, 100_000,
 				new FluidStack(Fluids.HELIUM4, 1_000),
 				new AStack[] {
@@ -103,7 +118,7 @@ public class SolderingRecipes extends SerializableRecipe {
 				new AStack[] {
 						new OreDictStack(PB.wireFine(), 16)}
 		));
-		
+
 		/*
 		 * COMPUTERS
 		 */
@@ -149,7 +164,7 @@ public class SolderingRecipes extends SerializableRecipe {
 		/*
 		 * UPGRADES
 		 */
-		
+
 		recipes.add(new SolderingRecipe(new ItemStack(ModItems.upgrade_speed_1), 200, 1_000,
 				new AStack[] {new ComparableStack(ModItems.circuit, 4, EnumCircuitType.VACUUM_TUBE), new ComparableStack(ModItems.circuit, 1, EnumCircuitType.CAPACITOR)},
 				new AStack[] {new ComparableStack(ModItems.upgrade_template), new OreDictStack(MINGRADE.dust(), 4)},
@@ -185,7 +200,7 @@ public class SolderingRecipes extends SerializableRecipe {
 				new AStack[] {new ComparableStack(ModItems.upgrade_template), new OreDictStack(LI.dust(), 4)},
 				new AStack[] {}
 		));
-		
+
 		addFirstUpgrade(ModItems.upgrade_speed_1, ModItems.upgrade_speed_2);
 		addSecondUpgrade(ModItems.upgrade_speed_2, ModItems.upgrade_speed_3);
 		addFirstUpgrade(ModItems.upgrade_effect_1, ModItems.upgrade_effect_2);
@@ -197,7 +212,7 @@ public class SolderingRecipes extends SerializableRecipe {
 		addFirstUpgrade(ModItems.upgrade_afterburn_1, ModItems.upgrade_afterburn_2);
 		addSecondUpgrade(ModItems.upgrade_afterburn_2, ModItems.upgrade_afterburn_3);
 	}
-	
+
 	public static void addFirstUpgrade(Item lower, Item higher) {
 		boolean lbsm = GeneralConfig.enableLBSM && GeneralConfig.enableLBSMSimpleCrafting;
 		recipes.add(new SolderingRecipe(new ItemStack(higher), 300, 10_000,
@@ -206,7 +221,7 @@ public class SolderingRecipes extends SerializableRecipe {
 				new AStack[] {}
 		));
 	}
-	
+
 	public static void addSecondUpgrade(Item lower, Item higher) {
 		boolean lbsm = GeneralConfig.enableLBSM && GeneralConfig.enableLBSMSimpleCrafting;
 		recipes.add(new SolderingRecipe(new ItemStack(higher), 400, 25_000,
@@ -216,7 +231,7 @@ public class SolderingRecipes extends SerializableRecipe {
 				new AStack[] {}
 		));
 	}
-	
+
 	public static SolderingRecipe getRecipe(ItemStack[] inputs) {
 
 		for(SolderingRecipe recipe : recipes) {
@@ -224,25 +239,25 @@ public class SolderingRecipes extends SerializableRecipe {
 					matchesIngredients(new ItemStack[] {inputs[3], inputs[4]}, recipe.pcb) &&
 					matchesIngredients(new ItemStack[] {inputs[5]}, recipe.solder)) return recipe;
 		}
-		
+
 		return null;
 	}
-	
+
 	public static HashMap getRecipes() {
 
 		HashMap<Object, Object> recipes = new HashMap<Object, Object>();
-		
+
 		for(SolderingRecipe recipe : SolderingRecipes.recipes) {
-			
+
 			List ingredients = new ArrayList();
 			for(AStack stack : recipe.toppings) ingredients.add(stack);
 			for(AStack stack : recipe.pcb) ingredients.add(stack);
 			for(AStack stack : recipe.solder) ingredients.add(stack);
 			if(recipe.fluid != null) ingredients.add(ItemFluidIcon.make(recipe.fluid));
-			
+
 			recipes.put(ingredients.toArray(), recipe.output);
 		}
-		
+
 		return recipes;
 	}
 
@@ -275,31 +290,31 @@ public class SolderingRecipes extends SerializableRecipe {
 		ItemStack output = this.readItemStack(obj.get("output").getAsJsonArray());
 		int duration = obj.get("duration").getAsInt();
 		long consumption = obj.get("consumption").getAsLong();
-		
+
 		recipes.add(new SolderingRecipe(output, duration, consumption, fluid, toppings, pcb, solder));
 	}
 
 	@Override
 	public void writeRecipe(Object obj, JsonWriter writer) throws IOException {
 		SolderingRecipe recipe = (SolderingRecipe) obj;
-		
+
 		writer.name("toppings").beginArray();
 		for(AStack aStack : recipe.toppings) this.writeAStack(aStack, writer);
 		writer.endArray();
-		
+
 		writer.name("pcb").beginArray();
 		for(AStack aStack : recipe.pcb) this.writeAStack(aStack, writer);
 		writer.endArray();
-		
+
 		writer.name("solder").beginArray();
 		for(AStack aStack : recipe.solder) this.writeAStack(aStack, writer);
 		writer.endArray();
-		
+
 		if(recipe.fluid != null) {
 			writer.name("fluid");
 			this.writeFluidStack(recipe.fluid, writer);
 		}
-		
+
 		writer.name("output");
 		this.writeItemStack(recipe.output, writer);
 
@@ -310,7 +325,7 @@ public class SolderingRecipes extends SerializableRecipe {
 	public static HashSet<AStack> toppings = new HashSet();
 	public static HashSet<AStack> pcb = new HashSet();
 	public static HashSet<AStack> solder = new HashSet();
-	
+
 	public static class SolderingRecipe {
 
 		public AStack[] toppings;
@@ -320,7 +335,7 @@ public class SolderingRecipes extends SerializableRecipe {
 		public ItemStack output;
 		public int duration;
 		public long consumption;
-		
+
 		public SolderingRecipe(ItemStack output, int duration, long consumption, FluidStack fluid, AStack[] toppings, AStack[] pcb, AStack[] solder) {
 			this.toppings = toppings;
 			this.pcb = pcb;
@@ -333,7 +348,7 @@ public class SolderingRecipes extends SerializableRecipe {
 			for(AStack t : pcb) SolderingRecipes.pcb.add(t);
 			for(AStack t : solder) SolderingRecipes.solder.add(t);
 		}
-		
+
 		public SolderingRecipe(ItemStack output, int duration, long consumption, AStack[] toppings, AStack[] pcb, AStack[] solder) {
 			this(output, duration, consumption, null, toppings, pcb, solder);
 		}

--- a/src/main/java/com/hbm/main/CraftingManager.java
+++ b/src/main/java/com/hbm/main/CraftingManager.java
@@ -121,6 +121,12 @@ public class CraftingManager {
 		addRecipeAuto(DictFrame.fromOne(ModItems.circuit, EnumCircuitType.CHIP_BISMOID), new Object[] { "III", "SNS", "WWW", 'I', ModItems.plate_polymer, 'S', DictFrame.fromOne(ModItems.circuit, EnumCircuitType.SILICON), 'N', ANY_BISMOID.nugget(), 'W', GOLD.wireFine() });
 		addRecipeAuto(DictFrame.fromOne(ModItems.circuit, EnumCircuitType.CHIP_QUANTUM), new Object[] { "HHH", "SIS", "WWW", 'H', ANY_HARDPLASTIC.ingot(), 'S', BSCCO.wireDense(), 'I', ModItems.pellet_charged, 'W', CU.wireFine() });
 		addRecipeAuto(DictFrame.fromOne(ModItems.circuit, EnumCircuitType.CHIP_QUANTUM), new Object[] { "HHH", "SIS", "WWW", 'H', ANY_HARDPLASTIC.ingot(), 'S', BSCCO.wireDense(), 'I', ModItems.pellet_charged, 'W', GOLD.wireFine() });
+
+		if(!GeneralConfig.enable528) {
+			addRecipeAuto(DictFrame.fromOne(ModItems.circuit, EnumCircuitType.CHIP_QUANTUM, 2), new Object[]{"HHH", "SIS", "WWW", 'H', ANY_HARDPLASTIC.ingot(), 'S', BSCCO.wireDense(), 'I', ModItems.pellet_charged, 'W', TA.nugget()});
+			addRecipeAuto(DictFrame.fromOne(ModItems.circuit, EnumCircuitType.CHIP_BISMOID, 2), new Object[] { "III", "SNS", "WWW", 'I', ModItems.plate_polymer, 'S', DictFrame.fromOne(ModItems.circuit, EnumCircuitType.SILICON), 'N', ANY_BISMOID.nugget(), 'W', TA.nugget()});
+		}
+
 		addRecipeAuto(DictFrame.fromOne(ModItems.circuit, EnumCircuitType.CONTROLLER_CHASSIS), new Object[] { "PPP", "CBB", "PPP", 'P', ANY_PLASTIC.ingot(), 'C', ModItems.crt_display, 'B', DictFrame.fromOne(ModItems.circuit, EnumCircuitType.PCB) });
 		addRecipeAuto(DictFrame.fromOne(ModItems.circuit, EnumCircuitType.ATOMIC_CLOCK), new Object[] { "ICI", "CSC", "ICI", 'I', ModItems.plate_polymer, 'C', DictFrame.fromOne(ModItems.circuit, EnumCircuitType.CHIP), 'S', SR.dust() });
 
@@ -411,7 +417,7 @@ public class CraftingManager {
 		addRecipeAuto(new ItemStack(ModBlocks.basalt_polished, 4), new Object[] { "CC", "CC", 'C', ModBlocks.basalt_smooth });
 		addRecipeAuto(new ItemStack(ModBlocks.basalt_brick, 4), new Object[] { "CC", "CC", 'C', ModBlocks.basalt_polished });
 		addRecipeAuto(new ItemStack(ModBlocks.basalt_tiles, 4), new Object[] { "CC", "CC", 'C', ModBlocks.basalt_brick });
-		
+
 		addShapelessAuto(new ItemStack(ModBlocks.lightstone, 4), new Object[] { Blocks.stone, Blocks.stone, Blocks.stone, ModItems.powder_limestone });
 		addRecipeAuto(new ItemStack(ModBlocks.lightstone, 4, LightstoneType.TILE.ordinal()), new Object[] { "CC", "CC", 'C', new ItemStack(ModBlocks.lightstone, 1, 0) });
 		addRecipeAuto(new ItemStack(ModBlocks.lightstone, 4, LightstoneType.BRICKS.ordinal()), new Object[] { "CC", "CC", 'C', new ItemStack(ModBlocks.lightstone, 1, LightstoneType.TILE.ordinal()) });
@@ -443,7 +449,7 @@ public class CraftingManager {
 		addRecipeAuto(new ItemStack(ModBlocks.barbed_wire_ultradeath, 4), new Object[] { "BCB", "CIC", "BCB", 'B', ModBlocks.barbed_wire, 'C', ModItems.powder_yellowcake, 'I', ModItems.nuclear_waste });
 
 		addShapelessAuto(new ItemStack(ModBlocks.sandbags, 4), new Object[] { ModItems.plate_polymer, KEY_SAND, KEY_SAND, KEY_SAND });
-		
+
 		addRecipeAuto(new ItemStack(Item.getItemFromBlock(ModBlocks.tape_recorder), 4), new Object[] { "TST", "SSS", 'T', W.ingot(), 'S', STEEL.ingot() });
 		addRecipeAuto(new ItemStack(Item.getItemFromBlock(ModBlocks.steel_poles), 16), new Object[] { "S S", "SSS", "S S", 'S', STEEL.ingot() });
 		addRecipeAuto(new ItemStack(Item.getItemFromBlock(ModBlocks.pole_top), 1), new Object[] { "T T", "TRT", "BBB", 'T', W.ingot(), 'B', BE.ingot(), 'R', MINGRADE.ingot() });
@@ -610,7 +616,7 @@ public class CraftingManager {
 		addRecipeAuto(new ItemStack(ModBlocks.fluid_pump, 1), new Object[] { " S ", "PGP", "IMI", 'S', STEEL.shell(), 'P', STEEL.pipe(), 'G', GRAPHITE.ingot(), 'I', STEEL.ingot(), 'M', ModItems.motor });
 		addRecipeAuto(new ItemStack(ModBlocks.pneumatic_tube, 8), new Object[] { "CRC", 'C', CU.plateCast(), 'R', ANY_RUBBER.ingot() });
 		addRecipeAuto(new ItemStack(ModBlocks.pneumatic_tube, 24), new Object[] { "CRC", 'C', CU.plateWelded(), 'R', ANY_RUBBER.ingot() });
-		
+
 		addRecipeAuto(new ItemStack(ModItems.template_folder, 1), new Object[] { "LPL", "BPB", "LPL", 'P', Items.paper, 'L', "dye", 'B', "dye" });
 		addRecipeAuto(new ItemStack(ModItems.pellet_antimatter, 1), new Object[] { "###", "###", "###", '#', ModItems.cell_antimatter });
 		addRecipeAuto(new ItemStack(ModItems.fluid_tank_empty, 8), new Object[] { "121", "1G1", "121", '1', AL.plate(), '2', IRON.plate(), 'G', KEY_ANYPANE });

--- a/src/main/java/com/hbm/world/feature/BedrockOre.java
+++ b/src/main/java/com/hbm/world/feature/BedrockOre.java
@@ -26,9 +26,9 @@ public class BedrockOre {
 
 	public static List<WeightedRandomGeneric<BedrockOreDefinition>> weightedOres = new ArrayList();
 	public static List<WeightedRandomGeneric<BedrockOreDefinition>> weightedOresNether = new ArrayList();
-	
+
 	public static HashMap<String, BedrockOreDefinition> replacements = new HashMap();
-	
+
 	public static void init() {
 		registerBedrockOre(weightedOres, new BedrockOreDefinition(EnumBedrockOre.IRON,													1),													WorldConfig.bedrockIronSpawn);
 		registerBedrockOre(weightedOres, new BedrockOreDefinition(EnumBedrockOre.COPPER,												1),													WorldConfig.bedrockCopperSpawn);
@@ -50,14 +50,16 @@ public class BedrockOre {
 		registerBedrockOre(weightedOres, new BedrockOreDefinition(DictFrame.fromOne(ModItems.chunk_ore, EnumChunkType.RARE),			2,	0x8F9999,	new FluidStack(Fluids.PEROXIDE, 500)),	WorldConfig.bedrockRareEarthSpawn);
 		registerBedrockOre(weightedOres, new BedrockOreDefinition(DictFrame.fromOne(ModBlocks.stone_resource, EnumStoneType.BAUXITE, 2),1,	0xEF7213),										WorldConfig.bedrockBauxiteSpawn);
 
-		registerBedrockOre(weightedOresNether, new BedrockOreDefinition(new ItemStack(Items.glowstone_dust, 4),		1,	0xF9FF4D),							WorldConfig.bedrockGlowstoneSpawn);
+		registerBedrockOre(weightedOresNether, new BedrockOreDefinition(new ItemStack(Items.glowstone_dust, 8),		1,	0xF9FF4D),							WorldConfig.bedrockGlowstoneSpawn);
 		registerBedrockOre(weightedOresNether, new BedrockOreDefinition(new ItemStack(ModItems.powder_fire, 4),		1,	0xD7341F),							WorldConfig.bedrockPhosphorusSpawn);
 		registerBedrockOre(weightedOresNether, new BedrockOreDefinition(new ItemStack(Items.quartz, 4),				1,	0xF0EFDD),							WorldConfig.bedrockQuartzSpawn);
+		registerBedrockOre(weightedOresNether, new BedrockOreDefinition(new ItemStack(ModItems.fragment_coltan, 4),				2,	0xF0EFDD,	new FluidStack(Fluids.CHLORINE, 100)),		WorldConfig.bedrockNetherColtanSpawn);
+
 
 		replacements.put("ore" + EnumBedrockOre.IRON.oreName, new BedrockOreDefinition(EnumBedrockOre.HEMATITE, 1));
 		replacements.put("ore" + EnumBedrockOre.COPPER.oreName, new BedrockOreDefinition(EnumBedrockOre.MALACHITE, 1));
 	}
-	
+
 	public static void registerBedrockOre(List list, BedrockOreDefinition def, int weight) {
 		WeightedRandomGeneric<BedrockOreDefinition> weighted = new WeightedRandomGeneric<BedrockOreDefinition>(def, weight);
 		list.add(weighted);
@@ -68,14 +70,14 @@ public class BedrockOre {
 	}
 
 	public static void generate(World world, int x, int z, ItemStack stack, FluidStack acid, int color, int tier, Block depthRock) {
-		
+
 		for(int ix = x - 1; ix <= x + 1; ix++) {
 			for(int iz = z - 1; iz <= z + 1; iz++) {
-				
+
 				Block b = world.getBlock(ix, 0, iz);
 				if(b.isReplaceableOreGen(world, ix, 0, iz, Blocks.bedrock)) {
 					if((ix == x && iz == z) || world.rand.nextBoolean()) {
-						
+
 						world.setBlock(ix, 0, iz, ModBlocks.ore_bedrock);
 						TileEntityBedrockOre ore = (TileEntityBedrockOre) world.getTileEntity(ix, 0, iz);
 						ore.resource = stack;
@@ -89,13 +91,13 @@ public class BedrockOre {
 				}
 			}
 		}
-		
+
 		for(int ix = x - 3; ix <= x + 3; ix++) {
 			for(int iz = z - 3; iz <= z + 3; iz++) {
-				
+
 				for(int iy = 1; iy < 7; iy++) {
 					if(iy < 3 || world.getBlock(ix, iy, iz) == Blocks.bedrock) {
-						
+
 						Block b = world.getBlock(ix, iy, iz);
 						if(b.isReplaceableOreGen(world, ix, iy, iz, Blocks.stone) || b.isReplaceableOreGen(world, ix, iy, iz, Blocks.bedrock)) {
 							world.setBlock(ix, iy, iz, depthRock);
@@ -105,18 +107,18 @@ public class BedrockOre {
 			}
 		}
 	}
-	
+
 	public static class BedrockOreDefinition {
 		public ItemStack stack;
 		public FluidStack acid;
 		public String id;
 		public int tier;
 		public int color;
-		
+
 		public BedrockOreDefinition(ItemStack stack, int tier, int color) {
 			this(stack, tier, color, null);
 		}
-		
+
 		public BedrockOreDefinition(ItemStack stack, int tier, int color, FluidStack acid) {
 			this.stack = stack;
 			this.id = stack.toString();
@@ -124,11 +126,11 @@ public class BedrockOre {
 			this.color = color;
 			this.acid = acid;
 		}
-		
+
 		public BedrockOreDefinition(EnumBedrockOre type, int tier) {
 			this(type, tier, null);
 		}
-		
+
 		public BedrockOreDefinition(EnumBedrockOre type, int tier, FluidStack acid) {
 			this.stack = DictFrame.fromOne(ModItems.ore_bedrock, type);
 			this.id = "ore" + type.oreName;


### PR DESCRIPTION
### **Reworked tantalum chain:**
First step replaces peroxide with sulfuric acid, and removed fluoride requirement due to the sole way of effective production at scale being bedrock ore
![image](https://github.com/user-attachments/assets/6478bc57-01e3-4e56-a562-42c69dca67ce)

Second Step has been completly reworked:

- Now uses Ethanol, cleaned coltan, and one of two routes
- - Aluminium powder 
![image](https://github.com/user-attachments/assets/1d3b2ff5-de51-4532-b96c-9d7fcbbbd7e7)
- - Liquid Sodium
![image](https://github.com/user-attachments/assets/c20a6a16-6d7e-4648-b80d-3e924b6f49f7)

Aluminium can be mass produced effectively via bauxite, however mass sodium production is difficult until later game, where a sodium sink is needed

Last step now also has a Vitriol byproduct, and an alternative electrolyzer option
![image](https://github.com/user-attachments/assets/3a854a15-2f54-48bc-a4ff-dbc3708ccfe0)

![image](https://github.com/user-attachments/assets/d168929f-4ba9-47f4-971d-bc405afc5faf)

**Other Changes**
Ethanol has obtained some slight improvements and a pre-liquefier, inefficient recipe from hemp in the Comb oven, and all sugar cane related ways have been buffed
Optional, improved circuit/chips recipes have been added using tantalum, primarily for late game circuits  (recipes not available on 528)
An alternate Coltan bedrock ore now can spawn in the nether, however requires chlorine to be mined
- I wonder where one can get chlorine from in the nether