### PR TITLE
Fix door hitboxes

### DIFF
--- a/src/main/java/com/hbm/blocks/generic/BlockDoorGeneric.java
+++ b/src/main/java/com/hbm/blocks/generic/BlockDoorGeneric.java
@@ -94,7 +94,7 @@ public class BlockDoorGeneric extends BlockDummyable implements IBomb {
 	
 	@Override
 	public void addCollisionBoxesToList(World worldIn, int x, int y, int z, AxisAlignedBB entityBox, List collidingBoxes, Entity entityIn) {
-		AxisAlignedBB box = getBoundingBox(worldIn, x, y ,z);
+		AxisAlignedBB box = getBoundingBox(worldIn, x, y, z, true);
 		box = AxisAlignedBB.getBoundingBox(
 				Math.min(box.minX, box.maxX), Math.min(box.minY, box.maxY), Math.min(box.minZ, box.maxZ),
 				Math.max(box.minX, box.maxX), Math.max(box.minY, box.maxY), Math.max(box.minZ, box.maxZ));
@@ -113,7 +113,7 @@ public class BlockDoorGeneric extends BlockDummyable implements IBomb {
 	
 	@Override
 	public AxisAlignedBB getCollisionBoundingBoxFromPool(World world, int x, int y, int z) {
-		AxisAlignedBB aabb = this.getBoundingBox(world, x, y, z);
+		AxisAlignedBB aabb = this.getBoundingBox(world, x, y, z, true);
 		if(aabb.minX == aabb.maxX && aabb.minY == aabb.maxY && aabb.minZ == aabb.maxZ) return null;
 		return aabb;
 	}
@@ -121,7 +121,7 @@ public class BlockDoorGeneric extends BlockDummyable implements IBomb {
 	// Enables clicking through the open door
 	@Override
 	public MovingObjectPosition collisionRayTrace(World world, int x, int y, int z, Vec3 startVec, Vec3 endVec) {
-		AxisAlignedBB box = getBoundingBox(world, x, y ,z);
+		AxisAlignedBB box = getBoundingBox(world, x, y, z, false);
 		box = AxisAlignedBB.getBoundingBox(
 			Math.min(box.minX, box.maxX), Math.min(box.minY, box.maxY), Math.min(box.minZ, box.maxZ),
 			Math.max(box.minX, box.maxX), Math.max(box.minY, box.maxY), Math.max(box.minZ, box.maxZ)
@@ -158,11 +158,11 @@ public class BlockDoorGeneric extends BlockDummyable implements IBomb {
 	
 	@Override
 	public AxisAlignedBB getSelectedBoundingBoxFromPool(World world, int x, int y, int z) {
-		return getBoundingBox(world, x, y, z);
+		return getBoundingBox(world, x, y, z, false);
 		//return AxisAlignedBB.getBoundingBox(x, y, z, x + 1, y + 1, z + 1);
 	}
 	
-	public AxisAlignedBB getBoundingBox(World world, int x, int y, int z) {
+	public AxisAlignedBB getBoundingBox(World world, int x, int y, int z, boolean forCollision) {
 		int meta = world.getBlockMetadata(x, y, z);
 		TileEntity te = world.getTileEntity(x, y, z);
 		int[] core = this.findCore(world, x, y, z);
@@ -173,7 +173,7 @@ public class BlockDoorGeneric extends BlockDummyable implements IBomb {
 		TileEntity te2 = world.getTileEntity(core[0], core[1], core[2]);
 		ForgeDirection dir = ForgeDirection.getOrientation(te2.getBlockMetadata() - BlockDummyable.offset);
 		BlockPos pos = new BlockPos(x - core[0], y - core[1], z - core[2]).rotate(Rotation.getBlockRotation(dir).add(Rotation.COUNTERCLOCKWISE_90));
-		AxisAlignedBB box = type.getBlockBound(pos.getX(), pos.getY(), pos.getZ(), open);
+		AxisAlignedBB box = type.getBlockBound(pos.getX(), pos.getY(), pos.getZ(), open, forCollision);
 		
 		switch(te2.getBlockMetadata() - offset){
 		case 2: return AxisAlignedBB.getBoundingBox(x + 1 - box.minX, y + box.minY, z + 1 - box.minZ, x + 1 - box.maxX, y + box.maxY, z + 1 - box.maxZ);

--- a/src/main/java/com/hbm/tileentity/DoorDecl.java
+++ b/src/main/java/com/hbm/tileentity/DoorDecl.java
@@ -67,8 +67,8 @@ public abstract class DoorDecl {
 		}
 
 		@Override
-		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open) {
-			return super.getBlockBound(x, y, z, open);
+		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open, boolean forCollision) {
+			return super.getBlockBound(x, y, z, open, forCollision);
 		}
 
 		@Override
@@ -156,7 +156,7 @@ public abstract class DoorDecl {
 		}
 
 		@Override
-		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open) {
+		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open, boolean forCollision) {
 			if(!open)
 				return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 1, 1);
 			if(z == 1) {
@@ -168,7 +168,7 @@ public abstract class DoorDecl {
 			} else if(y == 0) {
 				return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 0.1, 1);
 			} else {
-				return super.getBlockBound(x, y, z, open);
+				return super.getBlockBound(x, y, z, open, forCollision);
 			}
 		}
 
@@ -240,7 +240,7 @@ public abstract class DoorDecl {
 		}
 
 		@Override
-		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open) {
+		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open, boolean forCollision) {
 			if(open) {
 				if(y == 3) {
 					return AxisAlignedBB.getBoundingBox(0, 0.5, 0, 1, 1, 1);
@@ -248,7 +248,7 @@ public abstract class DoorDecl {
 					return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 0.08, 1);
 				}
 			}
-			return super.getBlockBound(x, y, z, open);
+			return super.getBlockBound(x, y, z, open, forCollision);
 		}
 
 		@Override
@@ -327,7 +327,7 @@ public abstract class DoorDecl {
 		};
 
 		@Override
-		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open) {
+		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open, boolean forCollision) {
 			if(open) {
 				if(y == 0) return AxisAlignedBB.getBoundingBox(0, 0, 1 - 0.25, 1, 0, 1);
 				return AxisAlignedBB.getBoundingBox(0, 0.9375, 1 - 0.25, 1, 1, 1);
@@ -429,7 +429,7 @@ public abstract class DoorDecl {
 		}
 
 		@Override
-		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open) {
+		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open, boolean forCollision) {
 			if(!open) {
 				if(y > 0) {
 					return AxisAlignedBB.getBoundingBox(0, 0, 0.375, 1, 1, 0.625);
@@ -441,7 +441,7 @@ public abstract class DoorDecl {
 			} else if(y == 4) {
 				return AxisAlignedBB.getBoundingBox(0, 0.5, 0.15, 1, 1, 0.85);
 			} else {
-				return super.getBlockBound(x, y, z, open);
+				return super.getBlockBound(x, y, z, open, forCollision);
 			}
 		}
 
@@ -504,9 +504,9 @@ public abstract class DoorDecl {
 		};
 
 		@Override
-		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open) {
+		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open, boolean forCollision) {
 			if(!open)
-				return super.getBlockBound(x, y, z, open);
+				return super.getBlockBound(x, y, z, open, forCollision);
 			if(z == 1) {
 				return AxisAlignedBB.getBoundingBox(0.4, 0, 0, 1, 1, 1);
 			} else if(z == -2) {
@@ -516,7 +516,7 @@ public abstract class DoorDecl {
 			} else if(y == 0) {
 				return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 0.0625, 1);
 			}
-			return super.getBlockBound(x, y, z, open);
+			return super.getBlockBound(x, y, z, open, forCollision);
 		};
 
 		@Override
@@ -595,7 +595,7 @@ public abstract class DoorDecl {
 		};
 
 		@Override
-		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open) {
+		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open, boolean forCollision) {
 			if(open) {
 				if(z == 0) {
 					return AxisAlignedBB.getBoundingBox(1 - 0.125, 0, 1 - 0.1875, 1, 1, 1);
@@ -691,14 +691,14 @@ public abstract class DoorDecl {
 		}
 
 		@Override
-		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open) {
+		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open, boolean forCollision) {
 			if(!open)
 				return AxisAlignedBB.getBoundingBox(0, 0, 0.5, 1, 1, 1);
 			if(y > 1)
 				return AxisAlignedBB.getBoundingBox(0, 0.5, 0.5, 1, 1, 1);
 			else if(y == 0)
 				return AxisAlignedBB.getBoundingBox(0, 0, 0.5, 1, 0.1, 1);
-			return super.getBlockBound(x, y, z, open);
+			return super.getBlockBound(x, y, z, open, forCollision);
 		};
 
 		@Override
@@ -814,7 +814,7 @@ public abstract class DoorDecl {
 		};
 
 		@Override
-		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open) {
+		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open, boolean forCollision) {
 			if(!open) {
 				return AxisAlignedBB.getBoundingBox(0, 0, 0.75, 1, 1, 1);
 			} else if(y > 1) {
@@ -822,7 +822,7 @@ public abstract class DoorDecl {
 			} else if(y == 0) {
 				return AxisAlignedBB.getBoundingBox(0, 0, 0.75, 1, 0.15, 1);
 			}
-			return super.getBlockBound(x, y, z, open);
+			return super.getBlockBound(x, y, z, open, forCollision);
 		};
 
 		@Override
@@ -1018,15 +1018,15 @@ public abstract class DoorDecl {
 		};
 
 		@Override
-		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open) {
+		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open, boolean forCollision) {
 			if(!open)
-				return super.getBlockBound(x, y, z, open);
+				return super.getBlockBound(x, y, z, open, forCollision);
 			if(z == 3) {
 				return AxisAlignedBB.getBoundingBox(0.4, 0, 0, 1, 1, 1);
 			} else if(z == -3) {
 				return AxisAlignedBB.getBoundingBox(0, 0, 0, 0.6, 1, 1);
 			}
-			return super.getBlockBound(x, y, z, open);
+			return super.getBlockBound(x, y, z, open, forCollision);
 		};
 
 		@Override
@@ -1159,7 +1159,7 @@ public abstract class DoorDecl {
 	public void doOffsetTransform() {
 	}
 
-	public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open) {
+	public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open, boolean forCollision) {
 		return open ? AxisAlignedBB.getBoundingBox(0, 0, 0, 0, 0, 0) : AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 1, 1);
 	}
 

--- a/src/main/java/com/hbm/tileentity/DoorDecl.java
+++ b/src/main/java/com/hbm/tileentity/DoorDecl.java
@@ -166,7 +166,7 @@ public abstract class DoorDecl {
 			} else if(y > 1) {
 				return AxisAlignedBB.getBoundingBox(0, 0.75, 0, 1, 1, 1);
 			} else if(y == 0) {
-				return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 0.1, 1);
+				return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, forCollision ? 0 : 0.1, 1);
 			} else {
 				return super.getBlockBound(x, y, z, open, forCollision);
 			}
@@ -245,7 +245,7 @@ public abstract class DoorDecl {
 				if(y == 3) {
 					return AxisAlignedBB.getBoundingBox(0, 0.5, 0, 1, 1, 1);
 				} else if(y == 0) {
-					return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 0.08, 1);
+					return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, forCollision ? 0 : 0.08, 1);
 				}
 			}
 			return super.getBlockBound(x, y, z, open, forCollision);
@@ -328,9 +328,8 @@ public abstract class DoorDecl {
 
 		@Override
 		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open, boolean forCollision) {
-			if(open) {
-				if(y == 0) return AxisAlignedBB.getBoundingBox(0, 0, 1 - 0.25, 1, 0, 1);
-				return AxisAlignedBB.getBoundingBox(0, 0.9375, 1 - 0.25, 1, 1, 1);
+			if(forCollision && open) {
+				return AxisAlignedBB.getBoundingBox(0, 0, 0, 0, 0, 0);
 			} else {
 				return AxisAlignedBB.getBoundingBox(0, 0, 1 - 0.25, 1, 1, 1);
 			}
@@ -437,7 +436,7 @@ public abstract class DoorDecl {
 				return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 1, 1);
 			}
 			if(y == 1) {
-				return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 0.0625, 1);
+				return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, forCollision ? 0 : 0.0625, 1);
 			} else if(y == 4) {
 				return AxisAlignedBB.getBoundingBox(0, 0.5, 0.15, 1, 1, 0.85);
 			} else {
@@ -514,7 +513,7 @@ public abstract class DoorDecl {
 			} else if(y == 3) {
 				return AxisAlignedBB.getBoundingBox(0, 0.5, 0, 1, 1, 1);
 			} else if(y == 0) {
-				return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 0.0625, 1);
+				return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, forCollision ? 0 : 0.0625, 1);
 			}
 			return super.getBlockBound(x, y, z, open, forCollision);
 		};
