### PR TITLE
Make conveyor extractors take items to inventory when not facing a conveyor

### DIFF
--- a/src/main/java/com/hbm/tileentity/network/TileEntityCraneExtractor.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityCraneExtractor.java
@@ -10,6 +10,8 @@ import com.hbm.items.ModItems;
 import com.hbm.module.ModulePatternMatcher;
 import com.hbm.tileentity.IControlReceiverFilter;
 import com.hbm.tileentity.IGUIProvider;
+import com.hbm.util.InventoryUtil;
+
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
@@ -94,54 +96,62 @@ public class TileEntityCraneExtractor extends TileEntityCraneBase implements IGU
 				}
 				
 				boolean hasSent = false;
+
+				IConveyorBelt belt = null;
 				
 				if(b instanceof IConveyorBelt) {
+					belt = (IConveyorBelt) b;
+				}
 					
-					IConveyorBelt belt = (IConveyorBelt) b;
+				/* try to send items from a connected inv, if present */
+				if(te instanceof IInventory) {
 					
-					/* try to send items from a connected inv, if present */
-					if(te instanceof IInventory) {
+					IInventory inv = (IInventory) te;
+					int size = access == null ? inv.getSizeInventory() : access.length;
+					
+					for(int i = 0; i < size; i++) {
+						int index = access == null ? i : access[i];
+						ItemStack stack = inv.getStackInSlot(index);
 						
-						IInventory inv = (IInventory) te;
-						int size = access == null ? inv.getSizeInventory() : access.length;
-						
-						for(int i = 0; i < size; i++) {
-							int index = access == null ? i : access[i];
-							ItemStack stack = inv.getStackInSlot(index);
+						if(stack != null && (sided == null || sided.canExtractItem(index, stack, inputSide.getOpposite().ordinal()))){
 							
-							if(stack != null && (sided == null || sided.canExtractItem(index, stack, inputSide.getOpposite().ordinal()))){
+							boolean match = this.matchesFilter(stack);
+							
+							if((isWhitelist && match) || (!isWhitelist && !match)) {
+								stack = stack.copy();
+								int toSend = Math.min(amount, stack.stackSize);
 								
-								boolean match = this.matchesFilter(stack);
-								
-								if((isWhitelist && match) || (!isWhitelist && !match)) {
-									stack = stack.copy();
-									int toSend = Math.min(amount, stack.stackSize);
+								if (belt != null) {
 									inv.decrStackSize(index, toSend);
 									stack.stackSize = toSend;
-									
 									sendItem(stack, belt, outputSide);
-									hasSent = true;
-									break;
+								} else {
+									stack.stackSize = toSend;
+									ItemStack remaining = InventoryUtil.tryAddItemToInventory(this.slots, stack);
+									inv.decrStackSize(index, toSend - (remaining == null ? 0 : remaining.stackSize));
 								}
+								hasSent = true;
+								break;
 							}
 						}
 					}
+				}
+				
+				/* if no item has been sent, send buffered items while ignoring the filter */
+				if(!hasSent && belt != null) {
 					
-					/* if no item has been sent, send buffered items while ignoring the filter */
-					if(!hasSent) {
+					for(int i = 9; i < 18; i++) {
+						ItemStack stack = slots[i];
 						
-						for(int i = 9; i < 18; i++) {
-							ItemStack stack = slots[i];
-							
-							if(stack != null){
-								stack = stack.copy();
-								int toSend = Math.min(amount, stack.stackSize);
-								decrStackSize(i, toSend);
-								stack.stackSize = toSend;
-								
-								sendItem(stack, belt, outputSide);
-								break;
-							}
+						if(stack != null){
+							stack = stack.copy();
+							int toSend = Math.min(amount, stack.stackSize);
+
+							decrStackSize(i, toSend);
+							stack.stackSize = toSend;
+							sendItem(stack, belt, outputSide);
+
+							break;
 						}
 					}
 				}

--- a/src/main/java/com/hbm/tileentity/network/TileEntityCraneExtractor.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityCraneExtractor.java
@@ -127,7 +127,7 @@ public class TileEntityCraneExtractor extends TileEntityCraneBase implements IGU
 									sendItem(stack, belt, outputSide);
 								} else {
 									stack.stackSize = toSend;
-									ItemStack remaining = InventoryUtil.tryAddItemToInventory(this.slots, stack);
+									ItemStack remaining = InventoryUtil.tryAddItemToInventory(this.slots, 9, 17, stack);
 									inv.decrStackSize(index, toSend - (remaining == null ? 0 : remaining.stackSize));
 								}
 								hasSent = true;


### PR DESCRIPTION
This allows using them as an ad-hoc hopper with a small buffer. Previously their buffer was effectively rudimentary -- it was used for output, but nothing ever inputted into it.