### PR TITLE
Stop QE sliding door model clipping

### DIFF
--- a/src/main/java/com/hbm/tileentity/DoorDecl.java
+++ b/src/main/java/com/hbm/tileentity/DoorDecl.java
@@ -586,7 +586,7 @@ public abstract class DoorDecl {
 		@Override
 		@SideOnly(Side.CLIENT)
 		public void doOffsetTransform() {
-			GL11.glTranslated(0.4375, 0, 0.5);
+			GL11.glTranslated(0.40625, 0, 0.5);
 		};
 
 		@Override
@@ -598,12 +598,12 @@ public abstract class DoorDecl {
 		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open) {
 			if(open) {
 				if(z == 0) {
-					return AxisAlignedBB.getBoundingBox(1 - 0.125, 0, 1 - 0.125, 1, 1, 1);
+					return AxisAlignedBB.getBoundingBox(1 - 0.125, 0, 1 - 0.1875, 1, 1, 1);
 				} else {
-					return AxisAlignedBB.getBoundingBox(0, 0, 1 - 0.125, 0.125, 1, 1);
+					return AxisAlignedBB.getBoundingBox(0, 0, 1 - 0.1875, 0.125, 1, 1);
 				}
 			} else {
-				return AxisAlignedBB.getBoundingBox(0, 0, 1 - 0.125, 1, 1, 1);
+				return AxisAlignedBB.getBoundingBox(0, 0, 1 - 0.1875, 1, 1, 1);
 			}
 		};
 


### PR DESCRIPTION
Previously, the QE sliding door (2x2) in its open state was partially visible through the wall it was supposed to slide into. Now it is recessed a bit further back (1/32nd) to fix that. The hitbox is made 1/16th thicker to cover the entire model.