### PR TITLE
fix crash in Highlands mod due to it using a deprecated biome hook

### DIFF
--- a/src/main/java/com/hbm/lib/HbmWorldGen.java
+++ b/src/main/java/com/hbm/lib/HbmWorldGen.java
@@ -21,6 +21,7 @@ import com.hbm.util.WeightedRandomGeneric;
 import com.hbm.world.dungeon.*;
 import com.hbm.world.feature.*;
 import com.hbm.world.feature.BedrockOre.BedrockOreDefinition;
+import com.hbm.world.gen.MapGenChainloader;
 import com.hbm.world.generator.CellularDungeonFactory;
 import com.hbm.world.generator.DungeonToolbox;
 import cpw.mods.fml.common.IWorldGenerator;
@@ -40,6 +41,11 @@ public class HbmWorldGen implements IWorldGenerator {
 
 	@Override
 	public void generate(Random rand, int chunkX, int chunkZ, World world, IChunkProvider chunkGenerator, IChunkProvider chunkProvider) {
+		// quick fix for bad generators
+		if(world.provider.dimensionId == 0) {
+			MapGenChainloader.repairBadGeneration(world, chunkX, chunkZ);
+		}
+
 		switch (world.provider.dimensionId) {
 		case -1:
 			generateNether(world, rand, chunkX * 16, chunkZ * 16); break;

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityFoundryChannel.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityFoundryChannel.java
@@ -5,10 +5,14 @@ import java.util.Collections;
 import java.util.List;
 
 import com.hbm.blocks.ModBlocks;
+import com.hbm.blocks.machine.FoundryChannel.FoundryNode;
 import com.hbm.inventory.material.MaterialShapes;
-import com.hbm.inventory.material.Mats;
 import com.hbm.inventory.material.Mats.MaterialStack;
-import com.hbm.inventory.material.NTMMaterial;
+import com.hbm.lib.Library;
+import com.hbm.uninos.UniNodespace;
+import com.hbm.uninos.networkproviders.FoundryNetworkProvider;
+import com.hbm.util.fauxpointtwelve.BlockPos;
+import com.hbm.util.fauxpointtwelve.DirPos;
 
 import api.hbm.block.ICrucibleAcceptor;
 import net.minecraft.block.Block;
@@ -18,60 +22,54 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 public class TileEntityFoundryChannel extends TileEntityFoundryBase {
-	
+
 	public int nextUpdate;
 	public int lastFlow = 0;
 
-	protected NTMMaterial neighborType;
-	protected boolean hasCheckedNeighbors;
-	protected int unpropagateTime;
-	
+	protected FoundryNode node;
+
 	@Override
 	public void updateEntity() {
-		
+
 		if(!worldObj.isRemote) {
+			initNode();
 
-			// Initialise before allowing pours, so newly added channels will avoid causing clog feeds
-			if(!hasCheckedNeighbors) {
-				List<TileEntityFoundryChannel> visited = new ArrayList<TileEntityFoundryChannel>();
-				visited.add(this);
-
-				neighborType = checkNeighbors(visited);
-				hasCheckedNeighbors = true;
+			if(this.node.type != null && this.amount == 0) {
+				this.node.type = null;
 			}
-			
+
 			if(this.type == null && this.amount != 0) {
 				this.amount = 0;
 			}
-			
+
 			nextUpdate--;
-			
+
 			if(nextUpdate <= 0 && this.amount > 0 && this.type != null) {
-				
+
 				boolean hasOp = false;
 				nextUpdate = 5;
-				
+
 				List<Integer> ints = new ArrayList<Integer>() {{ add(2); add(3); add(4); add(5); }};
 				Collections.shuffle(ints);
 				if(lastFlow > 0) {
 					ints.remove((Integer) this.lastFlow);
 					ints.add(this.lastFlow);
 				}
-				
+
 				for(Integer i : ints) {
 					ForgeDirection dir = ForgeDirection.getOrientation(i);
 					Block b = worldObj.getBlock(xCoord + dir.offsetX, yCoord, zCoord + dir.offsetZ);
-					
+
 					if(b instanceof ICrucibleAcceptor && b != ModBlocks.foundry_channel) {
 						ICrucibleAcceptor acc = (ICrucibleAcceptor) b;
-						
+
 						if(acc.canAcceptPartialFlow(worldObj, xCoord + dir.offsetX, yCoord, zCoord + dir.offsetZ, dir.getOpposite(), new MaterialStack(this.type, this.amount))) {
 							MaterialStack left = acc.flow(worldObj, xCoord + dir.offsetX, yCoord, zCoord + dir.offsetZ, dir.getOpposite(), new MaterialStack(this.type, this.amount));
 							if(left == null) {
 								this.type = null;
 								this.amount = 0;
 
-								propagateMaterial(null);
+								this.node.type = null;
 							} else {
 								this.amount = left.amount;
 							}
@@ -80,31 +78,33 @@ public class TileEntityFoundryChannel extends TileEntityFoundryBase {
 						}
 					}
 				}
-				
+
 				if(!hasOp) {
 					for(Integer i : ints) {
 						ForgeDirection dir = ForgeDirection.getOrientation(i);
 						TileEntity b = worldObj.getTileEntity(xCoord + dir.offsetX, yCoord, zCoord + dir.offsetZ);
-						
+
 						if(b instanceof TileEntityFoundryChannel) {
 							TileEntityFoundryChannel acc = (TileEntityFoundryChannel) b;
-							
+
 							if(acc.type == null || acc.type == this.type || acc.amount == 0) {
 								acc.type = this.type;
-								
+								acc.initNode();
+								acc.node.type = this.type;
+
 								acc.lastFlow = dir.getOpposite().ordinal();
-								
+
 								if(worldObj.rand.nextInt(5) == 0 || this.amount == 1) { //force swap operations with single quanta to keep them moving
 									//1:4 chance that the fill states are simply swapped
 									//this promotes faster spreading and prevents spread limits
 									int buf = this.amount;
 									this.amount = acc.amount;
 									acc.amount = buf;
-									
+
 								} else {
 									//otherwise, equalize the neighbors
 									int diff = this.amount - acc.amount;
-									
+
 									if(diff > 0) {
 										diff /= 2;
 										this.amount -= diff;
@@ -117,22 +117,26 @@ public class TileEntityFoundryChannel extends TileEntityFoundryBase {
 				}
 			}
 
-			if(neighborType != null && amount == 0) unpropagateTime++;
-
-			// every 5 seconds do a unprop test, will only occur once per contiguous channel per 5 seconds due to the timer getting updated in all channels from the prop
-			if(unpropagateTime > 100) {
-				propagateMaterial(null);
-			}
-			
 			if(this.amount == 0) {
 				this.lastFlow = 0;
 				this.nextUpdate = 5;
-			} else {
-				unpropagateTime = 0;
 			}
 		}
-		
+
 		super.updateEntity();
+	}
+
+	protected void initNode() {
+		if(this.node == null || this.node.expired) {
+
+			this.node = (FoundryNode) UniNodespace.getNode(worldObj, xCoord, yCoord, zCoord, FoundryNetworkProvider.THE_PROVIDER);
+
+			if(this.node == null || this.node.expired) {
+				this.node = this.createNode();
+				this.node.type = this.type;
+				UniNodespace.createNode(worldObj, this.node);
+			}
+		}
 	}
 
 	@Override
@@ -144,95 +148,58 @@ public class TileEntityFoundryChannel extends TileEntityFoundryBase {
 	public void readFromNBT(NBTTagCompound nbt) {
 		super.readFromNBT(nbt);
 		this.lastFlow = nbt.getByte("flow");
-		this.neighborType = Mats.matById.get(nbt.getInteger("nType"));
-		this.hasCheckedNeighbors = nbt.getBoolean("init");
 	}
 
 	@Override
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
 		nbt.setByte("flow", (byte) this.lastFlow);
-		nbt.setInteger("nType", this.neighborType != null ? this.neighborType.id : -1);
-		nbt.setBoolean("init", hasCheckedNeighbors);
 	}
 
-	/**
-	 * Channels accept pouring as normal, except when neighbor channels already have material.
-	 * This prevents a contiguous channel from having multiple different types of material in it, causing clogs.
-	 * If you connect two channels that have different materials already in them, god help you (nah jokes it'll just be clogged until you fix manually)
-	 */
+	@Override
+	public void invalidate() {
+		super.invalidate();
+
+		if(!worldObj.isRemote) {
+			if(this.node != null) {
+				UniNodespace.destroyNode(worldObj, xCoord, yCoord, zCoord, FoundryNetworkProvider.THE_PROVIDER);
+			}
+		}
+	}
+
+	public FoundryNode createNode() {
+		TileEntity tile = (TileEntity) this;
+		return new FoundryNode(FoundryNetworkProvider.THE_PROVIDER, new BlockPos(tile.xCoord, tile.yCoord, tile.zCoord)).setConnections(
+			new DirPos(tile.xCoord + 1, tile.yCoord, tile.zCoord, Library.POS_X),
+			new DirPos(tile.xCoord - 1, tile.yCoord, tile.zCoord, Library.NEG_X),
+			new DirPos(tile.xCoord, tile.yCoord, tile.zCoord + 1, Library.POS_Z),
+			new DirPos(tile.xCoord, tile.yCoord, tile.zCoord - 1, Library.NEG_Z)
+		);
+	}
+
 	@Override
 	public boolean canAcceptPartialPour(World world, int x, int y, int z, double dX, double dY, double dZ, ForgeDirection side, MaterialStack stack) {
-		if(!hasCheckedNeighbors || (neighborType != null && neighborType != stack.material)) return false;
+		if(this.node == null) return false;
+		for(Object o : this.node.net.links) {
+			FoundryNode node = (FoundryNode) o;
+			if(node.type != null && node.type != stack.material) {
+				return false;
+			}
+		}
+
 		return super.canAcceptPartialPour(world, x, y, z, dX, dY, dZ, side, stack);
 	}
 
-	/** Upon pouring, propagate the current material type along contiguous channels */
+	@Override
+	public MaterialStack flow(World world, int x, int y, int z, ForgeDirection side, MaterialStack stack) {
+		if(this.node != null) this.node.type = stack.material;
+		return super.flow(world, x, y, z, side, stack);
+	}
+
 	@Override
 	public MaterialStack pour(World world, int x, int y, int z, double dX, double dY, double dZ, ForgeDirection side, MaterialStack stack) {
-		propagateMaterial(stack.material);
+		if(this.node != null) this.node.type = stack.material;
 		return super.pour(world, x, y, z, dX, dY, dZ, side, stack);
-	}
-
-	public void propagateMaterial(NTMMaterial propType) {
-		if(propType != null && neighborType != null) return; // optimise away any pours that change nothing
-
-		List<TileEntityFoundryChannel> visited = new ArrayList<TileEntityFoundryChannel>();
-		visited.add(this);
-
-		boolean hasMaterial = propagateMaterial(propType, visited, false);
-
-		// since we are now fully clear, it's safe to unassign the contiguous channel type
-		if(propType == null && !hasMaterial) {
-			for(TileEntityFoundryChannel acc : visited) {
-				acc.neighborType = null;
-			}
-		}
-	}
-
-	protected boolean propagateMaterial(NTMMaterial propType, List<TileEntityFoundryChannel> visited, boolean hasMaterial) {
-		// if emptying, don't mark the channel as ready for a new material until it is entirely clear
-		if(propType != null) {
-			neighborType = propType;
-		} else {
-			// and when empty testing, update the last unpropagate time
-			unpropagateTime = 0;
-		}
-
-		for(ForgeDirection dir : new ForgeDirection[] { ForgeDirection.NORTH, ForgeDirection.SOUTH, ForgeDirection.WEST, ForgeDirection.EAST }) {
-			TileEntity b = worldObj.getTileEntity(xCoord + dir.offsetX, yCoord, zCoord + dir.offsetZ);
-					
-			if(b instanceof TileEntityFoundryChannel && !visited.contains(b)) {
-				TileEntityFoundryChannel acc = (TileEntityFoundryChannel) b;
-				visited.add(acc);
-
-				if(acc.amount > 0) hasMaterial = true;
-
-				hasMaterial = acc.propagateMaterial(propType, visited, hasMaterial);
-			}
-		}
-
-		return hasMaterial;
-	}
-
-	protected NTMMaterial checkNeighbors(List<TileEntityFoundryChannel> visited) {
-		if(neighborType != null) return neighborType;
-
-		for(ForgeDirection dir : new ForgeDirection[] { ForgeDirection.NORTH, ForgeDirection.SOUTH, ForgeDirection.WEST, ForgeDirection.EAST }) {
-			TileEntity b = worldObj.getTileEntity(xCoord + dir.offsetX, yCoord, zCoord + dir.offsetZ);
-			
-			if(b instanceof TileEntityFoundryChannel && !visited.contains(b)) {
-				TileEntityFoundryChannel acc = (TileEntityFoundryChannel) b;
-				visited.add(acc);
-
-				NTMMaterial neighborMaterial = acc.checkNeighbors(visited);
-
-				// immediately propagate backwards if a material is found
-				if(neighborMaterial != null) return neighborMaterial;
-			}
-		}
-
-		return null;
 	}
 
 }

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineArcFurnaceLarge.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineArcFurnaceLarge.java
@@ -113,8 +113,8 @@ public class TileEntityMachineArcFurnaceLarge extends TileEntityMachineBase impl
 			this.isProgressing = false;
 
 			for(DirPos pos : getConPos()) this.trySubscribe(worldObj, pos.getX(), pos.getY(), pos.getZ(), pos.getDir());
-			
-			if(lid == 1) loadIngredients();
+
+			if(lid > 0) loadIngredients();
 
 			if(power > 0) {
 
@@ -269,17 +269,17 @@ public class TileEntityMachineArcFurnaceLarge extends TileEntityMachineBase impl
 			}
 		}
 	}
-	
+
 	/** Moves items from the input queue to the main grid */
 	public void loadIngredients() {
-		
+
 		boolean markDirty = false;
-		
+
 		for(int q /* queue */ = 25; q < 30; q++) {
 			if(slots[q] == null) continue;
 			ArcFurnaceRecipe recipe = ArcFurnaceRecipes.getOutput(slots[q], this.liquidMode);
 			if(recipe == null) continue;
-			
+
 			// add to existing stacks
 			for(int i /* ingredient */ = 5; i < 25; i++) {
 				if(slots[i] == null) continue;
@@ -293,7 +293,7 @@ public class TileEntityMachineArcFurnaceLarge extends TileEntityMachineBase impl
 				}
 				if(slots[q] == null) break;
 			}
-			
+
 			// add to empty slot
 			if(slots[q] != null) for(int i /* ingredient */ = 5; i < 25; i++) {
 				if(slots[i] != null) continue;
@@ -306,7 +306,7 @@ public class TileEntityMachineArcFurnaceLarge extends TileEntityMachineBase impl
 				if(slots[q] == null) break;
 			}
 		}
-		
+
 		if(markDirty) this.markDirty();
 	}
 

--- a/src/main/java/com/hbm/uninos/networkproviders/FoundryNetwork.java
+++ b/src/main/java/com/hbm/uninos/networkproviders/FoundryNetwork.java
@@ -1,0 +1,10 @@
+package com.hbm.uninos.networkproviders;
+
+import com.hbm.uninos.NodeNet;
+
+public class FoundryNetwork extends NodeNet {
+
+	@Override
+	public void update() { }
+
+}

--- a/src/main/java/com/hbm/uninos/networkproviders/FoundryNetworkProvider.java
+++ b/src/main/java/com/hbm/uninos/networkproviders/FoundryNetworkProvider.java
@@ -1,0 +1,14 @@
+package com.hbm.uninos.networkproviders;
+
+import com.hbm.uninos.INetworkProvider;
+
+public class FoundryNetworkProvider implements INetworkProvider<FoundryNetwork> {
+
+	public static FoundryNetworkProvider THE_PROVIDER = new FoundryNetworkProvider();
+
+	@Override
+	public FoundryNetwork provideNetwork() {
+		return new FoundryNetwork();
+	}
+
+}

--- a/src/main/java/com/hbm/world/gen/terrain/MapGenBubble.java
+++ b/src/main/java/com/hbm/world/gen/terrain/MapGenBubble.java
@@ -53,7 +53,7 @@ public class MapGenBubble extends MapGenBase {
 			double radiusSqr = (radius * radius) / 2; // original OilBubble implementation divided the square by 2 for some reason
 
 			int yMin = Math.max(1, MathHelper.floor_double(yCoord - radius));
-			int yMax = MathHelper.ceiling_double_int(yCoord + radius);
+			int yMax = Math.min(127, MathHelper.ceiling_double_int(yCoord + radius));
 
 			for(int bx = 15; bx >= 0; bx--) // bx, bz is the coordinate of the block we're modifying, relative to the generating chunk origin
 			for(int bz = 15; bz >= 0; bz--)


### PR DESCRIPTION
The [Highlands](https://www.curseforge.com/minecraft/mc-mods/highlands) mod crashes with the new cascadeless bedrock oil generation due to it using a deprecated forge hook that doesn't include block metas; this PR fixes that issue.

Bonus:
* Update foundry channels to nodespace, which should make large channels perform much better
* Arc furnace now continues to shift items from input slots while the lid is closing, so it can now fill with more than just one stack if inputting while it is idle