@@ -596,7 +595,7 @@ public abstract class DoorDecl {
 
 		@Override
 		public AxisAlignedBB getBlockBound(int x, int y, int z, boolean open, boolean forCollision) {
-			if(open) {
+			if(forCollision && open) {
 				if(z == 0) {
 					return AxisAlignedBB.getBoundingBox(1 - 0.125, 0, 1 - 0.1875, 1, 1, 1);
 				} else {
@@ -697,7 +696,7 @@ public abstract class DoorDecl {
 			if(y > 1)
 				return AxisAlignedBB.getBoundingBox(0, 0.5, 0.5, 1, 1, 1);
 			else if(y == 0)
-				return AxisAlignedBB.getBoundingBox(0, 0, 0.5, 1, 0.1, 1);
+				return AxisAlignedBB.getBoundingBox(0, 0, 0.5, 1, forCollision ? 0 : 0.1, 1);
 			return super.getBlockBound(x, y, z, open, forCollision);
 		};
 
@@ -820,7 +819,7 @@ public abstract class DoorDecl {
 			} else if(y > 1) {
 				return AxisAlignedBB.getBoundingBox(0, 0.85, 0.75, 1, 1, 1);
 			} else if(y == 0) {
-				return AxisAlignedBB.getBoundingBox(0, 0, 0.75, 1, 0.15, 1);
+				return AxisAlignedBB.getBoundingBox(0, 0, 0.75, 1, forCollision ? 0 : 0.15, 1);
 			}
 			return super.getBlockBound(x, y, z, open, forCollision);
 		};
@@ -1025,6 +1024,8 @@ public abstract class DoorDecl {
 				return AxisAlignedBB.getBoundingBox(0.4, 0, 0, 1, 1, 1);
 			} else if(z == -3) {
 				return AxisAlignedBB.getBoundingBox(0, 0, 0, 0.6, 1, 1);
+			} else if(y == 0) {
+				return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, forCollision ? 0 : 0.0625, 1);
 			}
 			return super.getBlockBound(x, y, z, open, forCollision);
 		};

--- a/src/main/java/com/hbm/tileentity/DoorDecl.java
+++ b/src/main/java/com/hbm/tileentity/DoorDecl.java
@@ -439,7 +439,9 @@ public abstract class DoorDecl {
 				return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, forCollision ? 0 : 0.0625, 1);
 			} else if(y == 4) {
 				return AxisAlignedBB.getBoundingBox(0, 0.5, 0.15, 1, 1, 0.85);
-			} else {
+			} else if(y == 0) {
+				return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 1, 1);
+			}else {
 				return super.getBlockBound(x, y, z, open, forCollision);
 			}
 		}


### PR DESCRIPTION
My solution to #2278 . Makes some hitboxes (mostly bottom ledges) of doors only have effect for clicking, highlighting, etc., but not collisions. Also gives the QE doors (1x2 and 2x2) full visual hitboxes regardless of openness, because people have complained these doors were otherwise hard to use after my clickthrough patch. @MellowArpeggiation, you might prefer this change to the solution you proposed previously for the Spork.