### PR TITLE
Better murky wings

### DIFF
--- a/src/main/java/com/hbm/items/armor/WingsMurk.java
+++ b/src/main/java/com/hbm/items/armor/WingsMurk.java
@@ -100,7 +100,7 @@ public class WingsMurk extends JetpackBase {
 				
 				Vec3 orig = player.getLookVec();
 				Vec3 look = Vec3.createVectorHelper(orig.xCoord, 0, orig.zCoord).normalize();
-				double mod = player.isSneaking() ? 0.25D : 1D;
+				double mod = player.isSneaking() ? 0.25D : player.isSprinting() ? 1D : 0.5D;
 				
 				if(player.moveForward != 0) {
 					player.motionX += look.xCoord * 0.35 * player.moveForward * mod;

--- a/src/main/java/com/hbm/items/armor/WingsMurk.java
+++ b/src/main/java/com/hbm/items/armor/WingsMurk.java
@@ -1,6 +1,7 @@
 package com.hbm.items.armor;
 
 import com.hbm.extprop.HbmPlayerProps;
+import com.hbm.handler.ArmorModHandler;
 import com.hbm.items.ModItems;
 import com.hbm.main.ResourceManager;
 import com.hbm.render.model.ModelArmorWings;
@@ -51,13 +52,12 @@ public class WingsMurk extends JetpackBase {
 		if(player.fallDistance > 0)
 			player.fallDistance = 0;
 		
-		if(player.motionY < -0.4D)
-			player.motionY = -0.4D;
-		
 		if(this == ModItems.wings_limp) {
+		
+			if(player.motionY < -0.4D)
+				player.motionY = -0.4D;
 			
-			 if(player.isSneaking()) {
-					
+			if(player.isSneaking()) {
 				if(player.motionY < -0.08) {
 
 					double mo = player.motionY * -0.2;

--- a/src/main/java/com/hbm/items/armor/WingsMurk.java
+++ b/src/main/java/com/hbm/items/armor/WingsMurk.java
@@ -100,7 +100,7 @@ public class WingsMurk extends JetpackBase {
 				
 				Vec3 orig = player.getLookVec();
 				Vec3 look = Vec3.createVectorHelper(orig.xCoord, 0, orig.zCoord).normalize();
-				double mod = player.isSneaking() ? 0.25D : player.isSprinting() ? 1D : 0.5D;
+				double mod = player.isSprinting() ? 1D : 0.25D;
 				
 				if(player.moveForward != 0) {
 					player.motionX += look.xCoord * 0.35 * player.moveForward * mod;

--- a/src/main/java/com/hbm/items/armor/WingsMurk.java
+++ b/src/main/java/com/hbm/items/armor/WingsMurk.java
@@ -81,10 +81,26 @@ public class WingsMurk extends JetpackBase {
 
 			if(props.isJetpackActive()) {
 
-				if(player.motionY < 0.6D)
-					player.motionY += 0.2D;
-				else
-					player.motionY = 0.8D;
+				if(player.isSneaking()) {
+					if(player.motionY < -1)
+						player.motionY += 0.4D;
+					else if(player.motionY < -0.1)
+						player.motionY += 0.2D;
+					else if(player.motionY < 0)
+						player.motionY = 0;
+					else if(player.motionY > 1)
+						player.motionY -= 0.4D;
+					else if(player.motionY > 0.1)
+						player.motionY -= 0.2D;
+					else if(player.motionY > 0)
+						player.motionY = 0;
+					
+				} else {
+					if(player.motionY < 0.6D)
+						player.motionY += 0.2D;
+					else
+						player.motionY = 0.8D;
+				}
 				
 			} else if(props.enableBackpack && !player.isSneaking()) {
 				

--- a/src/main/java/com/hbm/items/armor/WingsMurk.java
+++ b/src/main/java/com/hbm/items/armor/WingsMurk.java
@@ -1,7 +1,6 @@
 package com.hbm.items.armor;
 
 import com.hbm.extprop.HbmPlayerProps;
-import com.hbm.handler.ArmorModHandler;
 import com.hbm.items.ModItems;
 import com.hbm.main.ResourceManager;
 import com.hbm.render.model.ModelArmorWings;


### PR DESCRIPTION
A small tweak to make murky wings more convenient to use.

- Shift and Space now cancel each other out, enabling shift-clicking while hovering
- Slowfall isn't applied anymore. (Previously, it was always on, regardless of jetpack state. Considering activating the wings results in hovering, that felt redundant, and definitely very annoying when you needed to descend quickly somewhere).
- The default acceleration is lowered, and the previous ultra-fast mode is now triggered by sprinting.
- Shift no longer explicitly reduces acceleration, because it already affects the base movement values.

This makes wings useful not only for long-distance travel, but also for finer maneuvering, similar to the builder's jetpack.