### PR TITLE
RBMK crane improvement

### DIFF
--- a/src/main/java/com/hbm/render/tileentity/RenderCraneConsole.java
+++ b/src/main/java/com/hbm/render/tileentity/RenderCraneConsole.java
@@ -22,12 +22,14 @@ public class RenderCraneConsole extends TileEntitySpecialRenderer {
 		GL11.glDisable(GL11.GL_CULL_FACE);
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
+		int teFacing = 0;
 		switch(te.getBlockMetadata() - BlockDummyable.offset) {
-		case 2: GL11.glRotatef(90, 0F, 1F, 0F); break;
-		case 4: GL11.glRotatef(180, 0F, 1F, 0F); break;
-		case 3: GL11.glRotatef(270, 0F, 1F, 0F); break;
-		case 5: GL11.glRotatef(0, 0F, 1F, 0F); break;
+		case 2: teFacing = 90; break;
+		case 4: teFacing = 180; break;
+		case 3: teFacing = 270; break;
+		case 5: teFacing = 0; break;
 		}
+		GL11.glRotatef(teFacing, 0F, 1F, 0F);
 		
 		TileEntityCraneConsole console = (TileEntityCraneConsole) te;
 		
@@ -99,12 +101,7 @@ public class RenderCraneConsole extends TileEntitySpecialRenderer {
 			double cranePosZ = (-te.zCoord + console.centerZ);
 			
 			GL11.glTranslated(cranePosX, cranePosY, cranePosZ);
-			switch(te.getBlockMetadata() - BlockDummyable.offset) {
-			case 2: GL11.glRotatef(90, 0F, 1F, 0F); break;
-			case 4: GL11.glRotatef(180, 0F, 1F, 0F); break;
-			case 3: GL11.glRotatef(270, 0F, 1F, 0F); break;
-			case 5: GL11.glRotatef(0, 0F, 1F, 0F); break;
-			}
+			GL11.glRotatef(teFacing, 0F, 1F, 0F);
 
 			double posX = (console.lastPosFront + (console.posFront - console.lastPosFront) * interp);
 			double posZ = (console.lastPosLeft + (console.posLeft - console.lastPosLeft) * interp);
@@ -116,22 +113,22 @@ public class RenderCraneConsole extends TileEntitySpecialRenderer {
 			GL11.glPushMatrix();
 			int girderSpan = 0;
 			GL11.glRotatef(-craneRotationOffset, 0F, 1F, 0F);
-			switch(craneRotationOffset) {
+			switch((craneRotationOffset + teFacing) % 360) {
 			case 0:
-				girderSpan = console.spanL + console.spanR + 1;
-				GL11.glTranslated(posX - console.spanL, 0, 0);
+				girderSpan = console.spanF + console.spanB + 1;
+				GL11.glTranslated(posX + console.spanB, 0, 0);
 				break;
 			case 90:
-				girderSpan = console.spanF + console.spanB + 1;
-				GL11.glTranslated(0, 0, -posZ + console.spanB);
+				girderSpan = console.spanL + console.spanR + 1;
+				GL11.glTranslated(0, 0, -posZ - console.spanR);
 				break;
 			case 180:
-				girderSpan = console.spanL + console.spanR + 1;
-				GL11.glTranslated(posX + console.spanR, 0, 0);
+				girderSpan = console.spanF + console.spanB + 1;
+				GL11.glTranslated(posX - console.spanF, 0, 0);
 				break;
 			case 270:
-				girderSpan = console.spanF + console.spanB + 1;
-				GL11.glTranslated(0, 0, -posZ - console.spanF);
+				girderSpan = console.spanL + console.spanR + 1;
+				GL11.glTranslated(0, 0, -posZ + console.spanL);
 				break;
 			}
 			GL11.glRotatef(craneRotationOffset, 0F, 1F, 0F);

--- a/src/main/java/com/hbm/render/tileentity/RenderCraneConsole.java
+++ b/src/main/java/com/hbm/render/tileentity/RenderCraneConsole.java
@@ -116,26 +116,26 @@ public class RenderCraneConsole extends TileEntitySpecialRenderer {
 			switch((craneRotationOffset + teFacing) % 360) {
 			case 0:
 				girderSpan = console.spanF + console.spanB + 1;
-				GL11.glTranslated(posX + console.spanB, 0, 0);
+				GL11.glTranslated(posX - console.spanB, 0, 0);
 				break;
 			case 90:
 				girderSpan = console.spanL + console.spanR + 1;
-				GL11.glTranslated(0, 0, -posZ - console.spanR);
+				GL11.glTranslated(0, 0, -posZ + console.spanR);
 				break;
 			case 180:
 				girderSpan = console.spanF + console.spanB + 1;
-				GL11.glTranslated(posX - console.spanF, 0, 0);
+				GL11.glTranslated(posX + console.spanF, 0, 0);
 				break;
 			case 270:
 				girderSpan = console.spanL + console.spanR + 1;
-				GL11.glTranslated(0, 0, -posZ + console.spanL);
+				GL11.glTranslated(0, 0, -posZ - console.spanL);
 				break;
 			}
 			GL11.glRotatef(craneRotationOffset, 0F, 1F, 0F);
 			
 			for(int i = 0; i < girderSpan; i++) {
 				ResourceManager.rbmk_crane.renderPart("Girder");
-				GL11.glTranslated(1, 0, 0);
+				GL11.glTranslated(-1, 0, 0);
 			}
 			GL11.glPopMatrix();
 			

--- a/src/main/java/com/hbm/render/tileentity/RenderCraneConsole.java
+++ b/src/main/java/com/hbm/render/tileentity/RenderCraneConsole.java
@@ -113,22 +113,22 @@ public class RenderCraneConsole extends TileEntitySpecialRenderer {
 			GL11.glPushMatrix();
 			int girderSpan = 0;
 			GL11.glRotatef(-craneRotationOffset, 0F, 1F, 0F);
-			switch((craneRotationOffset + teFacing) % 360) {
+			switch(craneRotationOffset) {
 			case 0:
 				girderSpan = console.spanF + console.spanB + 1;
-				GL11.glTranslated(posX - console.spanB, 0, 0);
+				GL11.glTranslated(posX + console.spanB, 0, 0);
 				break;
 			case 90:
 				girderSpan = console.spanL + console.spanR + 1;
-				GL11.glTranslated(0, 0, -posZ + console.spanR);
+				GL11.glTranslated(0, 0, -posZ - console.spanR);
 				break;
 			case 180:
 				girderSpan = console.spanF + console.spanB + 1;
-				GL11.glTranslated(posX + console.spanF, 0, 0);
+				GL11.glTranslated(posX - console.spanF, 0, 0);
 				break;
 			case 270:
 				girderSpan = console.spanL + console.spanR + 1;
-				GL11.glTranslated(0, 0, -posZ - console.spanL);
+				GL11.glTranslated(0, 0, -posZ + console.spanL);
 				break;
 			}
 			GL11.glRotatef(craneRotationOffset, 0F, 1F, 0F);

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
@@ -275,7 +275,7 @@ public class TileEntityCraneConsole extends TileEntityLoadedBase implements Simp
 		this.centerY = y + RBMKDials.getColumnHeight(worldObj) + 1;
 		this.centerZ = z;
 
-		this.spanF = 7;
+		this.spanF = 16;
 		this.spanB = 7;
 		this.spanL = 7;
 		this.spanR = 7;

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
@@ -277,14 +277,14 @@ public class TileEntityCraneConsole extends TileEntityLoadedBase implements Simp
 
 		int girderY = centerY + 6;
 
-		ForgeDirection dir = ForgeDirection.getOrientation(this.getBlockMetadata() - BlockDummyable.offset);
-		this.spanF = this.findRoomExtent(x, girderY, z, dir, 0);
+		ForgeDirection dir = ForgeDirection.getOrientation(this.getBlockMetadata() - BlockDummyable.offset).getOpposite();
+		this.spanF = this.findRoomExtent(x, girderY, z, dir, 16);
 		dir = dir.getRotation(ForgeDirection.UP);
-		this.spanR = this.findRoomExtent(x, girderY, z, dir, 0);
+		this.spanR = this.findRoomExtent(x, girderY, z, dir, 16);
 		dir = dir.getRotation(ForgeDirection.UP);
-		this.spanB = this.findRoomExtent(x, girderY, z, dir, 0);
+		this.spanB = this.findRoomExtent(x, girderY, z, dir, 16);
 		dir = dir.getRotation(ForgeDirection.UP);
-		this.spanL = this.findRoomExtent(x, girderY, z, dir, 0);
+		this.spanL = this.findRoomExtent(x, girderY, z, dir, 16);
 
 		this.height = 7;
 
@@ -293,14 +293,14 @@ public class TileEntityCraneConsole extends TileEntityLoadedBase implements Simp
 		this.markDirty();
 	}
 
-	private int findRoomExtent(int x, int y, int z, ForgeDirection dir, int def) {
-		for (int i = 1; i < 32; i++) {
+	private int findRoomExtent(int x, int y, int z, ForgeDirection dir, int max) {
+		for (int i = 1; i < max; i++) {
 			if (!worldObj.isAirBlock(x + dir.offsetX * i, y, z + dir.offsetZ * i)) {
 				return i - 1;
 			}
 		}
 
-		return def;
+		return max;
 	}
 
 	public void cycleCraneRotation() {

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
@@ -275,16 +275,32 @@ public class TileEntityCraneConsole extends TileEntityLoadedBase implements Simp
 		this.centerY = y + RBMKDials.getColumnHeight(worldObj) + 1;
 		this.centerZ = z;
 
-		this.spanF = 16;
-		this.spanB = 7;
-		this.spanL = 7;
-		this.spanR = 7;
+		int girderY = centerY + 6;
+
+		ForgeDirection dir = ForgeDirection.getOrientation(this.getBlockMetadata() - BlockDummyable.offset);
+		this.spanF = this.findRoomExtent(x, girderY, z, dir, 0);
+		dir = dir.getRotation(ForgeDirection.UP);
+		this.spanR = this.findRoomExtent(x, girderY, z, dir, 0);
+		dir = dir.getRotation(ForgeDirection.UP);
+		this.spanB = this.findRoomExtent(x, girderY, z, dir, 0);
+		dir = dir.getRotation(ForgeDirection.UP);
+		this.spanL = this.findRoomExtent(x, girderY, z, dir, 0);
 
 		this.height = 7;
 
 		this.setUpCrane = true;
 
 		this.markDirty();
+	}
+
+	private int findRoomExtent(int x, int y, int z, ForgeDirection dir, int def) {
+		for (int i = 1; i < 32; i++) {
+			if (!worldObj.isAirBlock(x + dir.offsetX * i, y, z + dir.offsetZ * i)) {
+				return i - 1;
+			}
+		}
+
+		return def;
 	}
 
 	public void cycleCraneRotation() {


### PR DESCRIPTION
Now the crane, upon being linked to the reactor, scans the room size at the y-level where the girders are located, and sets its span fields accordingly. This is reflected in the girder lengths, which now extend all the way to the walls, as well as the crane movement limits. In unbounded directions (outdoors or with walls farther than 16 blocks), the default maximum span of 16 blocks is assigned in every such direction. Tested to work correctly with any TE rotations and screwdriver-controlled rotation offsets.