### PR TITLE
Make it possible to add more things that produce hazards

### DIFF
--- a/src/main/java/com/hbm/commands/CommandReloadRecipes.java
+++ b/src/main/java/com/hbm/commands/CommandReloadRecipes.java
@@ -1,6 +1,7 @@
 package com.hbm.commands;
 
 import com.hbm.config.ItemPoolConfigJSON;
+import com.hbm.hazard.HazardRegistry;
 import com.hbm.inventory.FluidContainerRegistry;
 import com.hbm.inventory.fluid.Fluids;
 import com.hbm.inventory.recipes.loader.SerializableRecipe;
@@ -35,6 +36,7 @@ public class CommandReloadRecipes extends CommandBase {
 			ItemPoolConfigJSON.initialize();
 			DamageResistanceHandler.init();
 			SkeletonCreator.init();
+			HazardRegistry.initialize();
 
 			sender.addChatMessage(new ChatComponentText(EnumChatFormatting.YELLOW + "Reload complete :)"));
 		} catch(Exception ex) {

--- a/src/main/java/com/hbm/config/RadiationConfig.java
+++ b/src/main/java/com/hbm/config/RadiationConfig.java
@@ -36,8 +36,6 @@ public class RadiationConfig {
 	public static double sootFogThreshold = 35D;
 	public static double sootFogDivisor = 120D;
 	public static double smokeStackSootMult = 0.8;
-	public static String[] coalDustItems = {"hbm:item.powder_coal:0", "hbm:item.powder_lignite:0"};
-	public static String[] coalDustTinyItems = {"hbm:item.powder_coal_tiny:0", "hbm:item.powder_lignite_tiny:0"};
 	public static String[] coalDustBlocks = {"hbm:tile.ore_lignite:0", "minecraft:coal_ore:0"};
 
 	public static void loadFromConfig(Configuration config) {
@@ -79,8 +77,6 @@ public class RadiationConfig {
 		sootFogThreshold = CommonConfig.createConfigDouble(config, CATEGORY_POL, "POL_06_sootFogThreshold", "How much soot is required for smog to become visible", 35D);
 		sootFogDivisor = CommonConfig.createConfigDouble(config, CATEGORY_POL, "POL_07_sootFogDivisor", "The divisor for smog, higher numbers will require more soot for the same smog density", 120D);
 		smokeStackSootMult = CommonConfig.createConfigDouble(config, CATEGORY_POL, "POL_08_smokeStackSootMult", "How much does smokestack multiply soot by, with decimal values reducing the soot", 0.8);
-		coalDustItems = CommonConfig.createConfigStringList(config, CATEGORY_POL, "POL_09_coalDustHazards", "Items that cause the coal dust hazard to apply.", new String[]{"hbm:item.powder_coal:0", "hbm:item.powder_lignite:0"});
-		coalDustTinyItems = CommonConfig.createConfigStringList(config, CATEGORY_POL, "POL_10_tinyCoalDustHarzards", "Items that cause the coal hazard to apply, but with a smaller effect than normal coal dust hazard items.", new String[]{"hbm:item.powder_coal_tiny:0", "hbm:item.powder_lignite_tiny:0"});
 		coalDustBlocks = CommonConfig.createConfigStringList(config, CATEGORY_POL, "POL_11_coalDustBlocks", "Blocks that can cause a puff of coal dust to appear.", new String[]{"hbm:tile.ore_lignite:0", "minecraft:coal_ore:0"});
 	}
 }

--- a/src/main/java/com/hbm/config/RadiationConfig.java
+++ b/src/main/java/com/hbm/config/RadiationConfig.java
@@ -36,7 +36,10 @@ public class RadiationConfig {
 	public static double sootFogThreshold = 35D;
 	public static double sootFogDivisor = 120D;
 	public static double smokeStackSootMult = 0.8;
-	
+	public static String[] coalDustItems = {"hbm:item.powder_coal:0", "hbm:item.powder_lignite:0"};
+	public static String[] coalDustTinyItems = {"hbm:item.powder_coal_tiny:0", "hbm:item.powder_lignite_tiny:0"};
+	public static String[] coalDustBlocks = {"hbm:tile.ore_lignite", "minecraft:coal_ore"};
+
 	public static void loadFromConfig(Configuration config) {
 
 		final String CATEGORY_NUKE = CommonConfig.CATEGORY_RADIATION;
@@ -53,7 +56,7 @@ public class RadiationConfig {
 		enableChunkRads = CommonConfig.createConfigBool(config, CATEGORY_NUKE, "RADIATION_01_enableChunkRads", "Toggles the world radiation system (chunk radiation only, some blocks use an AoE!)", true);
 		enablePRISM = CommonConfig.createConfigBool(config, CATEGORY_NUKE, "RADIATION_99_enablePRISM", "Enables the new 3D resistance-aware PRISM radiation system", false);
 		if(enablePRISM) ChunkRadiationManager.proxy = new ChunkRadiationHandlerPRISM();
-		
+
 		fogCh = CommonConfig.setDef(fogCh, 20);
 
 		final String CATEGORY_HAZ = CommonConfig.CATEGORY_HAZARD;
@@ -76,5 +79,8 @@ public class RadiationConfig {
 		sootFogThreshold = CommonConfig.createConfigDouble(config, CATEGORY_POL, "POL_06_sootFogThreshold", "How much soot is required for smog to become visible", 35D);
 		sootFogDivisor = CommonConfig.createConfigDouble(config, CATEGORY_POL, "POL_07_sootFogDivisor", "The divisor for smog, higher numbers will require more soot for the same smog density", 120D);
 		smokeStackSootMult = CommonConfig.createConfigDouble(config, CATEGORY_POL, "POL_08_smokeStackSootMult", "How much does smokestack multiply soot by, with decimal values reducing the soot", 0.8);
+		coalDustItems = CommonConfig.createConfigStringList(config, CATEGORY_POL, "POL_09_coalDustHazards", "Items that cause the coal dust hazard to apply.", new String[]{"hbm:item.powder_coal:0", "hbm:item.powder_lignite:0"});
+		coalDustTinyItems = CommonConfig.createConfigStringList(config, CATEGORY_POL, "POL_10_tinyCoalDustHarzards", "Items that cause the coal hazard to apply, but with a smaller effect than normal coal dust hazard items.", new String[]{"hbm:item.powder_coal_tiny:0", "hbm:item.powder_lignite_tiny:0"});
+		coalDustBlocks = CommonConfig.createConfigStringList(config, CATEGORY_POL, "POL_11_coalDustBlocks", "Blocks that can cause a puff of coal dust to appear.", new String[]{"hbm:tile.ore_lignite", "minecraft:coal_ore"});
 	}
 }

--- a/src/main/java/com/hbm/config/RadiationConfig.java
+++ b/src/main/java/com/hbm/config/RadiationConfig.java
@@ -38,7 +38,7 @@ public class RadiationConfig {
 	public static double smokeStackSootMult = 0.8;
 	public static String[] coalDustItems = {"hbm:item.powder_coal:0", "hbm:item.powder_lignite:0"};
 	public static String[] coalDustTinyItems = {"hbm:item.powder_coal_tiny:0", "hbm:item.powder_lignite_tiny:0"};
-	public static String[] coalDustBlocks = {"hbm:tile.ore_lignite", "minecraft:coal_ore"};
+	public static String[] coalDustBlocks = {"hbm:tile.ore_lignite:0", "minecraft:coal_ore:0"};
 
 	public static void loadFromConfig(Configuration config) {
 
@@ -81,6 +81,6 @@ public class RadiationConfig {
 		smokeStackSootMult = CommonConfig.createConfigDouble(config, CATEGORY_POL, "POL_08_smokeStackSootMult", "How much does smokestack multiply soot by, with decimal values reducing the soot", 0.8);
 		coalDustItems = CommonConfig.createConfigStringList(config, CATEGORY_POL, "POL_09_coalDustHazards", "Items that cause the coal dust hazard to apply.", new String[]{"hbm:item.powder_coal:0", "hbm:item.powder_lignite:0"});
 		coalDustTinyItems = CommonConfig.createConfigStringList(config, CATEGORY_POL, "POL_10_tinyCoalDustHarzards", "Items that cause the coal hazard to apply, but with a smaller effect than normal coal dust hazard items.", new String[]{"hbm:item.powder_coal_tiny:0", "hbm:item.powder_lignite_tiny:0"});
-		coalDustBlocks = CommonConfig.createConfigStringList(config, CATEGORY_POL, "POL_11_coalDustBlocks", "Blocks that can cause a puff of coal dust to appear.", new String[]{"hbm:tile.ore_lignite", "minecraft:coal_ore"});
+		coalDustBlocks = CommonConfig.createConfigStringList(config, CATEGORY_POL, "POL_11_coalDustBlocks", "Blocks that can cause a puff of coal dust to appear.", new String[]{"hbm:tile.ore_lignite:0", "minecraft:coal_ore:0"});
 	}
 }

--- a/src/main/java/com/hbm/hazard/HazardBuilder.java
+++ b/src/main/java/com/hbm/hazard/HazardBuilder.java
@@ -1,0 +1,236 @@
+package com.hbm.hazard;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.stream.JsonWriter;
+import com.hbm.hazard.type.*;
+import com.google.gson.Gson;
+import com.hbm.inventory.RecipesCommon;
+import com.hbm.main.MainRegistry;
+import com.hbm.util.Compat;
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+import java.io.*;
+import java.util.*;
+
+public class HazardBuilder {
+	private final String FILE_NAME = "hbmHazards.json";
+	private final HashMap<Object, HazardData> hazardItems = new HashMap<>();
+	private final float powder = HazardRegistry.powder;
+	private final float powder_tiny = HazardRegistry.powder_tiny;
+	private final Gson gson = new Gson();
+
+	public void initialize(){
+		File hazDir = new File(MainRegistry.configHbmDir.getAbsolutePath());
+
+		if(!hazDir.exists() && !hazDir.mkdir()){
+			throw new IllegalStateException("Unable to make hazards directory: " + hazDir.getAbsolutePath());
+		}
+
+		MainRegistry.logger.info("Starting hazard init!");
+
+		File hazFile = new File(hazDir.getAbsolutePath() + File.separatorChar + FILE_NAME);
+		if (hazFile.exists() && hazFile.isFile()){
+			try{
+				parseConfigFile(hazFile);
+			} catch (IOException e){
+				MainRegistry.logger.error("{} is malformed or inaccessible! Using default values.", FILE_NAME);
+				registerDefault();
+			}
+		}
+		else {
+			MainRegistry.logger.info("{} doesn't exists, creating a new one using default values...", FILE_NAME);
+			File hazFileTemplate = new File(hazDir.getAbsolutePath() + File.separatorChar + "_" + FILE_NAME);
+			createDefaultFile(hazFileTemplate);
+		}
+
+		for(HashMap.Entry<Object, HazardData> set : hazardItems.entrySet()){
+			HazardSystem.register(set.getKey(), set.getValue());
+		}
+	}
+
+	private void registerDefault() {
+		hazardItems.clear();
+
+		hazardItems.put("dustCoal", new HazardDataBuilder().addCoalHazard(powder).getHazardData());
+		hazardItems.put("dustTinyCoal", new HazardDataBuilder().addCoalHazard(powder_tiny).getHazardData());
+		hazardItems.put("dustLignite", new HazardDataBuilder().addCoalHazard(powder).getHazardData());
+		hazardItems.put("dustTinyLignite", new HazardDataBuilder().addCoalHazard(powder_tiny).getHazardData());
+	}
+
+	private void parseConfigFile(File hazFile) throws IOException {
+		JsonObject json = gson.fromJson(new FileReader(hazFile), JsonObject.class);
+		JsonArray itemHazards = json.get("itemHazards").getAsJsonArray();
+
+		// Iterate over all item hazards in the config file
+		for(JsonElement item : itemHazards){
+			JsonObject obj = (JsonObject) item;
+			HazardData hazData = extractHazardEnrties(obj.get("hazards").getAsJsonArray());
+
+			String itemName = obj.get("itemName").getAsString();
+
+			// Check if it is an oreDict item
+			String[] parts = itemName.split(":");
+			if (parts.length < 2){
+				hazardItems.put(itemName, hazData);
+				continue;
+			}
+
+			// Add as ItemStack instead
+			Item possibleItem = Compat.tryLoadItem(parts[0], parts[1]);
+			if (possibleItem == null){
+				MainRegistry.logger.warn("Item {} does not exists, skipping.", itemName);
+				continue;
+			}
+
+			int dataTag = obj.get("dataTag").getAsInt();
+			ItemStack completeItem = new ItemStack(possibleItem, 1, dataTag);
+
+			hazardItems.put(completeItem, hazData);
+		}
+	}
+
+	private HazardData extractHazardEnrties(JsonArray entries){
+		HazardData toReturn = new HazardData();
+
+		// Iterate over all hazards that should be applied to the item
+		for(JsonElement entry : entries){
+			JsonObject obj = (JsonObject) entry;
+
+			HazardTypeBase type;
+			String typeData = obj.get("type").getAsString();
+			switch (typeData) {
+				case "ASBESTOS":
+					type = HazardRegistry.ASBESTOS;
+					break;
+				case "BLINDING":
+					type = HazardRegistry.BLINDING;
+					break;
+				case "COAL":
+					type = HazardRegistry.COAL;
+					break;
+				case "DIGAMMA":
+					type = HazardRegistry.DIGAMMA;
+					break;
+				case "EXPLOSIVE":
+					type = HazardRegistry.EXPLOSIVE;
+					break;
+				case "HOT":
+					type = HazardRegistry.HOT;
+					break;
+				case "HYDROACTIVE":
+					type = HazardRegistry.HYDROACTIVE;
+					break;
+				case "RADIATION":
+					type = HazardRegistry.RADIATION;
+					break;
+				default:
+					MainRegistry.logger.warn("Hazard type {} doesn't exists skipping.");
+					continue;
+			}
+
+			float level = obj.get("level").getAsFloat();
+			toReturn.addEntry(type, level);
+		}
+
+		return toReturn;
+	}
+
+	private void createDefaultFile(File hazFile){
+		registerDefault();
+
+		try{
+			JsonWriter writer = new JsonWriter(new FileWriter(hazFile));
+			writer.setIndent("  ");
+			writer.beginObject();
+
+			writer.name("comment").value("Template file, remove the underscore ('_') from the name to enable the config.");
+
+			writer.name("itemHazards").beginArray();
+
+			// Write all items and their hazards
+			for(Map.Entry<Object, HazardData> set : hazardItems.entrySet()){
+				writer.beginObject();
+
+				// Determine the item name
+				writer.name("itemName");
+				Object o = set.getKey();
+				if(o instanceof String) {
+					writer.value((String) o);
+					writer.name("dataTag").value(0);
+				}
+				else if(o instanceof Item){
+					writer.value(((Item)o).getUnlocalizedName());
+					writer.name("dataTag").value(0);
+				}
+				else if(o instanceof Block) {
+					writer.value(((Block)o).getUnlocalizedName());
+					writer.name("dataTag").value(0);
+				}
+				else if(o instanceof ItemStack) {
+					ItemStack stack = (ItemStack)o;
+					writer.value(stack.getItem().getUnlocalizedName());
+					writer.name("dataTag").value(stack.getItemDamage());
+				}
+				else if(o instanceof RecipesCommon.ComparableStack) {
+					ItemStack stack = ((RecipesCommon.ComparableStack)o).toStack();
+					writer.value(stack.getItem().getUnlocalizedName());
+					writer.name("dataTag").value(stack.getItemDamage());
+				}
+				else {
+					writer.value("undefined");
+					writer.name("dataTag").value(0);
+				}
+
+				// Add all hazards and their levels
+				writer.name("hazards").beginArray();
+				for(HazardEntry he : set.getValue().entries){
+					writer.beginObject();
+					writer.name("type");
+					if(he.type instanceof HazardTypeAsbestos){
+						writer.value("ASBESTOS");
+					}
+					if(he.type instanceof HazardTypeBlinding){
+						writer.value("BLINDING");
+					}
+					if(he.type instanceof HazardTypeCoal){
+						writer.value("COAL");
+					}
+					if(he.type instanceof HazardTypeDigamma){
+						writer.value("DIGAMMA");
+					}
+					if(he.type instanceof HazardTypeExplosive){
+						writer.value("EXPLOSIVE");
+					}
+					if(he.type instanceof HazardTypeHot){
+						writer.value("HOT");
+					}
+					if(he.type instanceof HazardTypeHydroactive){
+						writer.value("HYDROACTIVE");
+					}
+					if(he.type instanceof HazardTypeRadiation){
+						writer.value("RADIATION");
+					}
+					writer.name("level").value(he.baseLevel);
+					writer.endObject();
+				}
+				writer.endArray();
+
+
+				writer.endObject();
+			}
+
+			writer.endArray();
+			writer.endObject();
+			writer.close();
+		} catch(IOException e){
+			MainRegistry.logger.error("An error occurred while tyring to write hazards to {}!", FILE_NAME);
+			e.printStackTrace();
+		}
+
+	}
+
+}

--- a/src/main/java/com/hbm/hazard/HazardBuilder.java
+++ b/src/main/java/com/hbm/hazard/HazardBuilder.java
@@ -1,23 +1,36 @@
 package com.hbm.hazard;
 
+import static com.hbm.items.ModItems.*;
+import static com.hbm.blocks.ModBlocks.*;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.stream.JsonWriter;
+import com.hbm.hazard.modifier.HazardModifier;
+import com.hbm.hazard.modifier.HazardModifierFuelRadiation;
 import com.hbm.hazard.type.*;
 import com.google.gson.Gson;
 import com.hbm.inventory.RecipesCommon;
 import com.hbm.main.MainRegistry;
 import com.hbm.util.Compat;
+import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.block.Block;
+import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
+import com.hbm.items.machine.ItemWatzPellet.EnumWatzType;
+import com.hbm.items.machine.ItemZirnoxRod.EnumZirnoxType;
+
 import java.io.*;
+import net.minecraft.init.Blocks;
 import java.util.*;
 
 public class HazardBuilder {
 	private final String FILE_NAME = "hbmHazards.json";
+	private final String comment = "Template file, remove the underscore ('_') from the name to enable the config. Hazard types available: ASBESTOS, BLINDING, COAL, DIGAMMA, EXPLOSIVE, HOT, HYDROACTIVE and RADIATION. Values are a decimal point number over 0.";
+
 	private final HashMap<Object, HazardData> hazardItems = new HashMap<>();
 	private final float powder = HazardRegistry.powder;
 	private final float powder_tiny = HazardRegistry.powder_tiny;
@@ -32,54 +45,208 @@ public class HazardBuilder {
 
 		MainRegistry.logger.info("Starting hazard init!");
 
+		HashMap<Object, HazardData> newHazardItems;
+
 		File hazFile = new File(hazDir.getAbsolutePath() + File.separatorChar + FILE_NAME);
 		if (hazFile.exists() && hazFile.isFile()){
 			try{
-				parseConfigFile(hazFile);
+				newHazardItems = parseConfigFile(hazFile);
 			} catch (IOException e){
 				MainRegistry.logger.error("{} is malformed or inaccessible! Using default values.", FILE_NAME);
-				registerDefault();
+				newHazardItems = registerDefault();
 			}
 		}
 		else {
 			MainRegistry.logger.info("{} doesn't exists, creating a new one using default values...", FILE_NAME);
 			File hazFileTemplate = new File(hazDir.getAbsolutePath() + File.separatorChar + "_" + FILE_NAME);
-			createDefaultFile(hazFileTemplate);
+			newHazardItems = registerDefault();
+			createDefaultFile(hazFileTemplate, newHazardItems);
 		}
 
-		for(HashMap.Entry<Object, HazardData> set : hazardItems.entrySet()){
+		// Remove old hazard items
+		for (Map.Entry<Object, HazardData> set : hazardItems.entrySet()){
+			if(set.getKey() instanceof String)
+				HazardSystem.oreMap.remove(set.getKey());
+			if(set.getKey() instanceof Item)
+				HazardSystem.itemMap.remove(set.getKey());
+			if(set.getKey() instanceof Block)
+				HazardSystem.itemMap.remove(Item.getItemFromBlock((Block)set.getKey()));
+			if(set.getKey() instanceof ItemStack)
+				HazardSystem.stackMap.remove(new RecipesCommon.ComparableStack((ItemStack)set.getKey()));
+			if(set.getKey() instanceof RecipesCommon.ComparableStack)
+				HazardSystem.stackMap.remove((RecipesCommon.ComparableStack)set.getKey());
+		}
+
+		// Add new hazard items
+		hazardItems.clear();
+		hazardItems.putAll(newHazardItems);
+
+		for(HashMap.Entry<Object, HazardData> set : newHazardItems.entrySet()){
 			HazardSystem.register(set.getKey(), set.getValue());
 		}
 	}
 
-	private void registerDefault() {
-		hazardItems.clear();
+	private HashMap<Object, HazardData> registerDefault() {
+		HashMap<Object, HazardData> newHazardItems = new HashMap<>();
 
-		hazardItems.put("dustCoal", new HazardDataBuilder().addCoalHazard(powder).getHazardData());
-		hazardItems.put("dustTinyCoal", new HazardDataBuilder().addCoalHazard(powder_tiny).getHazardData());
-		hazardItems.put("dustLignite", new HazardDataBuilder().addCoalHazard(powder).getHazardData());
-		hazardItems.put("dustTinyLignite", new HazardDataBuilder().addCoalHazard(powder_tiny).getHazardData());
+		newHazardItems.put("dustCoal", new HazardDataBuilder().addCoal(powder).getHazardData());
+		newHazardItems.put("dustTinyCoal", new HazardDataBuilder().addCoal(powder_tiny).getHazardData());
+		newHazardItems.put("dustLignite", new HazardDataBuilder().addCoal(powder).getHazardData());
+		newHazardItems.put("dustTinyLignite", new HazardDataBuilder().addCoal(powder_tiny).getHazardData());
+
+		newHazardItems.put(Items.gunpowder, new HazardDataBuilder().addExplosive(1F).getHazardData());
+		newHazardItems.put(Blocks.tnt, new HazardDataBuilder().addExplosive(4F).getHazardData());
+		newHazardItems.put(Items.pumpkin_pie, new HazardDataBuilder().addExplosive(1F).getHazardData());
+
+		newHazardItems.put(ball_dynamite, new HazardDataBuilder().addExplosive(2F).getHazardData());
+		newHazardItems.put(stick_dynamite, new HazardDataBuilder().addExplosive(1F).getHazardData());
+		newHazardItems.put(stick_tnt, new HazardDataBuilder().addExplosive(1.5F).getHazardData());
+		newHazardItems.put(stick_semtex, new HazardDataBuilder().addExplosive(2.5F).getHazardData());
+		newHazardItems.put(stick_c4, new HazardDataBuilder().addExplosive(2.5F).getHazardData());
+
+		newHazardItems.put(cordite, new HazardDataBuilder().addExplosive(2F).getHazardData());
+		newHazardItems.put(ballistite, new HazardDataBuilder().addExplosive(1F).getHazardData());
+
+		newHazardItems.put(insert_polonium, new HazardDataBuilder().addRadiation(100F).getHazardData());
+
+		newHazardItems.put(demon_core_open, new HazardDataBuilder().addRadiation(5F).getHazardData());
+		newHazardItems.put(demon_core_closed, new HazardDataBuilder().addRadiation(100_000F).getHazardData());
+		newHazardItems.put(lamp_demon, new HazardDataBuilder().addRadiation(100_000F).getHazardData());
+
+		newHazardItems.put(cell_tritium, new HazardDataBuilder().addRadiation(0.001F).getHazardData());
+		newHazardItems.put(cell_sas3, new HazardDataBuilder().addRadiation(HazardRegistry.sas3).addBlinding(60F).getHazardData());
+		newHazardItems.put(cell_balefire, new HazardDataBuilder().addRadiation(50F).getHazardData());
+		newHazardItems.put(powder_balefire, new HazardDataBuilder().addRadiation(500F).getHazardData());
+		newHazardItems.put(egg_balefire_shard, new HazardDataBuilder().addRadiation(HazardRegistry.bf * HazardRegistry.nugget).getHazardData());
+		newHazardItems.put(egg_balefire, new HazardDataBuilder().addRadiation(HazardRegistry.bf * HazardRegistry.ingot).getHazardData());
+
+		newHazardItems.put(solid_fuel_bf, new HazardDataBuilder().addRadiation(1000F).getHazardData()); //roughly the amount of the balefire shard diluted in 250mB of rocket fuel
+		newHazardItems.put(solid_fuel_presto_bf, new HazardDataBuilder().addRadiation(2000F).getHazardData());
+		newHazardItems.put(solid_fuel_presto_triplet_bf, new HazardDataBuilder().addRadiation(6000F).getHazardData());
+
+		newHazardItems.put(nuclear_waste_long, new HazardDataBuilder().addRadiation(5F).getHazardData());
+		newHazardItems.put(nuclear_waste_long_tiny, new HazardDataBuilder().addRadiation(0.5F).getHazardData());
+		newHazardItems.put(nuclear_waste_short, new HazardDataBuilder().addRadiation(30F).addHot(5F).getHazardData());
+		newHazardItems.put(nuclear_waste_short_tiny, new HazardDataBuilder().addRadiation(3F).addHot(5F).getHazardData());
+		newHazardItems.put(nuclear_waste_long_depleted, new HazardDataBuilder().addRadiation(0.5F).getHazardData());
+		newHazardItems.put(nuclear_waste_long_depleted_tiny, new HazardDataBuilder().addRadiation(0.05F).getHazardData());
+		newHazardItems.put(nuclear_waste_short_depleted, new HazardDataBuilder().addRadiation(3F).getHazardData());
+		newHazardItems.put(nuclear_waste_short_depleted_tiny, new HazardDataBuilder().addRadiation(0.3F).getHazardData());
+
+		newHazardItems.put(scrap_nuclear, new HazardDataBuilder().addRadiation(1F).getHazardData());
+		newHazardItems.put(trinitite, new HazardDataBuilder().addRadiation(HazardRegistry.trn * HazardRegistry.ingot).getHazardData());
+		newHazardItems.put(block_trinitite, new HazardDataBuilder().addRadiation(HazardRegistry.trn * HazardRegistry.block).getHazardData());
+		newHazardItems.put(yellow_barrel, new HazardDataBuilder().addRadiation(HazardRegistry.wst * HazardRegistry.ingot * 10).getHazardData());
+		newHazardItems.put(billet_nuclear_waste, new HazardDataBuilder().addRadiation(HazardRegistry.wst * HazardRegistry.billet).getHazardData());
+		newHazardItems.put(nuclear_waste, new HazardDataBuilder().addRadiation(HazardRegistry.wst * HazardRegistry.ingot).getHazardData());
+		newHazardItems.put(nuclear_waste_tiny, new HazardDataBuilder().addRadiation(HazardRegistry.wst * HazardRegistry.nugget).getHazardData());
+		newHazardItems.put(nuclear_waste_vitrified, new HazardDataBuilder().addRadiation(HazardRegistry.wstv * HazardRegistry.ingot).getHazardData());
+		newHazardItems.put(nuclear_waste_vitrified_tiny, new HazardDataBuilder().addRadiation(HazardRegistry.wstv * HazardRegistry.nugget).getHazardData());
+		newHazardItems.put(block_waste, new HazardDataBuilder().addRadiation(HazardRegistry.wst * HazardRegistry.block).getHazardData());
+		newHazardItems.put(block_waste_painted, new HazardDataBuilder().addRadiation(HazardRegistry.wst * HazardRegistry.block).getHazardData());
+		newHazardItems.put(block_waste_vitrified, new HazardDataBuilder().addRadiation(HazardRegistry.wstv * HazardRegistry.block).getHazardData());
+		newHazardItems.put(ancient_scrap, new HazardDataBuilder().addRadiation(150F).getHazardData());
+		newHazardItems.put(block_corium, new HazardDataBuilder().addRadiation(150F).getHazardData());
+		newHazardItems.put(block_corium_cobble, new HazardDataBuilder().addRadiation(150F).getHazardData());
+
+		newHazardItems.put(new ItemStack(sellafield, 1, 0), new HazardDataBuilder().addRadiation(0.5F).getHazardData());
+		newHazardItems.put(new ItemStack(sellafield, 1, 1), new HazardDataBuilder().addRadiation(1F).getHazardData());
+		newHazardItems.put(new ItemStack(sellafield, 1, 2), new HazardDataBuilder().addRadiation(2.5F).getHazardData());
+		newHazardItems.put(new ItemStack(sellafield, 1, 3), new HazardDataBuilder().addRadiation(4F).getHazardData());
+		newHazardItems.put(new ItemStack(sellafield, 1, 4), new HazardDataBuilder().addRadiation(5F).getHazardData());
+		newHazardItems.put(new ItemStack(sellafield, 1, 5), new HazardDataBuilder().addRadiation(10F).getHazardData());
+
+		newHazardItems.put(ore_sellafield_radgem, new HazardDataBuilder().addRadiation(25F).getHazardData());
+		newHazardItems.put(gem_rad, new HazardDataBuilder().addRadiation(25F).getHazardData());
+
+		newHazardItems.put(new ItemStack(rod_zirnox, 1, EnumZirnoxType.NATURAL_URANIUM_FUEL.ordinal()), new HazardDataBuilder()
+			.addRadiation(HazardRegistry.u, new HazardModifier[]{
+				new HazardModifierFuelRadiation(HazardRegistry.wst * 11.5F)
+			})
+			.getHazardData());
+		newHazardItems.put(new ItemStack(rod_zirnox, 1, EnumZirnoxType.URANIUM_FUEL.ordinal()), new HazardDataBuilder()
+			.addRadiation(HazardRegistry.uf, new HazardModifier[]{
+				new HazardModifierFuelRadiation(HazardRegistry.wst * 10F)
+			})
+			.getHazardData());
+		newHazardItems.put(new ItemStack(rod_zirnox, 1, EnumZirnoxType.TH232.ordinal()), new HazardDataBuilder()
+			.addRadiation(HazardRegistry.th232, new HazardModifier[]{
+				new HazardModifierFuelRadiation(HazardRegistry.thf)
+			})
+			.getHazardData());
+		newHazardItems.put(new ItemStack(rod_zirnox, 1, EnumZirnoxType.THORIUM_FUEL.ordinal()), new HazardDataBuilder()
+			.addRadiation(HazardRegistry.thf, new HazardModifier[]{
+				new HazardModifierFuelRadiation(HazardRegistry.wst * 7.5F)
+			})
+			.getHazardData());
+		newHazardItems.put(new ItemStack(rod_zirnox, 1, EnumZirnoxType.MOX_FUEL.ordinal()), new HazardDataBuilder()
+			.addRadiation(HazardRegistry.mox, new HazardModifier[]{
+				new HazardModifierFuelRadiation(HazardRegistry.wst * 10F)
+			})
+			.getHazardData());
+		newHazardItems.put(new ItemStack(rod_zirnox, 1, EnumZirnoxType.PLUTONIUM_FUEL.ordinal()), new HazardDataBuilder()
+			.addRadiation(HazardRegistry.puf, new HazardModifier[]{
+				new HazardModifierFuelRadiation(HazardRegistry.wst * 12.5F)
+			})
+			.getHazardData());
+		newHazardItems.put(new ItemStack(rod_zirnox, 1, EnumZirnoxType.U233_FUEL.ordinal()), new HazardDataBuilder()
+			.addRadiation(HazardRegistry.u233, new HazardModifier[]{
+				new HazardModifierFuelRadiation(HazardRegistry.wst * 10F)
+			})
+			.getHazardData());
+		newHazardItems.put(new ItemStack(rod_zirnox, 1, EnumZirnoxType.U235_FUEL.ordinal()), new HazardDataBuilder()
+			.addRadiation(HazardRegistry.u235, new HazardModifier[]{
+				new HazardModifierFuelRadiation(HazardRegistry.wst * 11F)
+			})
+			.getHazardData());
+		newHazardItems.put(new ItemStack(rod_zirnox, 1, EnumZirnoxType.LES_FUEL.ordinal()), new HazardDataBuilder()
+			.addRadiation(HazardRegistry.saf, new HazardModifier[]{
+				new HazardModifierFuelRadiation(HazardRegistry.wst * 15F)
+			})
+			.getHazardData());
+		newHazardItems.put(new ItemStack(rod_zirnox, 1, EnumZirnoxType.LITHIUM.ordinal()), new HazardDataBuilder()
+			.addRadiation(0, new HazardModifier[]{
+				new HazardModifierFuelRadiation(0.001F)
+			})
+			.getHazardData());
+		newHazardItems.put(new ItemStack(rod_zirnox, 1, EnumZirnoxType.ZFB_MOX.ordinal()), new HazardDataBuilder()
+			.addRadiation(HazardRegistry.mox, new HazardModifier[]{
+				new HazardModifierFuelRadiation(HazardRegistry.wst * 5F)
+			})
+			.getHazardData());
+
+		return newHazardItems;
 	}
 
-	private void parseConfigFile(File hazFile) throws IOException {
+	private HashMap<Object, HazardData> parseConfigFile(File hazFile) throws IOException {
+		HashMap<Object, HazardData> newHazardItems = new HashMap<>();
+
 		JsonObject json = gson.fromJson(new FileReader(hazFile), JsonObject.class);
 		JsonArray itemHazards = json.get("itemHazards").getAsJsonArray();
 
 		// Iterate over all item hazards in the config file
 		for(JsonElement item : itemHazards){
 			JsonObject obj = (JsonObject) item;
-			HazardData hazData = extractHazardEnrties(obj.get("hazards").getAsJsonArray());
+			HazardData hazData;
+			try {
+				hazData = extractHazardEnrties(obj.get("hazards").getAsJsonArray());
+			}
+			catch (ClassCastException e){
+				MainRegistry.logger.warn("Invalid hazard data format! Skipping: {}", itemHazards);
+				continue;
+			}
 
 			String itemName = obj.get("itemName").getAsString();
 
 			// Check if it is an oreDict item
 			String[] parts = itemName.split(":");
 			if (parts.length < 2){
-				hazardItems.put(itemName, hazData);
+				newHazardItems.put(itemName, hazData);
 				continue;
 			}
 
 			// Add as ItemStack instead
+
 			Item possibleItem = Compat.tryLoadItem(parts[0], parts[1]);
 			if (possibleItem == null){
 				MainRegistry.logger.warn("Item {} does not exists, skipping.", itemName);
@@ -89,11 +256,12 @@ public class HazardBuilder {
 			int dataTag = obj.get("dataTag").getAsInt();
 			ItemStack completeItem = new ItemStack(possibleItem, 1, dataTag);
 
-			hazardItems.put(completeItem, hazData);
+			newHazardItems.put(completeItem, hazData);
 		}
+		return newHazardItems;
 	}
 
-	private HazardData extractHazardEnrties(JsonArray entries){
+	private HazardData extractHazardEnrties(JsonArray entries) throws ClassCastException{
 		HazardData toReturn = new HazardData();
 
 		// Iterate over all hazards that should be applied to the item
@@ -139,7 +307,7 @@ public class HazardBuilder {
 		return toReturn;
 	}
 
-	private void createDefaultFile(File hazFile){
+	private void createDefaultFile(File hazFile, HashMap<Object, HazardData> hazardItemsWrite){
 		registerDefault();
 
 		try{
@@ -147,12 +315,12 @@ public class HazardBuilder {
 			writer.setIndent("  ");
 			writer.beginObject();
 
-			writer.name("comment").value("Template file, remove the underscore ('_') from the name to enable the config.");
+			writer.name("comment").value(comment);
 
 			writer.name("itemHazards").beginArray();
 
 			// Write all items and their hazards
-			for(Map.Entry<Object, HazardData> set : hazardItems.entrySet()){
+			for(Map.Entry<Object, HazardData> set : hazardItemsWrite.entrySet()){
 				writer.beginObject();
 
 				// Determine the item name
@@ -163,21 +331,22 @@ public class HazardBuilder {
 					writer.name("dataTag").value(0);
 				}
 				else if(o instanceof Item){
-					writer.value(((Item)o).getUnlocalizedName());
+					writer.value(getModId((Item)o) + ":" + getItemName((Item)o));
 					writer.name("dataTag").value(0);
 				}
 				else if(o instanceof Block) {
-					writer.value(((Block)o).getUnlocalizedName());
+					Item item = Item.getItemFromBlock((Block)o);
+					writer.value(getModId(item) + ":" + getItemName(item));
 					writer.name("dataTag").value(0);
 				}
 				else if(o instanceof ItemStack) {
 					ItemStack stack = (ItemStack)o;
-					writer.value(stack.getItem().getUnlocalizedName());
+					writer.value(getModId(stack) + ":" + getItemName(stack));
 					writer.name("dataTag").value(stack.getItemDamage());
 				}
 				else if(o instanceof RecipesCommon.ComparableStack) {
 					ItemStack stack = ((RecipesCommon.ComparableStack)o).toStack();
-					writer.value(stack.getItem().getUnlocalizedName());
+					writer.value(getModId(stack) + ":" + getItemName(stack));
 					writer.name("dataTag").value(stack.getItemDamage());
 				}
 				else {
@@ -230,7 +399,24 @@ public class HazardBuilder {
 			MainRegistry.logger.error("An error occurred while tyring to write hazards to {}!", FILE_NAME);
 			e.printStackTrace();
 		}
+	}
 
+	private String getItemName(Item item){
+		GameRegistry.UniqueIdentifier id = GameRegistry.findUniqueIdentifierFor(item);
+		return id == null || id.name.isEmpty() ? null : id.name;
+	}
+
+	private String getItemName(ItemStack stack){
+		return getItemName(stack.getItem());
+	}
+
+	private String getModId(Item item){
+		GameRegistry.UniqueIdentifier id = GameRegistry.findUniqueIdentifierFor(item);
+		return id == null || id.modId.isEmpty() ? "minecraft" : id.modId;
+	}
+
+	private String getModId(ItemStack stack){
+		return getModId(stack.getItem());
 	}
 
 }

--- a/src/main/java/com/hbm/hazard/HazardDataBuilder.java
+++ b/src/main/java/com/hbm/hazard/HazardDataBuilder.java
@@ -1,5 +1,7 @@
 package com.hbm.hazard;
 
+import com.hbm.hazard.modifier.HazardModifier;
+
 public class HazardDataBuilder {
 	private final HazardData hazardData;
 
@@ -11,18 +13,61 @@ public class HazardDataBuilder {
 		this.hazardData = hazardData;
 	}
 
-	public HazardDataBuilder addCoalHazard(float level){
+	public HazardDataBuilder addAsbestos(float level){
+		hazardData.addEntry(HazardRegistry.ASBESTOS, level);
+		return this;
+	}
+
+	public HazardDataBuilder addAsbestos(float level, HazardModifier[] modifiers){
+		HazardEntry newEntry = new HazardEntry(HazardRegistry.ASBESTOS, level);
+		for (HazardModifier mod : modifiers){
+			newEntry.addMod(mod);
+		}
+		hazardData.addEntry(newEntry);
+		return this;
+	}
+
+	public HazardDataBuilder addBlinding(float level){
+		hazardData.addEntry(HazardRegistry.BLINDING, level);
+		return this;
+	}
+
+	public HazardDataBuilder addCoal(float level){
 		hazardData.addEntry(HazardRegistry.COAL, level);
 		return this;
 	}
 
-	public HazardDataBuilder addExplosiveHazard(float level){
+	public HazardDataBuilder addDigamma(float level){
+		hazardData.addEntry(HazardRegistry.DIGAMMA, level);
+		return this;
+	}
+
+	public HazardDataBuilder addExplosive(float level){
 		hazardData.addEntry(HazardRegistry.EXPLOSIVE, level);
 		return this;
 	}
 
-	public HazardDataBuilder addHydroactiveHazard(float level){
+	public HazardDataBuilder addHot(float level){
+		hazardData.addEntry(HazardRegistry.HOT, level);
+		return this;
+	}
+
+	public HazardDataBuilder addHydroactive(float level){
 		hazardData.addEntry(HazardRegistry.HYDROACTIVE, level);
+		return this;
+	}
+
+	public HazardDataBuilder addRadiation(float level){
+		hazardData.addEntry(HazardRegistry.RADIATION, level);
+		return this;
+	}
+
+	public HazardDataBuilder addRadiation(float level, HazardModifier[] modifiers){
+		HazardEntry newEntry = new HazardEntry(HazardRegistry.RADIATION, level);
+		for (HazardModifier mod : modifiers){
+			newEntry.addMod(mod);
+		}
+		hazardData.addEntry(newEntry);
 		return this;
 	}
 

--- a/src/main/java/com/hbm/hazard/HazardDataBuilder.java
+++ b/src/main/java/com/hbm/hazard/HazardDataBuilder.java
@@ -1,0 +1,33 @@
+package com.hbm.hazard;
+
+public class HazardDataBuilder {
+	private final HazardData hazardData;
+
+	public HazardDataBuilder(){
+		this(new HazardData());
+	}
+
+	public HazardDataBuilder(HazardData hazardData){
+		this.hazardData = hazardData;
+	}
+
+	public HazardDataBuilder addCoalHazard(float level){
+		hazardData.addEntry(HazardRegistry.COAL, level);
+		return this;
+	}
+
+	public HazardDataBuilder addExplosiveHazard(float level){
+		hazardData.addEntry(HazardRegistry.EXPLOSIVE, level);
+		return this;
+	}
+
+	public HazardDataBuilder addHydroactiveHazard(float level){
+		hazardData.addEntry(HazardRegistry.HYDROACTIVE, level);
+		return this;
+	}
+
+	public HazardData getHazardData(){
+		return hazardData;
+	}
+
+}

--- a/src/main/java/com/hbm/hazard/HazardRegistry.java
+++ b/src/main/java/com/hbm/hazard/HazardRegistry.java
@@ -20,7 +20,6 @@ import com.hbm.items.machine.ItemZirnoxRod.EnumZirnoxType;
 import com.hbm.items.special.ItemHolotapeImage.EnumHoloImage;
 import com.hbm.util.Compat;
 import com.hbm.util.Compat.ReikaIsotope;
-import com.hbm.config.RadiationConfig;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -172,52 +171,8 @@ public class HazardRegistry {
 		HazardSystem.register(ballistite, makeData(EXPLOSIVE, 1F));
 
 		// Register all coal dust items
-		for (int i = 0; i < RadiationConfig.coalDustItems.length; i++) {
-			String dustName = RadiationConfig.coalDustItems[i];
-			int dataTag = 0;
-
-			String[] dustNameParts = dustName.split(":");
-			if (dustNameParts.length <= 1){
-				continue;
-			}
-			else if (dustNameParts.length == 3) {
-				try {
-					dataTag = Integer.parseInt(dustNameParts[2]);
-				} catch (NumberFormatException e){}
-			}
-
-			Item dustItem = Compat.tryLoadItem(dustNameParts[0], dustNameParts[1]);
-			ItemStack dustStack = new ItemStack(dustItem, 1, dataTag);
-
-			if (dustItem == null) {
-				continue;
-			}
-			HazardSystem.register(dustStack, makeData(COAL, powder));
-		}
-
-		// Register all tiny coal dust items
-		for (int i = 0; i < RadiationConfig.coalDustTinyItems.length; i++) {
-			String tinyDustName = RadiationConfig.coalDustTinyItems[i];
-			int dataTag = 0;
-
-			String[] tinyDustNameParts = tinyDustName.split(":");
-			if (tinyDustNameParts.length <= 1){
-				continue;
-			}
-			else if (tinyDustNameParts.length == 3) {
-				try {
-					dataTag = Integer.parseInt(tinyDustNameParts[2]);
-				} catch (NumberFormatException e){}
-			}
-
-			Item tinyDustItem = Compat.tryLoadItem(tinyDustNameParts[0], tinyDustNameParts[1]);
-			ItemStack tinyDustStack = new ItemStack(tinyDustItem, 1, dataTag);
-
-			if (tinyDustItem == null) {
-				continue;
-			}
-			HazardSystem.register(tinyDustStack, makeData(COAL, powder));
-		}
+		HazardBuilder builder = new HazardBuilder();
+		builder.initialize();
 
 		HazardSystem.register(insert_polonium, makeData(RADIATION, 100F));
 

--- a/src/main/java/com/hbm/hazard/HazardRegistry.java
+++ b/src/main/java/com/hbm/hazard/HazardRegistry.java
@@ -20,6 +20,7 @@ import com.hbm.items.machine.ItemZirnoxRod.EnumZirnoxType;
 import com.hbm.items.special.ItemHolotapeImage.EnumHoloImage;
 import com.hbm.util.Compat;
 import com.hbm.util.Compat.ReikaIsotope;
+import com.hbm.config.RadiationConfig;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -154,13 +155,13 @@ public class HazardRegistry {
 	public static final HazardTypeBase COAL = new HazardTypeCoal();
 	public static final HazardTypeBase HYDROACTIVE = new HazardTypeHydroactive();
 	public static final HazardTypeBase EXPLOSIVE = new HazardTypeExplosive();
-	
+
 	public static void registerItems() {
-		
+
 		HazardSystem.register(Items.gunpowder, makeData(EXPLOSIVE, 1F));
 		HazardSystem.register(Blocks.tnt, makeData(EXPLOSIVE, 4F));
 		HazardSystem.register(Items.pumpkin_pie, makeData(EXPLOSIVE, 1F));
-		
+
 		HazardSystem.register(ball_dynamite, makeData(EXPLOSIVE, 2F));
 		HazardSystem.register(stick_dynamite, makeData(EXPLOSIVE, 1F));
 		HazardSystem.register(stick_tnt, makeData(EXPLOSIVE, 1.5F));
@@ -170,11 +171,54 @@ public class HazardRegistry {
 		HazardSystem.register(cordite, makeData(EXPLOSIVE, 2F));
 		HazardSystem.register(ballistite, makeData(EXPLOSIVE, 1F));
 
-		HazardSystem.register("dustCoal", makeData(COAL, powder));
-		HazardSystem.register("dustTinyCoal", makeData(COAL, powder_tiny));
-		HazardSystem.register("dustLignite", makeData(COAL, powder));
-		HazardSystem.register("dustTinyLignite", makeData(COAL, powder_tiny));
-		
+		// Register all coal dust items
+		for (int i = 0; i < RadiationConfig.coalDustItems.length; i++) {
+			String dustName = RadiationConfig.coalDustItems[i];
+			int dataTag = 0;
+
+			String[] dustNameParts = dustName.split(":");
+			if (dustNameParts.length <= 1){
+				continue;
+			}
+			else if (dustNameParts.length == 3) {
+				try {
+					dataTag = Integer.parseInt(dustNameParts[2]);
+				} catch (NumberFormatException e){}
+			}
+
+			Item dustItem = Compat.tryLoadItem(dustNameParts[0], dustNameParts[1]);
+			ItemStack dustStack = new ItemStack(dustItem, 1, dataTag);
+
+			if (dustItem == null) {
+				continue;
+			}
+			HazardSystem.register(dustStack, makeData(COAL, powder));
+		}
+
+		// Register all tiny coal dust items
+		for (int i = 0; i < RadiationConfig.coalDustTinyItems.length; i++) {
+			String tinyDustName = RadiationConfig.coalDustTinyItems[i];
+			int dataTag = 0;
+
+			String[] tinyDustNameParts = tinyDustName.split(":");
+			if (tinyDustNameParts.length <= 1){
+				continue;
+			}
+			else if (tinyDustNameParts.length == 3) {
+				try {
+					dataTag = Integer.parseInt(tinyDustNameParts[2]);
+				} catch (NumberFormatException e){}
+			}
+
+			Item tinyDustItem = Compat.tryLoadItem(tinyDustNameParts[0], tinyDustNameParts[1]);
+			ItemStack tinyDustStack = new ItemStack(tinyDustItem, 1, dataTag);
+
+			if (tinyDustItem == null) {
+				continue;
+			}
+			HazardSystem.register(tinyDustStack, makeData(COAL, powder));
+		}
+
 		HazardSystem.register(insert_polonium, makeData(RADIATION, 100F));
 
 		HazardSystem.register(demon_core_open, makeData(RADIATION, 5F));
@@ -216,17 +260,17 @@ public class HazardRegistry {
 		HazardSystem.register(ancient_scrap, makeData(RADIATION, 150F));
 		HazardSystem.register(block_corium, makeData(RADIATION, 150F));
 		HazardSystem.register(block_corium_cobble, makeData(RADIATION, 150F));
-		
+
 		HazardSystem.register(new ItemStack(ModBlocks.sellafield, 1, 0), makeData(RADIATION, 0.5F));
 		HazardSystem.register(new ItemStack(ModBlocks.sellafield, 1, 1), makeData(RADIATION, 1F));
 		HazardSystem.register(new ItemStack(ModBlocks.sellafield, 1, 2), makeData(RADIATION, 2.5F));
 		HazardSystem.register(new ItemStack(ModBlocks.sellafield, 1, 3), makeData(RADIATION, 4F));
-		HazardSystem.register(new ItemStack(ModBlocks.sellafield, 1, 4), makeData(RADIATION, 5F));	
+		HazardSystem.register(new ItemStack(ModBlocks.sellafield, 1, 4), makeData(RADIATION, 5F));
 		HazardSystem.register(new ItemStack(ModBlocks.sellafield, 1, 5), makeData(RADIATION, 10F));
 
 		HazardSystem.register(new ItemStack(ModBlocks.ore_sellafield_radgem), makeData(RADIATION, 25F));
 		HazardSystem.register(new ItemStack(ModItems.gem_rad), makeData(RADIATION, 25F));
-		
+
 		registerOtherFuel(rod_zirnox, EnumZirnoxType.NATURAL_URANIUM_FUEL.ordinal(), u * rod_dual, wst * rod_dual * 11.5F, false);
 		registerOtherFuel(rod_zirnox, EnumZirnoxType.URANIUM_FUEL.ordinal(), uf * rod_dual, wst * rod_dual * 10F, false);
 		registerOtherFuel(rod_zirnox, EnumZirnoxType.TH232.ordinal(), th232 * rod_dual, thf * rod_dual, false);
@@ -238,7 +282,7 @@ public class HazardRegistry {
 		registerOtherFuel(rod_zirnox, EnumZirnoxType.LES_FUEL.ordinal(), saf * rod_dual, wst * rod_dual * 15F, false);
 		registerOtherFuel(rod_zirnox, EnumZirnoxType.LITHIUM.ordinal(), 0, 0.001F * rod_dual, false);
 		registerOtherFuel(rod_zirnox, EnumZirnoxType.ZFB_MOX.ordinal(), mox * rod_dual, wst * rod_dual * 5F, false);
-		
+
 		HazardSystem.register(rod_zirnox_natural_uranium_fuel_depleted, makeData(RADIATION, wst * rod_dual * 11.5F));
 		HazardSystem.register(rod_zirnox_uranium_fuel_depleted, makeData(RADIATION, wst * rod_dual * 10F));
 		HazardSystem.register(rod_zirnox_thorium_fuel_depleted, makeData(RADIATION, wst * rod_dual * 7.5F));
@@ -249,7 +293,7 @@ public class HazardRegistry {
 		HazardSystem.register(rod_zirnox_les_fuel_depleted, makeData().addEntry(RADIATION, wst * rod_dual * 15F).addEntry(BLINDING, 20F));
 		HazardSystem.register(rod_zirnox_tritium, makeData(RADIATION, 0.001F * rod_dual));
 		HazardSystem.register(rod_zirnox_zfb_mox_depleted, makeData(RADIATION, wst * rod_dual * 5F));
-		
+
 		registerOtherWaste(waste_natural_uranium, wst * billet * 11.5F);
 		registerOtherWaste(waste_uranium, wst * billet * 10F);
 		registerOtherWaste(waste_thorium, wst * billet * 7.5F);
@@ -259,7 +303,7 @@ public class HazardRegistry {
 		registerOtherWaste(waste_u235, wst * billet * 11F);
 		registerOtherWaste(waste_schrabidium, wst * billet * 15F);
 		registerOtherWaste(waste_zfb_mox, wst * billet * 5F);
-		
+
 		registerOtherFuel(plate_fuel_u233, u233 * ingot, wst * ingot * 13F, false);
 		registerOtherFuel(plate_fuel_u235, u235 * ingot, wst * ingot * 10F, false);
 		registerOtherFuel(plate_fuel_mox, mox * ingot, wst * ingot * 16F, false);
@@ -267,7 +311,7 @@ public class HazardRegistry {
 		registerOtherFuel(plate_fuel_sa326, sa326 * ingot, wst * ingot * 10F, true);
 		registerOtherFuel(plate_fuel_ra226be, rabe * billet, pobe * nugget * 3, false);
 		registerOtherFuel(plate_fuel_pu238be, pube * billet, pube * nugget * 1, false);
-		
+
 		registerOtherWaste(waste_plate_u233, wst * ingot * 13F);
 		registerOtherWaste(waste_plate_u235, wst * ingot * 10F);
 		registerOtherWaste(waste_plate_mox, wst * ingot * 16F);
@@ -275,7 +319,7 @@ public class HazardRegistry {
 		registerOtherWaste(waste_plate_sa326, wst * ingot * 10F);
 		registerRadSourceWaste(waste_plate_ra226be, pobe * nugget * 3);
 		registerRadSourceWaste(waste_plate_pu238be, pube * nugget * 1);
-		
+
 		HazardSystem.register(debris_graphite, makeData().addEntry(RADIATION, 70F).addEntry(HOT, 5F));
 		HazardSystem.register(debris_metal, makeData(RADIATION, 5F));
 		HazardSystem.register(debris_fuel, makeData().addEntry(RADIATION, 500F).addEntry(HOT, 5F));
@@ -283,44 +327,44 @@ public class HazardRegistry {
 		HazardSystem.register(debris_exchanger, makeData(RADIATION, 25F));
 		HazardSystem.register(debris_shrapnel, makeData(RADIATION, 2.5F));
 		HazardSystem.register(debris_element, makeData(RADIATION, 100F));
-		
+
 		HazardSystem.register(nugget_uranium_fuel, makeData(RADIATION, uf * nugget));
 		HazardSystem.register(billet_uranium_fuel, makeData(RADIATION, uf * billet));
 		HazardSystem.register(ingot_uranium_fuel, makeData(RADIATION, uf * ingot));
 		HazardSystem.register(block_uranium_fuel, makeData(RADIATION, uf * block));
-		
+
 		HazardSystem.register(nugget_plutonium_fuel, makeData(RADIATION, puf * nugget));
 		HazardSystem.register(billet_plutonium_fuel, makeData(RADIATION, puf * billet));
 		HazardSystem.register(ingot_plutonium_fuel, makeData(RADIATION, puf * ingot));
 		HazardSystem.register(block_plutonium_fuel, makeData(RADIATION, puf * block));
-		
+
 		HazardSystem.register(nugget_thorium_fuel, makeData(RADIATION, thf * nugget));
 		HazardSystem.register(billet_thorium_fuel, makeData(RADIATION, thf * billet));
 		HazardSystem.register(ingot_thorium_fuel, makeData(RADIATION, thf * ingot));
 		HazardSystem.register(block_thorium_fuel, makeData(RADIATION, thf * block));
-		
+
 		HazardSystem.register(nugget_neptunium_fuel, makeData(RADIATION, npf * nugget));
 		HazardSystem.register(billet_neptunium_fuel, makeData(RADIATION, npf * billet));
 		HazardSystem.register(ingot_neptunium_fuel, makeData(RADIATION, npf * ingot));
-		
+
 		HazardSystem.register(nugget_mox_fuel, makeData(RADIATION, mox * nugget));
 		HazardSystem.register(billet_mox_fuel, makeData(RADIATION, mox * billet));
 		HazardSystem.register(ingot_mox_fuel, makeData(RADIATION, mox * ingot));
 		HazardSystem.register(block_mox_fuel, makeData(RADIATION, mox * block));
-		
+
 		HazardSystem.register(nugget_americium_fuel, makeData(RADIATION, amf * nugget));
 		HazardSystem.register(billet_americium_fuel, makeData(RADIATION, amf * billet));
 		HazardSystem.register(ingot_americium_fuel, makeData(RADIATION, amf * ingot));
-		
+
 		HazardSystem.register(nugget_schrabidium_fuel, makeData().addEntry(RADIATION, saf * nugget).addEntry(BLINDING, 5F * nugget));
 		HazardSystem.register(billet_schrabidium_fuel, makeData().addEntry(RADIATION, saf * billet).addEntry(BLINDING, 5F * billet));
 		HazardSystem.register(ingot_schrabidium_fuel, makeData().addEntry(RADIATION, saf * ingot).addEntry(BLINDING, 5F * ingot));
 		HazardSystem.register(block_schrabidium_fuel, makeData().addEntry(RADIATION, saf * block).addEntry(BLINDING, 5F * block));
-		
+
 		HazardSystem.register(nugget_hes, makeData(RADIATION, saf * nugget));
 		HazardSystem.register(billet_hes, makeData(RADIATION, saf * billet));
 		HazardSystem.register(ingot_hes, makeData(RADIATION, saf * ingot));
-		
+
 		HazardSystem.register(nugget_les, makeData(RADIATION, saf * nugget));
 		HazardSystem.register(billet_les, makeData(RADIATION, saf * billet));
 		HazardSystem.register(ingot_les, makeData(RADIATION, saf * ingot));
@@ -330,7 +374,7 @@ public class HazardRegistry {
 		HazardSystem.register(billet_po210be, makeData(RADIATION, pobe * billet));
 		HazardSystem.register(billet_ra226be, makeData(RADIATION, rabe * billet));
 		HazardSystem.register(billet_pu238be, makeData(RADIATION, pube * billet));
-		
+
 		registerRTGPellet(pellet_rtg, pu238 * rtg, 0, 3F);
 		registerRTGPellet(pellet_rtg_radium, ra226 * rtg, 0);
 		registerRTGPellet(pellet_rtg_weak, (pu238 + (u238 * 2)) * billet, 0);
@@ -342,12 +386,12 @@ public class HazardRegistry {
 		registerRTGPellet(pellet_rtg_gold, au198 * rtg, 0, 5F);
 		registerRTGPellet(pellet_rtg_americium, am241 * rtg, 0);
 		HazardSystem.register(new ItemStack(pellet_rtg_depleted, 1, DepletedRTGMaterial.NEPTUNIUM.ordinal()), makeData(RADIATION, np237 * rtg));
-		
+
 		HazardSystem.register(pile_rod_uranium, makeData(RADIATION, u * billet * 3));
 		HazardSystem.register(pile_rod_pu239, makeData(RADIATION, !GeneralConfig.enable528 ? purg * billet + pu239 * billet + u * billet : purg * billet + pu239 * billet + wst * billet));
 		HazardSystem.register(pile_rod_plutonium, makeData(RADIATION, !GeneralConfig.enable528 ? purg * billet * 2 + u * billet : purg * billet * 2 + wst * billet));
 		HazardSystem.register(pile_rod_source, makeData(RADIATION, rabe * billet * 3));
-		
+
 		registerBreedingRodRadiation(BreedingRodType.TRITIUM, 0.001F);
 		registerBreedingRodRadiation(BreedingRodType.CO60, co60);
 		registerBreedingRodRadiation(BreedingRodType.RA226, ra226);
@@ -395,7 +439,7 @@ public class HazardRegistry {
 		registerRBMKRod(rbmk_fuel_zfb_am_mix, pu241 * rod_rbmk * 0.1F, wst * rod_rbmk * 10F);
 		registerRBMK(rbmk_fuel_drx, bf * rod_rbmk, bf * rod_rbmk * 100F, true, true, 0, 1F/3F);
 		//registerRBMKRod(rbmk_fuel_curve, saf * rod_rbmk * np237 * rod_rbmk, wst * rod_rbmk * 35F);
-		
+
 		registerRBMKPellet(rbmk_pellet_ueu, u * billet, wst * billet * 20F);
 		registerRBMKPellet(rbmk_pellet_meu, uf * billet, wst * billet * 21.5F);
 		registerRBMKPellet(rbmk_pellet_heu233, u233 * billet, wst * billet * 31F);
@@ -427,7 +471,7 @@ public class HazardRegistry {
 		registerRBMKPellet(rbmk_pellet_zfb_pu241, pu239 * billet * 0.1F, wst * billet * 7.5F);
 		registerRBMKPellet(rbmk_pellet_zfb_am_mix, pu241 * billet * 0.1F, wst * billet * 10F);
 		registerRBMKPellet(rbmk_pellet_drx, bf * billet, bf * billet * 100F, true, 0F, 1F/24F);
-		
+
 		HazardSystem.register(DictFrame.fromOne(ModItems.watz_pellet, EnumWatzType.SCHRABIDIUM), makeData(RADIATION, sa326 * ingot * 4));
 		HazardSystem.register(DictFrame.fromOne(ModItems.watz_pellet, EnumWatzType.HES), makeData(RADIATION, saf * ingot * 4));
 		HazardSystem.register(DictFrame.fromOne(ModItems.watz_pellet, EnumWatzType.MES), makeData(RADIATION, saf * ingot * 4));
@@ -454,18 +498,18 @@ public class HazardRegistry {
 		registerPWRFuel(EnumPWRFuel.HES327, sa327 * billet * 2);
 		registerPWRFuel(EnumPWRFuel.BFB_AM_MIX, amrg * billet);
 		registerPWRFuel(EnumPWRFuel.BFB_PU241, pu241 * billet);
-		
+
 		HazardSystem.register(powder_yellowcake, makeData(RADIATION, yc * powder));
 		HazardSystem.register(block_yellowcake, makeData(RADIATION, yc * block * powder_mult));
 		HazardSystem.register(ModItems.fallout, makeData(RADIATION, fo * powder));
 		HazardSystem.register(ModBlocks.fallout, makeData(RADIATION, fo * powder * 2));
 		HazardSystem.register(ModBlocks.block_fallout, makeData(RADIATION, yc * block * powder_mult));
 		HazardSystem.register(powder_caesium, makeData().addEntry(HYDROACTIVE, 1F).addEntry(HOT, 3F));
-		
+
 		HazardSystem.register(brick_asbestos, makeData(ASBESTOS, 1F));
 		HazardSystem.register(tile_lab_broken, makeData(ASBESTOS, 1F));
 		HazardSystem.register(powder_coltan_ore, makeData(ASBESTOS, 3F));
-		
+
 		//crystals
 		HazardSystem.register(crystal_uranium, makeData(RADIATION, u * crystal));
 		HazardSystem.register(crystal_thorium, makeData(RADIATION, th232 * crystal));
@@ -475,34 +519,34 @@ public class HazardRegistry {
 		HazardSystem.register(crystal_phosphorus, makeData(HOT, 2F * crystal));
 		HazardSystem.register(crystal_lithium, makeData(HYDROACTIVE, 1F * crystal));
 		HazardSystem.register(ModItems.crystal_trixite, makeData(RADIATION, trx * crystal));
-		
+
 		//nuke parts
 		HazardSystem.register(boy_propellant, makeData(EXPLOSIVE, 2F));
-		
+
 		HazardSystem.register(gadget_core, makeData(RADIATION, pu239 * nugget * 10));
 		HazardSystem.register(boy_target, makeData(RADIATION, u235 * ingot * 2));
 		HazardSystem.register(boy_bullet, makeData(RADIATION, u235 * ingot));
 		HazardSystem.register(man_core, makeData(RADIATION, pu239 * nugget * 10));
 		HazardSystem.register(mike_core, makeData(RADIATION, u238 * nugget * 10));
 		HazardSystem.register(tsar_core, makeData(RADIATION, pu239 * nugget * 15));
-		
+
 		HazardSystem.register(fleija_propellant, makeData().addEntry(RADIATION, 15F).addEntry(EXPLOSIVE, 8F).addEntry(BLINDING, 50F));
 		HazardSystem.register(fleija_core, makeData(RADIATION, 10F));
-		
+
 		HazardSystem.register(solinium_propellant, makeData(EXPLOSIVE, 10F));
 		HazardSystem.register(solinium_core, makeData().addEntry(RADIATION, sa327 * nugget * 8).addEntry(BLINDING, 45F));
 
 		HazardSystem.register(nuke_fstbmb, makeData(DIGAMMA, 0.01F));
 		HazardSystem.register(DictFrame.fromOne(ModItems.holotape_image, EnumHoloImage.HOLO_RESTORED), makeData(DIGAMMA, 1F));
 		HazardSystem.register(holotape_damaged, makeData(DIGAMMA, 1_000F));
-		
+
 		/*
 		 * Blacklist
 		 */
 		for(String ore : TH232.all(MaterialShapes.ORE)) HazardSystem.blacklist(ore);
 		for(String ore : U.all(MaterialShapes.ORE)) HazardSystem.blacklist(ore);
 
-		
+
 		/*
 		 * ReC compat
 		 */
@@ -514,15 +558,15 @@ public class HazardRegistry {
 				}
 			}
 		}
-		
+
 		if(Compat.isModLoaded(Compat.MOD_GT6)) {
-			
+
 			Object[][] data = new Object[][] {
 				{"Naquadah", u},
 				{"Naquadah-Enriched", u235},
 				{"Naquadria", pu239},
 			};
-			
+
 			for(MaterialShapes shape : MaterialShapes.allShapes) {
 				if(!shape.noAutogen) for(String prefix : shape.prefixes) {
 					for(Object[] o : data) {
@@ -532,42 +576,42 @@ public class HazardRegistry {
 			}
 		}
 	}
-	
+
 	public static void registerTrafos() {
 		HazardSystem.trafos.add(new HazardTransformerRadiationNBT());
-		
+
 		if(!(GeneralConfig.enableLBSM && GeneralConfig.enableLBSMSafeCrates))	HazardSystem.trafos.add(new HazardTransformerRadiationContainer());
 		if(!(GeneralConfig.enableLBSM && GeneralConfig.enableLBSMSafeMEDrives))	HazardSystem.trafos.add(new HazardTransformerRadiationME());
 	}
-	
+
 	private static HazardData makeData() { return new HazardData(); }
 	private static HazardData makeData(HazardTypeBase hazard) { return new HazardData().addEntry(hazard); }
 	private static HazardData makeData(HazardTypeBase hazard, float level) { return new HazardData().addEntry(hazard, level); }
 	private static HazardData makeData(HazardTypeBase hazard, float level, boolean override) { return new HazardData().addEntry(hazard, level, override); }
-	
+
 	private static void registerPWRFuel(EnumPWRFuel fuel, float baseRad) {
 		HazardSystem.register(DictFrame.fromOne(ModItems.pwr_fuel, fuel), makeData(RADIATION, baseRad));
 		HazardSystem.register(DictFrame.fromOne(ModItems.pwr_fuel_hot, fuel), makeData(RADIATION, baseRad * 10).addEntry(HOT, 5));
 		HazardSystem.register(DictFrame.fromOne(ModItems.pwr_fuel_depleted, fuel), makeData(RADIATION, baseRad * 10));
 	}
-	
+
 	private static void registerRBMKPellet(Item pellet, float base, float dep) { registerRBMKPellet(pellet, base, dep, false, 0F, 0F); }
 	private static void registerRBMKPellet(Item pellet, float base, float dep, boolean linear) { registerRBMKPellet(pellet, base, dep, linear, 0F, 0F); }
 	private static void registerRBMKPellet(Item pellet, float base, float dep, boolean linear, float blinding, float digamma) {
-		
+
 		HazardData data = new HazardData();
 		data.addEntry(new HazardEntry(RADIATION, base).addMod(new HazardModifierRBMKRadiation(dep, linear)));
 		if(blinding > 0) data.addEntry(new HazardEntry(BLINDING, blinding));
 		if(digamma > 0) data.addEntry(new HazardEntry(DIGAMMA, digamma));
 		HazardSystem.register(pellet, data);
 	}
-	
+
 	private static void registerRBMKRod(Item rod, float base, float dep) { registerRBMK(rod, base, dep, true, false, 0F, 0F); }
 	private static void registerRBMKRod(Item rod, float base, float dep, float blinding) { registerRBMK(rod, base, dep, true, false, blinding, 0F); }
 	private static void registerRBMKRod(Item rod, float base, float dep, boolean linear) { registerRBMK(rod, base, dep, true, linear, 0F, 0F); }
-	
+
 	private static void registerRBMK(Item rod, float base, float dep, boolean hot, boolean linear, float blinding, float digamma) {
-		
+
 		HazardData data = new HazardData();
 		data.addEntry(new HazardEntry(RADIATION, base).addMod(new HazardModifierRBMKRadiation(dep, linear)));
 		if(hot) data.addEntry(new HazardEntry(HOT, 0).addMod(new HazardModifierRBMKHot()));
@@ -575,34 +619,34 @@ public class HazardRegistry {
 		if(digamma > 0) data.addEntry(new HazardEntry(DIGAMMA, digamma));
 		HazardSystem.register(rod, data);
 	}
-	
+
 	private static void registerBreedingRodRadiation(BreedingRodType type, float base) {
 		HazardSystem.register(new ItemStack(ModItems.rod, 1, type.ordinal()), makeData(RADIATION, base));
 		HazardSystem.register(new ItemStack(ModItems.rod_dual, 1, type.ordinal()), makeData(RADIATION, base * rod_dual));
 		HazardSystem.register(new ItemStack(ModItems.rod_quad, 1, type.ordinal()), makeData(RADIATION, base * rod_quad));
 	}
-	
+
 	private static void registerOtherFuel(Item fuel, float base, float target, boolean blinding) {
-		
+
 		HazardData data = new HazardData();
 		data.addEntry(new HazardEntry(RADIATION, base).addMod(new HazardModifierFuelRadiation(target)));
 		if(blinding)
 			data.addEntry(BLINDING, 20F);
 		HazardSystem.register(fuel, data);
 	}
-	
+
 	private static void registerOtherFuel(Item fuel, int meta, float base, float target, boolean blinding) {
-		
+
 		HazardData data = new HazardData();
 		data.addEntry(new HazardEntry(RADIATION, base).addMod(new HazardModifierFuelRadiation(target)));
 		if(blinding)
 			data.addEntry(BLINDING, 20F);
 		HazardSystem.register(new ItemStack(fuel, 1, meta), data);
 	}
-	
+
 	private static void registerRTGPellet(Item pellet, float base, float target) { registerRTGPellet(pellet, base, target, 0, 0); }
 	private static void registerRTGPellet(Item pellet, float base, float target, float hot) { registerRTGPellet(pellet, base, target, hot, 0); }
-	
+
 	private static void registerRTGPellet(Item pellet, float base, float target, float hot, float blinding) {
 		HazardData data = new HazardData();
 		data.addEntry(new HazardEntry(RADIATION, base).addMod(new HazardModifierRTGRadiation(target)));
@@ -610,19 +654,19 @@ public class HazardRegistry {
 		if(blinding > 0) data.addEntry(new HazardEntry(BLINDING, blinding));
 		HazardSystem.register(pellet, data);
 	}
-	
+
 	private static void registerOtherWaste(Item waste, float base) {
 		HazardSystem.register(new ItemStack(waste, 1, 0), makeData(RADIATION, base * 0.075F));
-		
+
 		HazardData data = new HazardData();
 		data.addEntry(new HazardEntry(RADIATION, base));
 		data.addEntry(new HazardEntry(HOT, 5F));
 		HazardSystem.register(new ItemStack(waste, 1, 1), data);
 	}
-	
+
 	private static void registerRadSourceWaste(Item waste, float base) {
 		HazardSystem.register(new ItemStack(waste, 1, 0), makeData(RADIATION, base));
-		
+
 		HazardData data = new HazardData();
 		data.addEntry(new HazardEntry(RADIATION, base));
 		data.addEntry(new HazardEntry(HOT, 5F));

--- a/src/main/java/com/hbm/hazard/HazardRegistry.java
+++ b/src/main/java/com/hbm/hazard/HazardRegistry.java
@@ -16,13 +16,10 @@ import com.hbm.items.machine.ItemBreedingRod.BreedingRodType;
 import com.hbm.items.machine.ItemPWRFuel.EnumPWRFuel;
 import com.hbm.items.machine.ItemRTGPelletDepleted.DepletedRTGMaterial;
 import com.hbm.items.machine.ItemWatzPellet.EnumWatzType;
-import com.hbm.items.machine.ItemZirnoxRod.EnumZirnoxType;
 import com.hbm.items.special.ItemHolotapeImage.EnumHoloImage;
 import com.hbm.util.Compat;
 import com.hbm.util.Compat.ReikaIsotope;
 
-import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
@@ -155,8 +152,9 @@ public class HazardRegistry {
 	public static final HazardTypeBase HYDROACTIVE = new HazardTypeHydroactive();
 	public static final HazardTypeBase EXPLOSIVE = new HazardTypeExplosive();
 
+	private static final HazardBuilder builder = new HazardBuilder();
+
 	public static void registerItems() {
-		HazardBuilder builder = new HazardBuilder();
 		builder.initialize();
 
 		HazardSystem.register(rod_zirnox_natural_uranium_fuel_depleted, makeData(RADIATION, wst * rod_dual * 11.5F));
@@ -454,7 +452,6 @@ public class HazardRegistry {
 	}
 
 	public static void initialize(){
-		HazardBuilder builder = new HazardBuilder();
 		builder.initialize();
 	}
 

--- a/src/main/java/com/hbm/hazard/HazardRegistry.java
+++ b/src/main/java/com/hbm/hazard/HazardRegistry.java
@@ -156,87 +156,8 @@ public class HazardRegistry {
 	public static final HazardTypeBase EXPLOSIVE = new HazardTypeExplosive();
 
 	public static void registerItems() {
-
-		HazardSystem.register(Items.gunpowder, makeData(EXPLOSIVE, 1F));
-		HazardSystem.register(Blocks.tnt, makeData(EXPLOSIVE, 4F));
-		HazardSystem.register(Items.pumpkin_pie, makeData(EXPLOSIVE, 1F));
-
-		HazardSystem.register(ball_dynamite, makeData(EXPLOSIVE, 2F));
-		HazardSystem.register(stick_dynamite, makeData(EXPLOSIVE, 1F));
-		HazardSystem.register(stick_tnt, makeData(EXPLOSIVE, 1.5F));
-		HazardSystem.register(stick_semtex, makeData(EXPLOSIVE, 2.5F));
-		HazardSystem.register(stick_c4, makeData(EXPLOSIVE, 2.5F));
-
-		HazardSystem.register(cordite, makeData(EXPLOSIVE, 2F));
-		HazardSystem.register(ballistite, makeData(EXPLOSIVE, 1F));
-
-		// Register all coal dust items
 		HazardBuilder builder = new HazardBuilder();
 		builder.initialize();
-
-		HazardSystem.register(insert_polonium, makeData(RADIATION, 100F));
-
-		HazardSystem.register(demon_core_open, makeData(RADIATION, 5F));
-		HazardSystem.register(demon_core_closed, makeData(RADIATION, 100_000F));
-		HazardSystem.register(lamp_demon, makeData(RADIATION, 100_000F));
-
-		HazardSystem.register(cell_tritium, makeData(RADIATION, 0.001F));
-		HazardSystem.register(cell_sas3, makeData().addEntry(RADIATION, sas3).addEntry(BLINDING, 60F));
-		HazardSystem.register(cell_balefire, makeData(RADIATION, 50F));
-		HazardSystem.register(powder_balefire, makeData(RADIATION, 500F));
-		HazardSystem.register(egg_balefire_shard, makeData(RADIATION, bf * nugget));
-		HazardSystem.register(egg_balefire, makeData(RADIATION, bf * ingot));
-
-		HazardSystem.register(solid_fuel_bf, makeData(RADIATION, 1000)); //roughly the amount of the balefire shard diluted in 250mB of rocket fuel
-		HazardSystem.register(solid_fuel_presto_bf, makeData(RADIATION, 2000));
-		HazardSystem.register(solid_fuel_presto_triplet_bf, makeData(RADIATION, 6000));
-
-		HazardSystem.register(nuclear_waste_long, makeData(RADIATION, 5F));
-		HazardSystem.register(nuclear_waste_long_tiny, makeData(RADIATION, 0.5F));
-		HazardSystem.register(nuclear_waste_short, makeData().addEntry(RADIATION, 30F).addEntry(HOT, 5F));
-		HazardSystem.register(nuclear_waste_short_tiny, makeData().addEntry(RADIATION, 3F).addEntry(HOT, 5F));
-		HazardSystem.register(nuclear_waste_long_depleted, makeData(RADIATION, 0.5F));
-		HazardSystem.register(nuclear_waste_long_depleted_tiny, makeData(RADIATION, 0.05F));
-		HazardSystem.register(nuclear_waste_short_depleted, makeData(RADIATION, 3F));
-		HazardSystem.register(nuclear_waste_short_depleted_tiny, makeData(RADIATION, 0.3F));
-
-		HazardSystem.register(scrap_nuclear, makeData(RADIATION, 1F));
-		HazardSystem.register(trinitite, makeData(RADIATION, trn * ingot));
-		HazardSystem.register(block_trinitite, makeData(RADIATION, trn * block));
-		HazardSystem.register(nuclear_waste, makeData(RADIATION, wst * ingot));
-		HazardSystem.register(yellow_barrel, makeData(RADIATION, wst * ingot * 10));
-		HazardSystem.register(billet_nuclear_waste, makeData(RADIATION, wst * billet));
-		HazardSystem.register(nuclear_waste_tiny, makeData(RADIATION, wst * nugget));
-		HazardSystem.register(nuclear_waste_vitrified, makeData(RADIATION, wstv * ingot));
-		HazardSystem.register(nuclear_waste_vitrified_tiny, makeData(RADIATION, wstv * nugget));
-		HazardSystem.register(block_waste, makeData(RADIATION, wst * block));
-		HazardSystem.register(block_waste_painted, makeData(RADIATION, wst * block));
-		HazardSystem.register(block_waste_vitrified, makeData(RADIATION, wstv * block));
-		HazardSystem.register(ancient_scrap, makeData(RADIATION, 150F));
-		HazardSystem.register(block_corium, makeData(RADIATION, 150F));
-		HazardSystem.register(block_corium_cobble, makeData(RADIATION, 150F));
-
-		HazardSystem.register(new ItemStack(ModBlocks.sellafield, 1, 0), makeData(RADIATION, 0.5F));
-		HazardSystem.register(new ItemStack(ModBlocks.sellafield, 1, 1), makeData(RADIATION, 1F));
-		HazardSystem.register(new ItemStack(ModBlocks.sellafield, 1, 2), makeData(RADIATION, 2.5F));
-		HazardSystem.register(new ItemStack(ModBlocks.sellafield, 1, 3), makeData(RADIATION, 4F));
-		HazardSystem.register(new ItemStack(ModBlocks.sellafield, 1, 4), makeData(RADIATION, 5F));
-		HazardSystem.register(new ItemStack(ModBlocks.sellafield, 1, 5), makeData(RADIATION, 10F));
-
-		HazardSystem.register(new ItemStack(ModBlocks.ore_sellafield_radgem), makeData(RADIATION, 25F));
-		HazardSystem.register(new ItemStack(ModItems.gem_rad), makeData(RADIATION, 25F));
-
-		registerOtherFuel(rod_zirnox, EnumZirnoxType.NATURAL_URANIUM_FUEL.ordinal(), u * rod_dual, wst * rod_dual * 11.5F, false);
-		registerOtherFuel(rod_zirnox, EnumZirnoxType.URANIUM_FUEL.ordinal(), uf * rod_dual, wst * rod_dual * 10F, false);
-		registerOtherFuel(rod_zirnox, EnumZirnoxType.TH232.ordinal(), th232 * rod_dual, thf * rod_dual, false);
-		registerOtherFuel(rod_zirnox, EnumZirnoxType.THORIUM_FUEL.ordinal(), thf * rod_dual, wst * rod_dual * 7.5F, false);
-		registerOtherFuel(rod_zirnox, EnumZirnoxType.MOX_FUEL.ordinal(), mox * rod_dual, wst * rod_dual * 10F, false);
-		registerOtherFuel(rod_zirnox, EnumZirnoxType.PLUTONIUM_FUEL.ordinal(), puf * rod_dual, wst * rod_dual * 12.5F, false);
-		registerOtherFuel(rod_zirnox, EnumZirnoxType.U233_FUEL.ordinal(), u233 * rod_dual, wst * rod_dual * 10F, false);
-		registerOtherFuel(rod_zirnox, EnumZirnoxType.U235_FUEL.ordinal(), u235 * rod_dual, wst * rod_dual * 11F, false);
-		registerOtherFuel(rod_zirnox, EnumZirnoxType.LES_FUEL.ordinal(), saf * rod_dual, wst * rod_dual * 15F, false);
-		registerOtherFuel(rod_zirnox, EnumZirnoxType.LITHIUM.ordinal(), 0, 0.001F * rod_dual, false);
-		registerOtherFuel(rod_zirnox, EnumZirnoxType.ZFB_MOX.ordinal(), mox * rod_dual, wst * rod_dual * 5F, false);
 
 		HazardSystem.register(rod_zirnox_natural_uranium_fuel_depleted, makeData(RADIATION, wst * rod_dual * 11.5F));
 		HazardSystem.register(rod_zirnox_uranium_fuel_depleted, makeData(RADIATION, wst * rod_dual * 10F));
@@ -530,6 +451,11 @@ public class HazardRegistry {
 				}
 			}
 		}
+	}
+
+	public static void initialize(){
+		HazardBuilder builder = new HazardBuilder();
+		builder.initialize();
 	}
 
 	public static void registerTrafos() {

--- a/src/main/java/com/hbm/hazard/modifier/HazardModifierFuelRadiation.java
+++ b/src/main/java/com/hbm/hazard/modifier/HazardModifierFuelRadiation.java
@@ -4,18 +4,22 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class HazardModifierFuelRadiation extends HazardModifier {
-	
+
 float target;
-	
+
 	public HazardModifierFuelRadiation(float target) {
 		this.target = target;
+	}
+
+	public float getTarget(){
+		return target;
 	}
 
 	@Override
 	public float modify(ItemStack stack, EntityLivingBase holder, float level) {
 		double depletion = Math.pow(stack.getItem().getDurabilityForDisplay(stack), 0.4D);
 		level = (float) (level + (this.target - level) * depletion);
-		
+
 		return level;
 	}
 }

--- a/src/main/java/com/hbm/hazard/modifier/HazardModifierRBMKRadiation.java
+++ b/src/main/java/com/hbm/hazard/modifier/HazardModifierRBMKRadiation.java
@@ -8,37 +8,45 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class HazardModifierRBMKRadiation extends HazardModifier {
-	
+
 	float target;
 	boolean linear = false;
-	
+
 	public HazardModifierRBMKRadiation(float target, boolean linear) {
 		this.target = target;
 		this.linear = linear;
 	}
 
+	public float getTarget(){
+		return target;
+	}
+
+	public boolean isLinear(){
+		return linear;
+	}
+
 	@Override
 	public float modify(ItemStack stack, EntityLivingBase holder, float level) {
-		
+
 		if(stack.getItem() instanceof ItemRBMKRod) {
 			//Due to short-lived fission products, radioactivity rises quicker than depletion when applicable
 			double depletion = linear ? 1D - ItemRBMKRod.getEnrichment(stack) : 1D - Math.pow(ItemRBMKRod.getEnrichment(stack), 2);
 			double xenon = ItemRBMKRod.getPoisonLevel(stack);
-			
+
 			level = (float) (level + (this.target - level) * depletion);
 			level += HazardRegistry.xe135 * xenon;
-			
+
 		} else if(stack.getItem() instanceof ItemRBMKPellet) {
-			
+
 			//double depletion = linear ? (ItemRBMKPellet.rectify(stack.getItemDamage()) % 5) / 4F : 1 - Math.pow((4 - ItemRBMKPellet.rectify(stack.getItemDamage()) % 5) / 4F, 2);
-			
+
 			level = level + (target - level) * ((ItemRBMKPellet.rectify(stack.getItemDamage()) % 5) / 4F);
-			
+
 			if(ItemRBMKPellet.hasXenon(stack.getItemDamage()))
 				level += HazardRegistry.xe135 * HazardRegistry.nugget;
 		}
-		
-		
+
+
 		return level;
 	}
 

--- a/src/main/java/com/hbm/hazard/modifier/HazardModifierRTGRadiation.java
+++ b/src/main/java/com/hbm/hazard/modifier/HazardModifierRTGRadiation.java
@@ -6,25 +6,29 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class HazardModifierRTGRadiation extends HazardModifier {
-		
+
 	float target;
-			
+
 	public HazardModifierRTGRadiation(float target) {
 			this.target = target;
 	}
 
+	public float getTarget(){
+		return target;
+	}
+
 	@Override
 	public float modify(ItemStack stack, EntityLivingBase holder, float level) {
-				
+
 		if(stack.getItem() instanceof ItemRTGPellet) {
 			ItemRTGPellet fuel = (ItemRTGPellet) stack.getItem();
 			double depletion = fuel.getDurabilityForDisplay(stack);
-					
+
 			level = (float) (level + (this.target - level) * depletion);
-					
+
 		}
-				
+
 		return level;
 	}
-	
+
 }

--- a/src/main/java/com/hbm/main/ModEventHandler.java
+++ b/src/main/java/com/hbm/main/ModEventHandler.java
@@ -1121,8 +1121,32 @@ public class ModEventHandler {
 			event.setExpToDrop(500);
 		}
 
-		if(event.block == Blocks.coal_ore || event.block == Blocks.coal_block || event.block == ModBlocks.ore_lignite) {
+		// Itterate over all blocks in config
+		boolean isCoalBlock = false;
+		for (String itemName : RadiationConfig.coalDustBlocks) {
+			int dataTag = 0;
+			String[] itemNameParts = itemName.split(":");
+			if (itemNameParts.length <= 1) {
+				continue;
+			}
+			if (itemNameParts.length == 3) {
+				try {
+					dataTag = Integer.parseInt(itemNameParts[2]);
+				} catch (NumberFormatException e){}
+			}
 
+			Block coalBlock = Compat.tryLoadBlock(itemNameParts[0], itemNameParts[1]);
+			if (coalBlock == null){
+				continue;
+			}
+
+			if (coalBlock == event.block && dataTag == event.blockMetadata) {
+				isCoalBlock = true;
+				break;
+			}
+		}
+
+		if (isCoalBlock) {
 			for(ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
 
 				int x = event.x + dir.offsetX;


### PR DESCRIPTION
This makes it possible to add other items from other mods to the list of items that gives the "black lung" effect. It also makes it possible to make other blocks than coal and lignite to generate "coal puffs".

This is done by adding a new configuration items in the 16_pollution tab in hbm.cfg, the default values looks like this:
```
# Items that cause the coal dust hazard to apply.
S:POL_09_coalDustHazards <
    hbm:item.powder_coal:0
    hbm:item.powder_lignite:0
 >

# Items that cause the coal hazard to apply, but with a smaller effect than normal coal dust hazard items.
S:POL_10_tinyCoalDustHarzards <
    hbm:item.powder_coal_tiny:0
    hbm:item.powder_lignite_tiny:0
 >

# Blocks that can cause a puff of coal dust to appear.
S:POL_11_coalDustBlocks <
    hbm:tile.ore_lignite:0
    minecraft:coal_ore:0
 >
```
To add new items or blocks you would use this template:
\<modID\>:\<item/blockID\>:\<metadataNr\>

Please let me know if this is the right place to add this and if any changes needs to be made.
This is also created with issue #1781 in mind.