### PR TITLE
Fix ItemToolAbility bedrock breaking

### DIFF
--- a/src/main/java/com/hbm/handler/ability/IToolHarvestAbility.java
+++ b/src/main/java/com/hbm/handler/ability/IToolHarvestAbility.java
@@ -37,7 +37,8 @@ public interface IToolHarvestAbility extends IBaseAbility {
 		if(skipDefaultDrops) {
 			// Emulate the block breaking without drops
 			world.setBlockToAir(x, y, z);
-			player.getHeldItem().damageItem(1, player);
+			ItemStack stack = player.getHeldItem();
+			if(stack != null) stack.damageItem(1, player);
 		} else if(player instanceof EntityPlayerMP) {
 			// Break the block conventionally
 			ItemToolAbility.standardDigPost(world, x, y, z, (EntityPlayerMP) player);
@@ -78,7 +79,7 @@ public interface IToolHarvestAbility extends IBaseAbility {
 		@Override
 		public void preHarvestAll(int level, World world, EntityPlayer player) {
 			ItemStack stack = player.getHeldItem();
-			EnchantmentUtil.addEnchantment(stack, Enchantment.silkTouch, 1);
+			if(stack != null) EnchantmentUtil.addEnchantment(stack, Enchantment.silkTouch, 1);
 		}
 
 		@Override
@@ -123,7 +124,7 @@ public interface IToolHarvestAbility extends IBaseAbility {
 		@Override
 		public void preHarvestAll(int level, World world, EntityPlayer player) {
 			ItemStack stack = player.getHeldItem();
-			EnchantmentUtil.addEnchantment(stack, Enchantment.fortune, powerAtLevel[level]);
+			if(stack != null) EnchantmentUtil.addEnchantment(stack, Enchantment.fortune, powerAtLevel[level]);
 		}
 
 		@Override

--- a/src/main/java/com/hbm/items/tool/ItemToolAbility.java
+++ b/src/main/java/com/hbm/items/tool/ItemToolAbility.java
@@ -292,14 +292,23 @@ public class ItemToolAbility extends ItemTool implements IDepthRockTool, IGUIPro
 		Block block = world.getBlock(x, y, z);
 		int meta = world.getBlockMetadata(x, y, z);
 
-		if(!(canHarvestBlock(block, stack) || canShearBlock(block, stack, world, x, y, z)) || block == Blocks.bedrock || block == ModBlocks.stone_keyhole)
+		if(!(
+			canHarvestBlock(block, stack) ||
+			canShearBlock(block, stack, world, x, y, z)) ||
+			block.getPlayerRelativeBlockHardness(player, world, x, y, z) < 0 ||
+			block == ModBlocks.stone_keyhole
+		)
 			return;
 
 		Block refBlock = world.getBlock(refX, refY, refZ);
 		float refStrength = ForgeHooks.blockStrength(refBlock, player, world, refX, refY, refZ);
 		float strength = ForgeHooks.blockStrength(block, player, world, x, y, z);
 
-		if(!ForgeHooks.canHarvestBlock(block, player, meta) || refStrength / strength > 10f || refBlock.getPlayerRelativeBlockHardness(player, world, refX, refY, refZ) < 0)
+		if(
+			!ForgeHooks.canHarvestBlock(block, player, meta) || 
+			refStrength / strength > 10f || 
+			refBlock.getPlayerRelativeBlockHardness(player, world, refX, refY, refZ) < 0
+		)
 			return;
 
 		BlockEvent.BreakEvent event = ForgeHooks.onBlockBreakEvent(world, player.theItemInWorldManager.getGameType(), player, x, y, z);


### PR DESCRIPTION
In response to @MellowArpeggiation 's bug report on Discord. The other part of it seems already fixed, though I also added null checks to every remaining `player.getHeldItem()` just to be safe