### PR TITLE
Allow stopping conveyor inserters with redstone

### DIFF
--- a/src/main/java/com/hbm/blocks/network/CraneInserter.java
+++ b/src/main/java/com/hbm/blocks/network/CraneInserter.java
@@ -68,17 +68,19 @@ public class CraneInserter extends BlockCraneBase implements IEnterableBlock {
 
 		ItemStack toAdd = entity.getItemStack().copy();
 
-		int[] access = null;
+		if (!world.isBlockIndirectlyGettingPowered(x, y, z)) {
+			int[] access = null;
 
-		if(te instanceof ISidedInventory) {
-			ISidedInventory sided = (ISidedInventory) te;
-			access = InventoryUtil.masquerade(sided, outputDirection.getOpposite().ordinal());
-		}
+			if(te instanceof ISidedInventory) {
+				ISidedInventory sided = (ISidedInventory) te;
+				access = InventoryUtil.masquerade(sided, outputDirection.getOpposite().ordinal());
+			}
 
-		if(te instanceof IInventory) {
-			IInventory inv = (IInventory) te;
+			if(te instanceof IInventory) {
+				IInventory inv = (IInventory) te;
 
-			addToInventory(inv, access, toAdd, outputDirection.getOpposite().ordinal());
+				addToInventory(inv, access, toAdd, outputDirection.getOpposite().ordinal());
+			}
 		}
 
 		TileEntityCraneInserter inserter = null;

--- a/src/main/java/com/hbm/tileentity/network/TileEntityCraneInserter.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityCraneInserter.java
@@ -40,48 +40,49 @@ public class TileEntityCraneInserter extends TileEntityCraneBase implements IGUI
 		super.updateEntity();
 		if(!worldObj.isRemote) {
 
-			ForgeDirection outputSide = getOutputSide();
-			TileEntity te = worldObj.getTileEntity(xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ);
-			
-			int[] access = null;
-			
-			if(te instanceof ISidedInventory) {
-				ISidedInventory sided = (ISidedInventory) te;
-				//access = sided.getAccessibleSlotsFromSide(dir.ordinal());
-				access = InventoryUtil.masquerade(sided, outputSide.getOpposite().ordinal());
-			}
-			
-			if(te instanceof IInventory) {
-				for(int i = 0; i < slots.length; i++) {
-					
-					ItemStack stack = slots[i];
-					
-					if(stack != null) {
-						ItemStack ret = CraneInserter.addToInventory((IInventory) te, access, stack.copy(), outputSide.getOpposite().ordinal());
-						
-						if(ret == null || ret.stackSize != stack.stackSize) {
-							slots[i] = ret;
-							this.markDirty();
-							return;
-						}
-					}
+			if (!this.worldObj.isBlockIndirectlyGettingPowered(xCoord, yCoord, zCoord)) {ForgeDirection outputSide = getOutputSide();
+				TileEntity te = worldObj.getTileEntity(xCoord + outputSide.offsetX, yCoord + outputSide.offsetY, zCoord + outputSide.offsetZ);
+				
+				int[] access = null;
+				
+				if(te instanceof ISidedInventory) {
+					ISidedInventory sided = (ISidedInventory) te;
+					//access = sided.getAccessibleSlotsFromSide(dir.ordinal());
+					access = InventoryUtil.masquerade(sided, outputSide.getOpposite().ordinal());
 				}
 				
-				//if the previous operation fails, repeat but use single items instead of the whole stack instead
-				//this should fix cases where the inserter can't insert into something that has a stack size limitation
-				for(int i = 0; i < slots.length; i++) {
-					
-					ItemStack stack = slots[i];
-					
-					if(stack != null) {
-						stack = stack.copy();
-						stack.stackSize = 1;
-						ItemStack ret = CraneInserter.addToInventory((IInventory) te, access, stack.copy(), outputSide.getOpposite().ordinal());
+				if(te instanceof IInventory) {
+					for(int i = 0; i < slots.length; i++) {
 						
-						if(ret == null || ret.stackSize != stack.stackSize) {
-							this.decrStackSize(i, 1);
-							this.markDirty();
-							return;
+						ItemStack stack = slots[i];
+						
+						if(stack != null) {
+							ItemStack ret = CraneInserter.addToInventory((IInventory) te, access, stack.copy(), outputSide.getOpposite().ordinal());
+							
+							if(ret == null || ret.stackSize != stack.stackSize) {
+								slots[i] = ret;
+								this.markDirty();
+								return;
+							}
+						}
+					}
+					
+					//if the previous operation fails, repeat but use single items instead of the whole stack instead
+					//this should fix cases where the inserter can't insert into something that has a stack size limitation
+					for(int i = 0; i < slots.length; i++) {
+						
+						ItemStack stack = slots[i];
+						
+						if(stack != null) {
+							stack = stack.copy();
+							stack.stackSize = 1;
+							ItemStack ret = CraneInserter.addToInventory((IInventory) te, access, stack.copy(), outputSide.getOpposite().ordinal());
+							
+							if(ret == null || ret.stackSize != stack.stackSize) {
+								this.decrStackSize(i, 1);
+								this.markDirty();
+								return;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
A stopped inserted will still take items to its own inventory, but won't insert them into the inventory it is facing. Useful for taking out stuff from overflowing outputs, if you want to maintain a particular slot distribution.