### PR TITLE
Turn burner & electric press into proper pseudomultiblocks

### DIFF
--- a/src/main/java/com/hbm/blocks/BlockDummyable.java
+++ b/src/main/java/com/hbm/blocks/BlockDummyable.java
@@ -103,7 +103,12 @@ public abstract class BlockDummyable extends BlockContainer implements ICustomBl
 		ForgeDirection dir = ForgeDirection.getOrientation(metadata).getOpposite();
 		Block b = world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ);
 
-		if(b != this) {
+		// An extra precaution against multiblocks on chunk borders being erroneously deleted.
+		// Technically, this might be used to persist ghost dummy blocks by manipulating
+		// loaded chunks and block destruction, but this gives no benefit to the player,
+		// cannot be done accidentally, and is definitely preferable to multiblocks
+		// just vanishing when their chunks are unloaded in an unlucky way.
+		if(b != this && world.checkChunksExist(x - 1, y - 1, z - 1, x + 1, y + 1, z + 1)) {
 			if (isLegacyMonoblock(world, x, y, z)) {
 				fixLegacyMonoblock(world, x, y, z);
 			} else {

--- a/src/main/java/com/hbm/blocks/BlockDummyable.java
+++ b/src/main/java/com/hbm/blocks/BlockDummyable.java
@@ -77,27 +77,20 @@ public abstract class BlockDummyable extends BlockContainer implements ICustomBl
 
 		super.onNeighborBlockChange(world, x, y, z, block);
 
-		if(world.isRemote || safeRem)
+		if(safeRem)
 			return;
 
-		int metadata = world.getBlockMetadata(x, y, z);
-
-		// if it's an extra, remove the extra-ness
-		if(metadata >= extra)
-			metadata -= extra;
-
-		ForgeDirection dir = ForgeDirection.getOrientation(metadata).getOpposite();
-		Block b = world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ);
-
-		if(b != this) {
-			world.setBlockToAir(x, y, z);
-		}
+		destroyIfOrphan(world, x, y, z);
 	}
 
 	public void updateTick(World world, int x, int y, int z, Random rand) {
 
 		super.updateTick(world, x, y, z, rand);
 
+		destroyIfOrphan(world, x, y, z);
+	}
+
+	private void destroyIfOrphan(World world, int x, int y, int z) {
 		if(world.isRemote)
 			return;
 
@@ -111,9 +104,26 @@ public abstract class BlockDummyable extends BlockContainer implements ICustomBl
 		Block b = world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ);
 
 		if(b != this) {
-			world.setBlockToAir(x, y, z);
+			if (isLegacyMonoblock(world, x, y, z)) {
+				fixLegacyMonoblock(world, x, y, z);
+			} else {
+				world.setBlockToAir(x, y, z);
+			}
 		}
+	}
 
