### PR TITLE
Add OpenComputers compat for fluid pump and fix CCGT allowing throttle over max when using OpenComputers callbacks

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineTurbineGas.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineTurbineGas.java
@@ -105,11 +105,11 @@ public class TileEntityMachineTurbineGas extends TileEntityMachineBase implement
 					tanks[0].setTankType(fluid);
 				}
 			}
-			
+
 			if(autoMode) { //power production depending on power requirement and fuel level
-				
+
 				int powerSliderTarget;
-				
+
 				//when low on fuel, decrease consumption linearly
 				if(tanks[0].getFill() * 10 > tanks[0].getMaxFill()) {
 					powerSliderTarget = 60 - (int) (60 * power / maxPower); //scales the slider proportionally to the power gauge
@@ -117,7 +117,7 @@ public class TileEntityMachineTurbineGas extends TileEntityMachineBase implement
 				else {
 					powerSliderTarget = (int) ( tanks[0].getFill() * 0.0001 * (60 - (int) (60 * power / maxPower)) );
 				}
-				
+
 				if(powerSliderTarget > powerSliderPos) { //makes the auto slider slide instead of snapping into position
 					powerSliderPos++;
 				}
@@ -403,12 +403,12 @@ public class TileEntityMachineTurbineGas extends TileEntityMachineBase implement
 		double waterPerTick = (consMax * energy * (temp - tempIdle) / 220000); //it just works fuck you
 
 		this.waterToBoil = waterPerTick; //caching in a field for the EC compat to use
-		
+
 		int heatCycles = (int) Math.floor(waterToBoil);
 		int waterCycles = tanks[2].getFill();
 		int steamCycles = (tanks[3].getMaxFill() - tanks[3].getFill()) / 10;
 		int cycles = BobMathUtil.min(heatCycles, waterCycles, steamCycles);
-		
+
 		tanks[2].setFill(tanks[2].getFill() - cycles);
 		tanks[3].setFill(tanks[3].getFill() + cycles * 10);
 	}
@@ -619,8 +619,11 @@ public class TileEntityMachineTurbineGas extends TileEntityMachineBase implement
 	@Callback(direct = true, limit = 4)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] setThrottle(Context context, Arguments args) {
-		powerSliderPos = (int) (args.checkInteger(0) * 60D / 100D);
-		return new Object[] {};
+		double input = args.checkInteger(0) * 60D / 100D;
+		if (input < 0 || input > 100)
+			return new Object[] {null, "Input out of range."};
+		powerSliderPos = (int) (input);
+		return new Object[] {true};
 	}
 
 	@Callback(direct = true, limit = 4)


### PR DESCRIPTION
Adds the flow control pump as a opencomputers component, named ``ntm_fluid_pump``.
Callbacks:
- ``getPriority()`` : returns string : gets the set priority of the flow control pump, (``LOWEST``, ``LOW``, ``NORMAL``, ``HIGH``, or ``HIGHEST``.)
- ``getPressure()`` : returns number : gets the set pressure of the flow control pump. (0-5)
- ``getFluid()`` : returns string : gets the unlocalized name of the fluid the flow control pump is set to.
- ``getFlow()`` : returns number : gets the set flow of the flow control pump (0-10000)
- ``getInfo()`` : returns array : returns an array of information about the flow control pump. (fluid, pressure, flow, priority)
- ``setPriority(number [0-4])`` : returns true on success, nil and an error on failure : sets the priority of the flow control pump.
- ``setFlow(number [0-10000])`` :  returns true on success, nil and an error on failure : sets the flow of the flow control pump.

Modified CCGT callbacks:
- ``setThrottle(number)`` : now returns true on success, nil and an error on failure.