### PR TITLE
Shredder Preferential Ore registry.

### DIFF
--- a/src/main/java/com/hbm/config/CommonConfig.java
+++ b/src/main/java/com/hbm/config/CommonConfig.java
@@ -81,8 +81,8 @@ public class CommonConfig {
 		prop.comment = comment;
 		return prop.getIntList();
 	}
-	public static String[] createConfigStringList(Configuration config, String category, String name, String comment) {
-		Property prop = config.get(category, name, new String[] { "PLACEHOLDER" });
+	public static String[] createConfigStringList(Configuration config, String category, String name, String comment, String[] def) {
+		Property prop = config.get(category, name, def);
 		prop.comment = comment;
 		return prop.getStringList();
 	}

--- a/src/main/java/com/hbm/config/GeneralConfig.java
+++ b/src/main/java/com/hbm/config/GeneralConfig.java
@@ -1,7 +1,7 @@
 package com.hbm.config;
 
 import net.minecraftforge.common.config.Configuration;
-
+import com.hbm.lib.RefStrings;
 public class GeneralConfig {
 
 	public static boolean enableThermosPreventer = true;
@@ -70,6 +70,7 @@ public class GeneralConfig {
 	public static boolean enableLBSMSafeMEDrives = true;
 	public static boolean enableLBSMIGen = true;
 	public static int schrabRate = 20;
+	public static String[] preferredOutputMod = new String[] {RefStrings.MODID};
 
 	public static void loadFromConfig(Configuration config) {
 
@@ -117,7 +118,8 @@ public class GeneralConfig {
 		normalSoundChannels = CommonConfig.createConfigInt(config, CATEGORY_GENERAL, "1.41_normalSoundChannels",
 				"The amount of channels to create while 1.39_enableSoundExtension is enabled.\n" +
 				"Note that a value below 28 or above 200 can cause buggy sounds and issues with other mods running out of sound memory.", 100);
-
+		preferredOutputMod = CommonConfig.createConfigStringList(config,CATEGORY_GENERAL,"1.42_preferredOutputMod",
+				"The mod which is preferred as output when certain machines autogenerate recipes. Currently used for the shredder", new String[] {RefStrings.MODID});
 		enableExpensiveMode = config.get(CATEGORY_GENERAL, "1.99_enableExpensiveMode", false, "It does what the name implies.").getBoolean(false);
 
 		final String CATEGORY_528 = CommonConfig.CATEGORY_528;

--- a/src/main/java/com/hbm/inventory/recipes/ShredderRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/ShredderRecipes.java
@@ -360,9 +360,9 @@ public class ShredderRecipes extends SerializableRecipe {
 
 		/* AR COMPAT */
 		Block arMoonTurf = Compat.tryLoadBlock(Compat.MOD_AR, "turf");
-		if(arMoonTurf != null && gcMoonBlock != Blocks.air) ShredderRecipes.setRecipe(arMoonTurf, new ItemStack(ModBlocks.moon_turf)); //i assume it's moon turf
+		if(arMoonTurf != null && arMoonTurf != Blocks.air) ShredderRecipes.setRecipe(arMoonTurf, new ItemStack(ModBlocks.moon_turf)); //i assume it's moon turf
 		Block arMoonTurfDark = Compat.tryLoadBlock(Compat.MOD_AR, "turfDark");
-		if(arMoonTurfDark != null && gcMoonBlock != Blocks.air) ShredderRecipes.setRecipe(arMoonTurfDark, new ItemStack(ModBlocks.moon_turf)); //probably moon dirt? would have helped if i had ever played AR for more than 5 seconds
+		if(arMoonTurfDark != null && arMoonTurfDark != Blocks.air) ShredderRecipes.setRecipe(arMoonTurfDark, new ItemStack(ModBlocks.moon_turf)); //probably moon dirt? would have helped if i had ever played AR for more than 5 seconds
 	}
 
 	/**

--- a/src/main/java/com/hbm/inventory/recipes/ShredderRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/ShredderRecipes.java
@@ -374,8 +374,9 @@ public class ShredderRecipes extends SerializableRecipe {
 
 		List<ItemStack> matches = OreDictionary.getOres("dust" + name);
 
-		if(matches != null && !matches.isEmpty())
-			return matches.get(0).copy();
+		if(matches != null && !matches.isEmpty()) {
+			return Compat.getPreferredOreOutput(matches);
+		}
 
 		return new ItemStack(ModItems.scrap);
 	}

--- a/src/main/java/com/hbm/util/Compat.java
+++ b/src/main/java/com/hbm/util/Compat.java
@@ -49,7 +49,29 @@ public class Compat {
 	private static String getReg(String domain, String name) {
 		return domain + ":" + name;
 	}
-
+	
+	public static ItemStack getPreferredOreOutput(List<ItemStack> oreList) {
+		int lowestPref = -1;
+		ItemStack preferredStack = null;
+		
+		for(ItemStack item : oreList) {
+			String modid = ItemStackUtil.getModIdFromItemStack(item);
+			for(int i = 0; i < GeneralConfig.preferredOutputMod.length; i++) {
+				if (modid.equals(GeneralConfig.preferredOutputMod[i])){
+					if (lowestPref<0 || i <lowestPref) {
+						preferredStack = item;
+						lowestPref = i;
+					}
+					break;
+				}
+			}
+		}
+		if (preferredStack != null) {
+			return preferredStack.copy();
+		}
+		return oreList.get(0).copy();
+	}
+	
 	public static boolean isModLoaded(String modid) {
 		return Loader.isModLoaded(modid);
 	}

--- a/src/main/java/com/hbm/util/ItemStackUtil.java
+++ b/src/main/java/com/hbm/util/ItemStackUtil.java
@@ -15,6 +15,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
+
 public class ItemStackUtil {
 
 	public static ItemStack carefulCopy(ItemStack stack) {
@@ -165,6 +168,19 @@ public class ItemStackUtil {
 		}
 
 		return list;
+	}
+	
+	/**
+	 * Returns a String of the mod id of an itemstack. If a unique identifier can't be found in the registry, returns null.
+	 * @param stack
+	 * @return
+	 */
+	public static String getModIdFromItemStack(ItemStack stack) {
+		UniqueIdentifier id = GameRegistry.findUniqueIdentifierFor(stack.getItem());
+		if(id!=null) {
+			return id.modId;
+		}
+		return null;
 	}
 
 	public static void spillItems(World world, int x, int y, int z, Block block, Random rand) {


### PR DESCRIPTION
Inspired by various other mods that do it, I tried my hand implementing a preferential config for autogen recipes. 

Currently applies to the shredder, now it will produce NTM dusts by default, but the config could be changed to say: gregtech dusts, then ntm dusts, with enderio as a fallback if a modpack maker wanted.

I also accidentally fixed advanced rocketry moon turf compat - because of copy paste typo's, it had been set to only register the recipes if galacticraft was installed.