+	// Override this when turning a single block into a pseudo-multiblock.
+	// If this returns true, instead of being deleted as an orphan, the block
+	// will be promoted to a core of a dummyable, however without any dummies.
+	// This is only called if the block is presumed an orphan, so you don't
+	// need to check that here.
+	protected boolean isLegacyMonoblock(World world, int x, int y, int z) {
+		return false;
+	}
+
+	protected void fixLegacyMonoblock(World world, int x, int y, int z) {
+		// Promote to a lone core block with the same effective rotation as before the change
+		world.setBlockMetadataWithNotify(x, y, z, offset + world.getBlockMetadata(x, y, z), 3);
 	}
 
 	public int[] findCore(World world, int x, int y, int z) {

--- a/src/main/java/com/hbm/blocks/machine/MachineEPress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineEPress.java
@@ -4,6 +4,7 @@ import java.util.Random;
 
 import com.hbm.blocks.BlockDummyable;
 import com.hbm.main.MainRegistry;
+import com.hbm.tileentity.TileEntityProxyCombo;
 import com.hbm.tileentity.machine.TileEntityMachineEPress;
 import com.hbm.world.gen.INBTTransformable;
 
@@ -24,6 +25,7 @@ public class MachineEPress extends BlockDummyable implements INBTTransformable {
 	@Override
 	public TileEntity createNewTileEntity(World world, int meta) {
 		if(meta >= 12) return new TileEntityMachineEPress();
+		if(meta >= 6) return new TileEntityProxyCombo(true, false, false);
 		return null;
 	}
 
@@ -65,7 +67,7 @@ public class MachineEPress extends BlockDummyable implements INBTTransformable {
 			if(entity == null) 
 				return false;
 			
-			FMLNetworkHandler.openGui(player, MainRegistry.instance, 0, world, x, y, z);
+			FMLNetworkHandler.openGui(player, MainRegistry.instance, 0, world, pos[0], pos[1], pos[2]);
 			return true;
 		} else {
 			return false;

--- a/src/main/java/com/hbm/blocks/machine/MachineEPress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineEPress.java
@@ -8,28 +8,23 @@ import com.hbm.tileentity.machine.TileEntityMachineEPress;
 import com.hbm.world.gen.INBTTransformable;
 
 import cpw.mods.fml.common.network.internal.FMLNetworkHandler;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
 public class MachineEPress extends BlockDummyable implements INBTTransformable {
 
-	public MachineEPress(Material p_i45386_1_) {
-		super(p_i45386_1_);
+	public MachineEPress(Material mat) {
+		super(mat);
 	}
 
 	@Override
-	public TileEntity createNewTileEntity(World p_149915_1_, int p_149915_2_) {
-		return new TileEntityMachineEPress();
+	public TileEntity createNewTileEntity(World world, int meta) {
+		if(meta >= 12) return new TileEntityMachineEPress();
+		return null;
 	}
 
 	@Override

--- a/src/main/java/com/hbm/blocks/machine/MachineEPress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineEPress.java
@@ -37,6 +37,12 @@ public class MachineEPress extends BlockDummyable {
 	}
 
 	@Override
+	protected boolean isLegacyMonoblock(World world, int x, int y, int z) {
+		TileEntity te = world.getTileEntity(x, y, z);
+		return te != null && te instanceof TileEntityMachineEPress;
+	}
+
+	@Override
 	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase player, ItemStack itemStack) {
 		super.onBlockPlacedBy(world, x, y, z, player, itemStack);
 

--- a/src/main/java/com/hbm/blocks/machine/MachineEPress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineEPress.java
@@ -2,6 +2,7 @@ package com.hbm.blocks.machine;
 
 import java.util.Random;
 
+import com.hbm.blocks.BlockDummyable;
 import com.hbm.main.MainRegistry;
 import com.hbm.tileentity.machine.TileEntityMachineEPress;
 import com.hbm.world.gen.INBTTransformable;
@@ -20,10 +21,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
-public class MachineEPress extends BlockContainer implements INBTTransformable {
-
-	private final Random field_149933_a = new Random();
-	private static boolean keepInventory;
+public class MachineEPress extends BlockDummyable implements INBTTransformable {
 
 	public MachineEPress(Material p_i45386_1_) {
 		super(p_i45386_1_);
@@ -35,75 +33,27 @@ public class MachineEPress extends BlockContainer implements INBTTransformable {
 	}
 
 	@Override
-	public int getRenderType() {
-		return -1;
+	public int[] getDimensions() {
+		return new int[] {2, 0, 0, 0, 0, 0};
 	}
 
 	@Override
-	public boolean isOpaqueCube() {
-		return false;
-	}
-
-	@Override
-	public boolean renderAsNormalBlock() {
-		return false;
-	}
-
-	@Override
-	public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_) {
-		if(!keepInventory) {
-			ISidedInventory tileentityfurnace = (ISidedInventory) p_149749_1_.getTileEntity(p_149749_2_, p_149749_3_, p_149749_4_);
-
-			if(tileentityfurnace != null) {
-				for(int i1 = 0; i1 < tileentityfurnace.getSizeInventory(); ++i1) {
-					ItemStack itemstack = tileentityfurnace.getStackInSlot(i1);
-
-					if(itemstack != null) {
-						float f = this.field_149933_a.nextFloat() * 0.8F + 0.1F;
-						float f1 = this.field_149933_a.nextFloat() * 0.8F + 0.1F;
-						float f2 = this.field_149933_a.nextFloat() * 0.8F + 0.1F;
-
-						while(itemstack.stackSize > 0) {
-							int j1 = this.field_149933_a.nextInt(21) + 10;
-
-							if(j1 > itemstack.stackSize) {
-								j1 = itemstack.stackSize;
-							}
-
-							itemstack.stackSize -= j1;
-							EntityItem entityitem = new EntityItem(p_149749_1_, p_149749_2_ + f, p_149749_3_ + f1, p_149749_4_ + f2, new ItemStack(itemstack.getItem(), j1, itemstack.getItemDamage()));
-
-							if(itemstack.hasTagCompound()) {
-								entityitem.getEntityItem().setTagCompound((NBTTagCompound) itemstack.getTagCompound().copy());
-							}
-
-							float f3 = 0.05F;
-							entityitem.motionX = (float) this.field_149933_a.nextGaussian() * f3;
-							entityitem.motionY = (float) this.field_149933_a.nextGaussian() * f3 + 0.2F;
-							entityitem.motionZ = (float) this.field_149933_a.nextGaussian() * f3;
-							p_149749_1_.spawnEntityInWorld(entityitem);
-						}
-					}
-				}
-
-				p_149749_1_.func_147453_f(p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_);
-			}
-		}
-
-		super.breakBlock(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_, p_149749_6_);
+	public int getOffset() {
+		return 0;
 	}
 
 	@Override
 	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase player, ItemStack itemStack) {
-		int i = MathHelper.floor_double(player.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
-
-		if(i == 0) world.setBlockMetadataWithNotify(x, y, z, 2, 2);
-		if(i == 1) world.setBlockMetadataWithNotify(x, y, z, 5, 2);
-		if(i == 2) world.setBlockMetadataWithNotify(x, y, z, 3, 2);
-		if(i == 3) world.setBlockMetadataWithNotify(x, y, z, 4, 2);
+		super.onBlockPlacedBy(world, x, y, z, player, itemStack);
 
 		if(itemStack.hasDisplayName()) {
-			((TileEntityMachineEPress) world.getTileEntity(x, y, z)).setCustomName(itemStack.getDisplayName());
+			int[] pos = this.findCore(world, x, y, z);
+			if(pos != null) {
+				TileEntityMachineEPress entity = (TileEntityMachineEPress) world.getTileEntity(pos[0], pos[1], pos[2]);
+				if(entity != null) {
+					entity.setCustomName(itemStack.getDisplayName());
+				}
+			}
 		}
 	}
 
@@ -112,10 +62,15 @@ public class MachineEPress extends BlockContainer implements INBTTransformable {
 		if(world.isRemote) {
 			return true;
 		} else if(!player.isSneaking()) {
-			TileEntityMachineEPress entity = (TileEntityMachineEPress) world.getTileEntity(x, y, z);
-			if(entity != null) {
-				FMLNetworkHandler.openGui(player, MainRegistry.instance, 0, world, x, y, z);
-			}
+			int[] pos = this.findCore(world, x, y, z);
+			if(pos == null)
+				return false;
+
+			TileEntityMachineEPress entity = (TileEntityMachineEPress) world.getTileEntity(pos[0], pos[1], pos[2]);
+			if(entity == null) 
+				return false;
+			
+			FMLNetworkHandler.openGui(player, MainRegistry.instance, 0, world, x, y, z);
 			return true;
 		} else {
 			return false;

--- a/src/main/java/com/hbm/blocks/machine/MachineEPress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineEPress.java
@@ -1,12 +1,9 @@
 package com.hbm.blocks.machine;
 
-import java.util.Random;
-
 import com.hbm.blocks.BlockDummyable;
 import com.hbm.main.MainRegistry;
 import com.hbm.tileentity.TileEntityProxyCombo;
 import com.hbm.tileentity.machine.TileEntityMachineEPress;
-import com.hbm.world.gen.INBTTransformable;
 
 import cpw.mods.fml.common.network.internal.FMLNetworkHandler;
 import net.minecraft.block.material.Material;
@@ -16,7 +13,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-public class MachineEPress extends BlockDummyable implements INBTTransformable {
+public class MachineEPress extends BlockDummyable {
 
 	public MachineEPress(Material mat) {
 		super(mat);
@@ -72,10 +69,5 @@ public class MachineEPress extends BlockDummyable implements INBTTransformable {
 		} else {
 			return false;
 		}
-	}
-
-	@Override
-	public int transformMeta(int meta, int coordBaseMode) {
-		return INBTTransformable.transformMetaDeco(meta, coordBaseMode);
 	}
 }

--- a/src/main/java/com/hbm/blocks/machine/MachineEPress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineEPress.java
@@ -72,7 +72,9 @@ public class MachineEPress extends BlockDummyable implements IToolable {
 		if (meta >= 12)
 			return false;
 		
+		safeRem = true;
 		world.setBlockToAir(x, y, z);
+		safeRem = false;
 		return true;
 	}
 }

--- a/src/main/java/com/hbm/blocks/machine/MachineEPress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineEPress.java
@@ -59,21 +59,6 @@ public class MachineEPress extends BlockDummyable {
 
 	@Override
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
-		if(world.isRemote) {
-			return true;
-		} else if(!player.isSneaking()) {
-			int[] pos = this.findCore(world, x, y, z);
-			if(pos == null)
-				return false;
-
-			TileEntityMachineEPress entity = (TileEntityMachineEPress) world.getTileEntity(pos[0], pos[1], pos[2]);
-			if(entity == null) 
-				return false;
-			
-			FMLNetworkHandler.openGui(player, MainRegistry.instance, 0, world, pos[0], pos[1], pos[2]);
-			return true;
-		} else {
-			return false;
-		}
+		return this.standardOpenBehavior(world, x, y, z, player, 0);
 	}
 }

--- a/src/main/java/com/hbm/blocks/machine/MachineEPress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineEPress.java
@@ -1,11 +1,10 @@
 package com.hbm.blocks.machine;
 
 import com.hbm.blocks.BlockDummyable;
-import com.hbm.main.MainRegistry;
 import com.hbm.tileentity.TileEntityProxyCombo;
 import com.hbm.tileentity.machine.TileEntityMachineEPress;
 
-import cpw.mods.fml.common.network.internal.FMLNetworkHandler;
+import api.hbm.block.IToolable;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -13,7 +12,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-public class MachineEPress extends BlockDummyable {
+public class MachineEPress extends BlockDummyable implements IToolable {
 
 	public MachineEPress(Material mat) {
 		super(mat);
@@ -60,5 +59,20 @@ public class MachineEPress extends BlockDummyable {
 	@Override
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
 		return this.standardOpenBehavior(world, x, y, z, player, 0);
+	}
+
+	// Un-multiblickable with a hand drill for schenanigans
+	@Override
+	public boolean onScrew(World world, EntityPlayer player, int x, int y, int z, int side, float fX, float fY, float fZ, ToolType tool) {
+		
+		if (tool != ToolType.HAND_DRILL) 
+			return false;
+		
+		int meta = world.getBlockMetadata(x, y, z);
+		if (meta >= 12)
+			return false;
+		
+		world.setBlockToAir(x, y, z);
+		return true;
 	}
 }

--- a/src/main/java/com/hbm/blocks/machine/MachinePress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachinePress.java
@@ -43,21 +43,6 @@ public class MachinePress extends BlockDummyable {
 	
 	@Override
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
-		if(world.isRemote) {
-			return true;
-		} else if(!player.isSneaking()) {
-			int[] pos = this.findCore(world, x, y, z);
-			if(pos == null)
-				return false;
-
-			TileEntityMachinePress entity = (TileEntityMachinePress) world.getTileEntity(pos[0], pos[1], pos[2]);
-			if(entity == null) 
-				return false;
-			
-			FMLNetworkHandler.openGui(player, MainRegistry.instance, 0, world, pos[0], pos[1], pos[2]);
-			return true;
-		} else {
-			return false;
-		}
+		return this.standardOpenBehavior(world, x, y, z, player, 0);
 	}
 }

--- a/src/main/java/com/hbm/blocks/machine/MachinePress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachinePress.java
@@ -1,18 +1,16 @@
 package com.hbm.blocks.machine;
 
-import java.util.Random;
-
 import com.hbm.blocks.BlockDummyable;
-import com.hbm.main.MainRegistry;
 import com.hbm.tileentity.TileEntityProxyCombo;
 import com.hbm.tileentity.machine.TileEntityMachinePress;
-import cpw.mods.fml.common.network.internal.FMLNetworkHandler;
+
+import api.hbm.block.IToolable;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-public class MachinePress extends BlockDummyable {
+public class MachinePress extends BlockDummyable implements IToolable {
 
 	public MachinePress(Material mat) {
 		super(mat);
@@ -45,4 +43,20 @@ public class MachinePress extends BlockDummyable {
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
 		return this.standardOpenBehavior(world, x, y, z, player, 0);
 	}
+
+	// Un-multiblickable with a hand drill for schenanigans
+	@Override
+	public boolean onScrew(World world, EntityPlayer player, int x, int y, int z, int side, float fX, float fY, float fZ, ToolType tool) {
+		
+		if (tool != ToolType.HAND_DRILL) 
+			return false;
+		
+		int meta = world.getBlockMetadata(x, y, z);
+		if (meta >= 12)
+			return false;
+		
+		world.setBlockToAir(x, y, z);
+		return true;
+	}
+	
 }

--- a/src/main/java/com/hbm/blocks/machine/MachinePress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachinePress.java
@@ -13,13 +13,14 @@ import net.minecraft.world.World;
 
 public class MachinePress extends BlockDummyable {
 
-	public MachinePress(Material p_i45386_1_) {
-		super(p_i45386_1_);
+	public MachinePress(Material mat) {
+		super(mat);
 	}
 
 	@Override
-	public TileEntity createNewTileEntity(World p_149915_1_, int p_149915_2_) {
-		return new TileEntityMachinePress();
+	public TileEntity createNewTileEntity(World world, int meta) {
+		if(meta >= 12) return new TileEntityMachinePress();
+		return null;
 	}
 
 	@Override

--- a/src/main/java/com/hbm/blocks/machine/MachinePress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachinePress.java
@@ -2,23 +2,16 @@ package com.hbm.blocks.machine;
 
 import java.util.Random;
 
+import com.hbm.blocks.BlockDummyable;
 import com.hbm.main.MainRegistry;
 import com.hbm.tileentity.machine.TileEntityMachinePress;
 import cpw.mods.fml.common.network.internal.FMLNetworkHandler;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
-import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-public class MachinePress extends BlockContainer {
-	
-	private final Random field_149933_a = new Random();
-	private static boolean keepInventory;
+public class MachinePress extends BlockDummyable {
 
 	public MachinePress(Material p_i45386_1_) {
 		super(p_i45386_1_);
@@ -30,62 +23,13 @@ public class MachinePress extends BlockContainer {
 	}
 
 	@Override
-	public int getRenderType() {
-		return -1;
+	public int[] getDimensions() {
+		return new int[] {2, 0, 0, 0, 0, 0};
 	}
 
 	@Override
-	public boolean isOpaqueCube() {
-		return false;
-	}
-
-	@Override
-	public boolean renderAsNormalBlock() {
-		return false;
-	}
-	
-	@Override
-	public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_) {
-		if(!keepInventory) {
-			TileEntityMachinePress tileentityfurnace = (TileEntityMachinePress) p_149749_1_.getTileEntity(p_149749_2_, p_149749_3_, p_149749_4_);
-
-			if(tileentityfurnace != null) {
-				for(int i1 = 0; i1 < tileentityfurnace.getSizeInventory(); ++i1) {
-					ItemStack itemstack = tileentityfurnace.getStackInSlot(i1);
-
-					if(itemstack != null) {
-						float f = this.field_149933_a.nextFloat() * 0.8F + 0.1F;
-						float f1 = this.field_149933_a.nextFloat() * 0.8F + 0.1F;
-						float f2 = this.field_149933_a.nextFloat() * 0.8F + 0.1F;
-
-						while(itemstack.stackSize > 0) {
-							int j1 = this.field_149933_a.nextInt(21) + 10;
-
-							if(j1 > itemstack.stackSize) {
-								j1 = itemstack.stackSize;
-							}
-
-							itemstack.stackSize -= j1;
-							EntityItem entityitem = new EntityItem(p_149749_1_, p_149749_2_ + f, p_149749_3_ + f1, p_149749_4_ + f2, new ItemStack(itemstack.getItem(), j1, itemstack.getItemDamage()));
-
-							if(itemstack.hasTagCompound()) {
-								entityitem.getEntityItem().setTagCompound((NBTTagCompound) itemstack.getTagCompound().copy());
-							}
-
-							float f3 = 0.05F;
-							entityitem.motionX = (float) this.field_149933_a.nextGaussian() * f3;
-							entityitem.motionY = (float) this.field_149933_a.nextGaussian() * f3 + 0.2F;
-							entityitem.motionZ = (float) this.field_149933_a.nextGaussian() * f3;
-							p_149749_1_.spawnEntityInWorld(entityitem);
-						}
-					}
-				}
-
-				p_149749_1_.func_147453_f(p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_);
-			}
-		}
-
-		super.breakBlock(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, p_149749_5_, p_149749_6_);
+	public int getOffset() {
+		return 0;
 	}
 	
 	@Override
@@ -93,10 +37,15 @@ public class MachinePress extends BlockContainer {
 		if(world.isRemote) {
 			return true;
 		} else if(!player.isSneaking()) {
-			TileEntityMachinePress entity = (TileEntityMachinePress) world.getTileEntity(x, y, z);
-			if(entity != null) {
-				FMLNetworkHandler.openGui(player, MainRegistry.instance, 0, world, x, y, z);
-			}
+			int[] pos = this.findCore(world, x, y, z);
+			if(pos == null)
+				return false;
+
+			TileEntityMachinePress entity = (TileEntityMachinePress) world.getTileEntity(pos[0], pos[1], pos[2]);
+			if(entity == null) 
+				return false;
+			
+			FMLNetworkHandler.openGui(player, MainRegistry.instance, 0, world, x, y, z);
 			return true;
 		} else {
 			return false;

--- a/src/main/java/com/hbm/blocks/machine/MachinePress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachinePress.java
@@ -4,6 +4,7 @@ import java.util.Random;
 
 import com.hbm.blocks.BlockDummyable;
 import com.hbm.main.MainRegistry;
+import com.hbm.tileentity.TileEntityProxyCombo;
 import com.hbm.tileentity.machine.TileEntityMachinePress;
 import cpw.mods.fml.common.network.internal.FMLNetworkHandler;
 import net.minecraft.block.material.Material;
@@ -20,6 +21,7 @@ public class MachinePress extends BlockDummyable {
 	@Override
 	public TileEntity createNewTileEntity(World world, int meta) {
 		if(meta >= 12) return new TileEntityMachinePress();
+		if(meta >= 6) return new TileEntityProxyCombo(true, false, false);
 		return null;
 	}
 
@@ -46,7 +48,7 @@ public class MachinePress extends BlockDummyable {
 			if(entity == null) 
 				return false;
 			
-			FMLNetworkHandler.openGui(player, MainRegistry.instance, 0, world, x, y, z);
+			FMLNetworkHandler.openGui(player, MainRegistry.instance, 0, world, pos[0], pos[1], pos[2]);
 			return true;
 		} else {
 			return false;

--- a/src/main/java/com/hbm/blocks/machine/MachinePress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachinePress.java
@@ -34,6 +34,12 @@ public class MachinePress extends BlockDummyable {
 	public int getOffset() {
 		return 0;
 	}
+
+	@Override
+	protected boolean isLegacyMonoblock(World world, int x, int y, int z) {
+		TileEntity te = world.getTileEntity(x, y, z);
+		return te != null && te instanceof TileEntityMachinePress;
+	}
 	
 	@Override
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {

--- a/src/main/java/com/hbm/blocks/machine/MachinePress.java
+++ b/src/main/java/com/hbm/blocks/machine/MachinePress.java
@@ -55,7 +55,9 @@ public class MachinePress extends BlockDummyable implements IToolable {
 		if (meta >= 12)
 			return false;
 		
+		safeRem = true;
 		world.setBlockToAir(x, y, z);
+		safeRem = false;
 		return true;
 	}
 	

--- a/src/main/java/com/hbm/render/tileentity/RenderEPress.java
+++ b/src/main/java/com/hbm/render/tileentity/RenderEPress.java
@@ -2,6 +2,7 @@ package com.hbm.render.tileentity;
 
 import org.lwjgl.opengl.GL11;
 
+import com.hbm.blocks.BlockDummyable;
 import com.hbm.main.ResourceManager;
 import com.hbm.render.util.RenderDecoItem;
 import com.hbm.tileentity.machine.TileEntityMachineEPress;
@@ -28,7 +29,7 @@ public class RenderEPress extends TileEntitySpecialRenderer {
 			GL11.glEnable(GL11.GL_LIGHTING);
 			GL11.glRotatef(180, 0F, 1F, 0F);
 			
-			switch(tileentity.getBlockMetadata()) {
+			switch(tileentity.getBlockMetadata() - BlockDummyable.offset) {
 			case 2: GL11.glRotatef(270, 0F, 1F, 0F); break;
 			case 4: GL11.glRotatef(0, 0F, 1F, 0F); break;
 			case 3: GL11.glRotatef(90, 0F, 1F, 0F); break;
@@ -50,7 +51,7 @@ public class RenderEPress extends TileEntitySpecialRenderer {
 			GL11.glEnable(GL11.GL_LIGHTING);
 			GL11.glRotatef(180, 0F, 1F, 0F);
 			
-			switch(tileentity.getBlockMetadata()) {
+			switch(tileentity.getBlockMetadata() - BlockDummyable.offset) {
 			case 2: GL11.glRotatef(270, 0F, 1F, 0F); break;
 			case 4: GL11.glRotatef(0, 0F, 1F, 0F); break;
 			case 3: GL11.glRotatef(90, 0F, 1F, 0F); break;
@@ -78,7 +79,7 @@ public class RenderEPress extends TileEntitySpecialRenderer {
 			GL11.glEnable(GL11.GL_LIGHTING);
 			GL11.glRotatef(180, 0F, 1F, 0F);
 			
-			switch(tileentity.getBlockMetadata()) {
+			switch(tileentity.getBlockMetadata() - BlockDummyable.offset) {
 			case 2:
 				GL11.glRotatef(270, 0F, 1F, 0F); break;
 			case 4:

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineEPress.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineEPress.java
@@ -3,6 +3,7 @@ package com.hbm.tileentity.machine;
 import java.util.HashMap;
 import java.util.List;
 
+import com.hbm.blocks.BlockDummyable;
 import com.hbm.blocks.ModBlocks;
 import com.hbm.inventory.UpgradeManagerNT;
 import com.hbm.inventory.container.ContainerMachineEPress;
@@ -63,6 +64,17 @@ public class TileEntityMachineEPress extends TileEntityMachineBase implements IE
 	public void updateEntity() {
 
 		if(!worldObj.isRemote) {
+
+			// Triggers the legacy monoblock fix
+			if (worldObj.getBlockMetadata(xCoord, yCoord, zCoord) < BlockDummyable.offset) {
+				// Does nothing
+				// worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+
+				BlockDummyable block = (BlockDummyable)worldObj.getBlock(xCoord, yCoord, zCoord);
+				if (block != null) {
+					block.onNeighborBlockChange(worldObj, xCoord, yCoord, zCoord, null);
+				}
+			}
 
 			this.updateConnections();
 			power = Library.chargeTEFromItems(slots, 0, power, maxPower);

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineEPress.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineEPress.java
@@ -3,7 +3,6 @@ package com.hbm.tileentity.machine;
 import java.util.HashMap;
 import java.util.List;
 
-import com.hbm.blocks.BlockDummyable;
 import com.hbm.blocks.ModBlocks;
 import com.hbm.inventory.UpgradeManagerNT;
 import com.hbm.inventory.container.ContainerMachineEPress;
@@ -66,14 +65,8 @@ public class TileEntityMachineEPress extends TileEntityMachineBase implements IE
 		if(!worldObj.isRemote) {
 
 			// Triggers the legacy monoblock fix
-			if (worldObj.getBlockMetadata(xCoord, yCoord, zCoord) < BlockDummyable.offset) {
-				// Does nothing
-				// worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
-
-				BlockDummyable block = (BlockDummyable)worldObj.getBlock(xCoord, yCoord, zCoord);
-				if (block != null) {
-					block.onNeighborBlockChange(worldObj, xCoord, yCoord, zCoord, null);
-				}
+			if (worldObj.getBlockMetadata(xCoord, yCoord, zCoord) < 12) {
+				worldObj.scheduleBlockUpdate(xCoord, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord), 1);
 			}
 
 			this.updateConnections();

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachinePress.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachinePress.java
@@ -1,5 +1,6 @@
 package com.hbm.tileentity.machine;
 
+import com.hbm.blocks.BlockDummyable;
 import com.hbm.blocks.ModBlocks;
 import com.hbm.inventory.container.ContainerMachinePress;
 import com.hbm.inventory.gui.GUIMachinePress;
@@ -52,6 +53,17 @@ public class TileEntityMachinePress extends TileEntityMachineBase implements IGU
 	public void updateEntity() {
 
 		if(!worldObj.isRemote) {
+
+			// Triggers the legacy monoblock fix
+			if (worldObj.getBlockMetadata(xCoord, yCoord, zCoord) < BlockDummyable.offset) {
+				// Does nothing
+				// worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+
+				BlockDummyable block = (BlockDummyable)worldObj.getBlock(xCoord, yCoord, zCoord);
+				if (block != null) {
+					block.onNeighborBlockChange(worldObj, xCoord, yCoord, zCoord, null);
+				}
+			}
 
 			boolean preheated = false;
 

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachinePress.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachinePress.java
@@ -1,6 +1,5 @@
 package com.hbm.tileentity.machine;
 
-import com.hbm.blocks.BlockDummyable;
 import com.hbm.blocks.ModBlocks;
 import com.hbm.inventory.container.ContainerMachinePress;
 import com.hbm.inventory.gui.GUIMachinePress;
@@ -55,14 +54,8 @@ public class TileEntityMachinePress extends TileEntityMachineBase implements IGU
 		if(!worldObj.isRemote) {
 
 			// Triggers the legacy monoblock fix
-			if (worldObj.getBlockMetadata(xCoord, yCoord, zCoord) < BlockDummyable.offset) {
-				// Does nothing
-				// worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
-
-				BlockDummyable block = (BlockDummyable)worldObj.getBlock(xCoord, yCoord, zCoord);
-				if (block != null) {
-					block.onNeighborBlockChange(worldObj, xCoord, yCoord, zCoord, null);
-				}
+			if (worldObj.getBlockMetadata(xCoord, yCoord, zCoord) < 12) {
+				worldObj.scheduleBlockUpdate(xCoord, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord), 1);
 			}
 
 			boolean preheated = false;


### PR DESCRIPTION
They seem to have been implemented largely based on copy-pasted furnace code, and seemingly predate `BlockDummyable`. That meant the top two blocks of a press were intangible. Now they're in line with the rest of the machines, including the conveyor press.

I also added a bit of compatibility handling to `BlockDummyable`. It can now identify legacy monoblocks when deleting a suspected orphan, and promote them to lone cores. This makes this change savegame-compatible. Existing presses will remain single-block-sized and functionally identical to before. If broken and replaced, they will be 3-block-tall. The solution is general (the updated block must override `isLegacyMonoblock` to detect if it is a correct legacy block. There is a caveat, though: the fix is only triggered when the block is updated, which doesn't happen on world load, unfortunately. The best workaround for this that I came up with was triggering a block update from the tile entity tick if the metadata for the block indicates it's a dummy. The performance cost is negligible, thankfully.