### PR TITLE
common worldgen cascade fixes (improved worldgen performance)

### DIFF
--- a/src/main/java/com/hbm/lib/HbmWorldGen.java
+++ b/src/main/java/com/hbm/lib/HbmWorldGen.java
@@ -576,8 +576,8 @@ public class HbmWorldGen implements IWorldGenerator {
 		}
 
 		if(WorldConfig.meteoriteSpawn > 0 && rand.nextInt(WorldConfig.meteoriteSpawn) == 0) {
-			int x = i + rand.nextInt(16);
-			int z = j + rand.nextInt(16);
+			int x = i + rand.nextInt(16) + 8;
+			int z = j + rand.nextInt(16) + 8;
 			int y = world.getHeightValue(x, z) - rand.nextInt(10);
 			if(y > 1) (new Meteorite()).generate(world, rand, x, y, z, false, false, false);
 		}

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityCharger.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityCharger.java
@@ -130,7 +130,7 @@ public class TileEntityCharger extends TileEntityLoadedBase implements IEnergyRe
 					IBatteryItem battery = (IBatteryItem) stack.getItem();
 
 					long toCharge = Math.min(battery.getMaxCharge(stack) - battery.getCharge(stack), battery.getChargeRate());
-					toCharge = Math.min(toCharge, power / 5);
+					toCharge = Math.min(toCharge, Math.max(power / 5, 1));
 					battery.chargeBattery(stack, toCharge);
 					power -= toCharge;
 

--- a/src/main/java/com/hbm/world/generator/DungeonToolbox.java
+++ b/src/main/java/com/hbm/world/generator/DungeonToolbox.java
@@ -13,12 +13,12 @@ import net.minecraft.world.gen.feature.WorldGenFlowers;
 import net.minecraft.world.gen.feature.WorldGenMinable;
 
 public class DungeonToolbox {
-	
+
 	public static void generateBox(World world, int x, int y, int z, int sx, int sy, int sz, List<MetaBlock> blocks) {
-		
+
 		if(blocks.isEmpty())
 			return;
-		
+
 		for(int i = x; i < x + sx; i++) {
 			for(int j = y; j < y + sy; j++) {
 				for(int k = z; k < z + sz; k++) {
@@ -28,68 +28,68 @@ public class DungeonToolbox {
 			}
 		}
 	}
-	
+
 	public static void generateBox(World world, int x, int y, int z, int sx, int sy, int sz, Block block) {
 		generateBox(world, x, y, z, sx, sy, sz, new MetaBlock(block));
 	}
 
 	//i know it's copy paste, but it's a better strat than using a wrapper and generating single-entry lists for no good reason
 	public static void generateBox(World world, int x, int y, int z, int sx, int sy, int sz, MetaBlock block) {
-		
+
 		for(int i = x; i < x + sx; i++) {
-			
+
 			for(int j = y; j < y + sy; j++) {
-				
+
 				for(int k = z; k < z + sz; k++) {
-					
+
 					world.setBlock(i, j, k, block.block, block.meta, 2);
 				}
 			}
 		}
 	}
-	
+
 	//now with vectors to provide handy rotations
 	public static void generateBox(World world, int x, int y, int z, Vec3 size, List<MetaBlock> blocks) {
-		
+
 		generateBox(world, x, y, z, (int)size.xCoord, (int)size.yCoord, (int)size.zCoord, blocks);
 	}
-	
+
 	public static <T> T getRandom(List<T> list, Random rand) {
-		
+
 		if(list.isEmpty())
 			return null;
 
 		return list.get(rand.nextInt(list.size()));
 	}
-	
+
 	public static void generateOre(World world, Random rand, int chunkX, int chunkZ, int veinCount, int amount, int minHeight, int variance, Block ore) {
 		generateOre(world, rand, chunkX, chunkZ, veinCount, amount, minHeight, variance, ore, 0, Blocks.stone);
 	}
-	
+
 	public static void generateOre(World world, Random rand, int chunkX, int chunkZ, int veinCount, int amount, int minHeight, int variance, Block ore, int meta) {
 		generateOre(world, rand, chunkX, chunkZ, veinCount, amount, minHeight, variance, ore, meta, Blocks.stone);
 	}
-	
+
 	public static void generateOre(World world, Random rand, int chunkX, int chunkZ, int veinCount, int amount, int minHeight, int variance, Block ore, Block target) {
 		generateOre(world, rand, chunkX, chunkZ, veinCount, amount, minHeight, variance, ore, 0, target);
 	}
-	
+
 	public static void generateOre(World world, Random rand, int chunkX, int chunkZ, int veinCount, int amount, int minHeight, int variance, Block ore, int meta, Block target) {
-		
+
 		for(int i = 0; i < veinCount; i++) {
-			
+
 			int x = chunkX + rand.nextInt(16);
 			int y = minHeight + (variance > 0 ? rand.nextInt(variance) : 0);
 			int z = chunkZ + rand.nextInt(16);
-	
+
 			(new WorldGenMinable(ore, meta, amount, target)).generate(world, rand, x, y, z);
 		}
 	}
 
 	private static WorldGenFlowers genFlowers = new WorldGenFlowers(null);
 	public static void generateFlowers(World world, Random rand, int chunkX, int chunkZ, Block flower, int meta) {
-		int x = chunkX + rand.nextInt(16);
-		int z = chunkZ + rand.nextInt(16);
+		int x = chunkX + rand.nextInt(16) + 8;
+		int z = chunkZ + rand.nextInt(16) + 8;
 		int y = world.getHeightValue(x, z);
 		genFlowers.func_150550_a(flower, meta);
 		genFlowers.generate(world, rand, x, y, z);


### PR DESCRIPTION
Meteorites and flowers (hemp, foxglove, etc) were frequently causing worldgen cascades (verified with ArchaicFix logging). To verify that this fix is valid, I set the spawn frequency of everything affected by the change to 1 per chunk and flew around with murky wings.

Lazzzycat this might help with your "1.7.10 worldgen sucks ball ass" issues a fair bit, and after we remove the remainder of cascades (regular, sand, bedrock oil bubbles, and the remaining old structures), worldgen performance should be considerably closer to vanilla 1.7.10