### PR TITLE
Persist electrolyzer GUI

### DIFF
--- a/src/main/java/com/hbm/blocks/machine/MachineElectrolyser.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineElectrolyser.java
@@ -35,7 +35,7 @@ public class MachineElectrolyser extends BlockDummyable {
 
 	@Override
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
-		return this.standardOpenBehavior(world, x, y, z, player, 0);
+		return this.standardOpenBehavior(world, x, y, z, player, -1);
 	}
 
 	@Override


### PR DESCRIPTION
Now the electrolyzer remembers the last selected GUI instead of reverting to the fluid one every time. The functionality is unaffected.