### PR TITLE
Retain unused progress for the next craft on the blast furnace

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityDiFurnace.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityDiFurnace.java
@@ -203,7 +203,7 @@ public class TileEntityDiFurnace extends TileEntityMachinePolluting implements I
 				progress += extension ? 3 : 1;
 
 				if(this.progress >= TileEntityDiFurnace.processingSpeed) {
-					this.progress = 0;
+					this.progress -= TileEntityDiFurnace.processingSpeed; // look mom, ive finally added something to a popular project
 					this.processItem();
 					markDirty = true;
 				}


### PR DESCRIPTION
fixes some alignment issues when minmaxxing the blast furnace.

in theory speeds it up by 1/1200, but thats mostly because the blast furnace was actually slowed down by 1/1200. regardless, thats a pretty small increase