### PR TITLE
Change Builders Jetpack shift space behavior

### DIFF
--- a/src/main/java/com/hbm/items/armor/JetpackBreak.java
+++ b/src/main/java/com/hbm/items/armor/JetpackBreak.java
@@ -47,7 +47,10 @@ public class JetpackBreak extends JetpackFueledBase {
 
 		if(getFuel(stack) > 0) {
 
-			if(props.isJetpackActive()) {
+			boolean playerTriesToHover = player.isSneaking() && props.isJetpackActive();
+			boolean playerShouldHover = playerTriesToHover || !player.isSneaking();
+
+			if(props.isJetpackActive() && !playerTriesToHover) {
 				player.fallDistance = 0;
 
 				if(player.motionY < 0.4D)
@@ -56,7 +59,7 @@ public class JetpackBreak extends JetpackFueledBase {
 				world.playSoundEffect(player.posX, player.posY, player.posZ, "hbm:weapon.flamethrowerShoot", 0.25F, 1.5F);
 				this.useUpFuel(player, stack, 5);
 
-			} else if(!player.isSneaking() && !player.onGround && props.enableBackpack) {
+			} else if(playerShouldHover && !player.onGround && props.enableBackpack) {
 				player.fallDistance = 0;
 
 				if(player.motionY < -1)
@@ -72,7 +75,7 @@ public class JetpackBreak extends JetpackFueledBase {
 				world.playSoundEffect(player.posX, player.posY, player.posZ, "hbm:weapon.flamethrowerShoot", 0.25F, 1.5F);
 				this.useUpFuel(player, stack, 10);
 			}
-			
+
 			ArmorUtil.resetFlightTime(player);
 		}
 	}


### PR DESCRIPTION
Currently, pressing Shift+Space causes the jetpack to ascend, which I believe is unintentional. This change makes that key combination do nothing.

I don't know how to say it better in the NEI tool-tip. If you do please suggest/change that.


https://github.com/user-attachments/assets/a8ebc100-ec73-4431-a5ba-5712de1a909f

https://github.com/user-attachments/assets/721165ab-17ff-4a6b-9218-064f3e7c5f2d


