### PR TITLE
OC compat for new fusion reactor and particle accelerator

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/albion/TileEntityPADipole.java
+++ b/src/main/java/com/hbm/tileentity/machine/albion/TileEntityPADipole.java
@@ -268,6 +268,21 @@ public class TileEntityPADipole extends TileEntityCooledBase implements IGUIProv
 
 	@Callback(direct = true)
 	@Optional.Method(modid = "OpenComputers")
+	public Object[] getEnergyInfo(Context context, Arguments args) {
+		return new Object[] {getPower(), getMaxPower()};
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getCoolant(Context context, Arguments args) {
+		return new Object[] {
+			coolantTanks[0].getFill(), coolantTanks[0].getMaxFill(),
+			coolantTanks[1].getFill(), coolantTanks[1].getMaxFill(),
+		};
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
 	public Object[] getDirLower(Context context, Arguments args) {
 		return new Object[] {dirToName(dirLower)};
 	}
@@ -321,10 +336,25 @@ public class TileEntityPADipole extends TileEntityCooledBase implements IGUIProv
 		return new Object[] {};
 	}
 
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getInfo(Context context, Arguments args) {
+		return new Object[] {
+			getPower(), getMaxPower(),
+
+			coolantTanks[0].getFill(), coolantTanks[0].getMaxFill(),
+			coolantTanks[1].getFill(), coolantTanks[1].getMaxFill(),
+
+			dirToName(dirLower), dirToName(dirUpper), dirToName(dirRedstone), threshold
+		};
+	}
+
 	@Override
 	@Optional.Method(modid = "OpenComputers")
 	public String[] methods() {
 		return new String[] {
+			"getEnergyInfo",
+			"getCoolant",
 			"getDirLower",
 			"setDirLower",
 			"getDirUpper",
@@ -333,6 +363,7 @@ public class TileEntityPADipole extends TileEntityCooledBase implements IGUIProv
 			"setDirRedstone",
 			"getThreshold",
 			"setThreshold",
+			"getInfo",
 		};
 	}
 
@@ -340,6 +371,9 @@ public class TileEntityPADipole extends TileEntityCooledBase implements IGUIProv
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] invoke(String method, Context context, Arguments args) throws Exception {
 		switch (method) {
+			case "getEnergyInfo": return getEnergyInfo(context, args);
+			case "getCoolant": return getCoolant(context, args);
+
 			case "getDirLower": return getDirLower(context, args);
 			case "setDirLower": return setDirLower(context, args);
 			case "getDirUpper": return getDirUpper(context, args);
@@ -348,6 +382,8 @@ public class TileEntityPADipole extends TileEntityCooledBase implements IGUIProv
 			case "setDirRedstone": return setDirRedstone(context, args);
 			case "getThreshold": return getThreshold(context, args);
 			case "setThreshold": return setThreshold(context, args);
+
+			case "getInfo": return getInfo(context, args);
 		}
 		throw new NoSuchMethodException();
 	}
@@ -361,7 +397,7 @@ public class TileEntityPADipole extends TileEntityCooledBase implements IGUIProv
 
 	@Override
 	public String runRORFunction(String name, String[] params) {
-		
+
 		if((PREFIX_FUNCTION + "setthreshold").equals(name) && params.length > 0) {
 			this.threshold = IRORInteractive.parseInt(params[0], 0, 999_999_999);
 			this.markChanged();

--- a/src/main/java/com/hbm/tileentity/machine/albion/TileEntityPARFC.java
+++ b/src/main/java/com/hbm/tileentity/machine/albion/TileEntityPARFC.java
@@ -1,5 +1,6 @@
 package com.hbm.tileentity.machine.albion;
 
+import com.hbm.handler.CompatHandler;
 import com.hbm.inventory.container.ContainerPARFC;
 import com.hbm.inventory.gui.GUIPARFC;
 import com.hbm.lib.Library;
@@ -9,20 +10,26 @@ import com.hbm.tileentity.machine.albion.TileEntityPASource.Particle;
 import com.hbm.util.fauxpointtwelve.BlockPos;
 import com.hbm.util.fauxpointtwelve.DirPos;
 
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.SimpleComponent;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class TileEntityPARFC extends TileEntityCooledBase implements IGUIProvider, IParticleUser {
-	
+@Optional.InterfaceList({@Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers")})
+public class TileEntityPARFC extends TileEntityCooledBase implements IGUIProvider, IParticleUser, SimpleComponent, CompatHandler.OCComponent {
+
 	public static final long usage = 250_000;
 	public static final int momentumGain = 100;
 	public static final int defocusGain = 100;
-	
+
 	public TileEntityPARFC() {
 		super(1);
 	}
@@ -49,7 +56,7 @@ public class TileEntityPARFC extends TileEntityCooledBase implements IGUIProvide
 
 		if(!isCool())				particle.crash(PAState.CRASH_NOCOOL);
 		if(this.power < this.usage)	particle.crash(PAState.CRASH_NOPOWER);
-		
+
 		if(particle.invalid) return;
 
 		particle.addDistance(9);
@@ -66,19 +73,19 @@ public class TileEntityPARFC extends TileEntityCooledBase implements IGUIProvide
 
 	@Override
 	public void updateEntity() {
-		
+
 		if(!worldObj.isRemote) {
 			this.power = Library.chargeTEFromItems(slots, 0, power, this.getMaxPower());
 		}
-		
+
 		super.updateEntity();
 	}
-	
+
 	AxisAlignedBB bb = null;
-	
+
 	@Override
 	public AxisAlignedBB getRenderBoundingBox() {
-		
+
 		if(bb == null) {
 			bb = AxisAlignedBB.getBoundingBox(
 					xCoord - 4,
@@ -89,10 +96,10 @@ public class TileEntityPARFC extends TileEntityCooledBase implements IGUIProvide
 					zCoord + 5
 					);
 		}
-		
+
 		return bb;
 	}
-	
+
 	@Override
 	@SideOnly(Side.CLIENT)
 	public double getMaxRenderDistanceSquared() {
@@ -120,5 +127,58 @@ public class TileEntityPARFC extends TileEntityCooledBase implements IGUIProvide
 	@Override
 	public Object provideGUI(int ID, EntityPlayer player, World world, int x, int y, int z) {
 		return new GUIPARFC(player.inventory, this);
+	}
+
+	@Override
+	@Optional.Method(modid = "OpenComputers")
+	public String getComponentName() {
+		return "ntm_pa_rfc";
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getEnergyInfo(Context context, Arguments args) {
+		return new Object[] {getPower(), getMaxPower()};
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getCoolant(Context context, Arguments args) {
+		return new Object[] {
+			coolantTanks[0].getFill(), coolantTanks[0].getMaxFill(),
+			coolantTanks[1].getFill(), coolantTanks[1].getMaxFill(),
+		};
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getInfo(Context context, Arguments args) {
+		return new Object[] {
+			getPower(), getMaxPower(),
+
+			coolantTanks[0].getFill(), coolantTanks[0].getMaxFill(),
+			coolantTanks[1].getFill(), coolantTanks[1].getMaxFill(),
+		};
+	}
+
+	@Override
+	@Optional.Method(modid = "OpenComputers")
+	public String[] methods() {
+		return new String[] {
+			"getEnergyInfo",
+			"getCoolant",
+			"getInfo"
+		};
+	}
+
+	@Override
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] invoke(String method, Context context, Arguments args) throws Exception {
+		switch (method) {
+			case "getEnergyInfo": return getEnergyInfo(context, args);
+			case "getCoolant": return getCoolant(context, args);
+			case "getInfo": return getInfo(context, args);
+		}
+		throw new NoSuchMethodException();
 	}
 }

--- a/src/main/java/com/hbm/tileentity/machine/fusion/TileEntityFusionBreeder.java
+++ b/src/main/java/com/hbm/tileentity/machine/fusion/TileEntityFusionBreeder.java
@@ -1,5 +1,6 @@
 package com.hbm.tileentity.machine.fusion;
 
+import com.hbm.handler.CompatHandler;
 import com.hbm.inventory.FluidStack;
 import com.hbm.inventory.container.ContainerFusionBreeder;
 import com.hbm.inventory.fluid.Fluids;
@@ -18,9 +19,14 @@ import com.hbm.util.fauxpointtwelve.BlockPos;
 import com.hbm.util.fauxpointtwelve.DirPos;
 
 import api.hbm.fluidmk2.IFluidStandardTransceiverMK2;
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.SimpleComponent;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
@@ -29,10 +35,11 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class TileEntityFusionBreeder extends TileEntityMachineBase implements IFluidStandardTransceiverMK2, IFusionPowerReceiver, IGUIProvider {
+@Optional.InterfaceList({@Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers")})
+public class TileEntityFusionBreeder extends TileEntityMachineBase implements IFluidStandardTransceiverMK2, IFusionPowerReceiver, IGUIProvider, SimpleComponent, CompatHandler.OCComponent {
 
 	protected GenNode plasmaNode;
-	
+
 	public FluidTank[] tanks;
 
 	public double neutronEnergy;
@@ -42,7 +49,7 @@ public class TileEntityFusionBreeder extends TileEntityMachineBase implements IF
 
 	public TileEntityFusionBreeder() {
 		super(3);
-		
+
 		tanks = new FluidTank[2];
 		tanks[0] = new FluidTank(Fluids.NONE, 16_000);
 		tanks[1] = new FluidTank(Fluids.NONE, 16_000);
@@ -52,44 +59,44 @@ public class TileEntityFusionBreeder extends TileEntityMachineBase implements IF
 	public String getName() {
 		return "container.fusionBreeder";
 	}
-	
+
 	@Override
 	public void updateEntity() {
-		
+
 		if(!worldObj.isRemote) {
-			
+
 			tanks[0].setType(0, slots);
 
 			if(!canProcessSolid() && !canProcessLiquid()) {
 				this.progress = 0;
 			}
-			
+
 			// because tile updates may happen in any order and the value that needs
 			// to be synced needs to persist until the next tick due to the batched packets
 			this.neutronEnergySync = this.neutronEnergy;
-			
+
 			for(DirPos pos : getConPos()) {
 				if(tanks[0].getTankType() != Fluids.NONE) this.trySubscribe(tanks[0].getTankType(), worldObj, pos);
 				if(tanks[1].getFill() > 0) this.tryProvide(tanks[1], worldObj, pos);
 			}
-			
+
 			if(plasmaNode == null || plasmaNode.expired) {
 				ForgeDirection dir = ForgeDirection.getOrientation(this.getBlockMetadata() - 10).getOpposite();
 				plasmaNode = UniNodespace.getNode(worldObj, xCoord + dir.offsetX * 2, yCoord + 2, zCoord + dir.offsetZ * 2, PlasmaNetworkProvider.THE_PROVIDER);
-				
+
 				if(plasmaNode == null) {
 					plasmaNode = new GenNode(PlasmaNetworkProvider.THE_PROVIDER,
 							new BlockPos(xCoord + dir.offsetX * 2, yCoord + 2, zCoord + dir.offsetZ * 2))
 							.setConnections(new DirPos(xCoord + dir.offsetX * 3, yCoord + 2, zCoord + dir.offsetZ * 3, dir));
-					
+
 					UniNodespace.createNode(worldObj, plasmaNode);
 				}
 			}
-			
+
 			if(plasmaNode != null && plasmaNode.hasValidNet()) plasmaNode.net.addReceiver(this);
-			
+
 			this.networkPackNT(25);
-			
+
 			this.neutronEnergy = 0;
 		}
 	}
@@ -115,17 +122,17 @@ public class TileEntityFusionBreeder extends TileEntityMachineBase implements IF
 	}
 
 	public boolean canProcessLiquid() {
-		
+
 		Pair<Integer, FluidStack> output = FluidBreederRecipes.getOutput(tanks[0].getTankType());
 		if(output == null) return false;
 		if(tanks[0].getFill() < output.getKey()) return false;
-		
+
 		FluidStack fluid = output.getValue();
 
 		if(tanks[1].getTankType() != fluid.type && tanks[1].getFill() > 0) return false;
 		tanks[1].setTankType(fluid.type);
 		if(tanks[1].getFill() + fluid.fill > tanks[1].getMaxFill()) return false;
-		
+
 		return true;
 	}
 
@@ -156,7 +163,7 @@ public class TileEntityFusionBreeder extends TileEntityMachineBase implements IF
 		tanks[0].setFill(tanks[0].getFill() - output.getKey());
 		tanks[1].setFill(tanks[1].getFill() + output.getValue().fill);
 	}
-	
+
 	public void doProgress() {
 
 		if(canProcessSolid()) {
@@ -187,11 +194,11 @@ public class TileEntityFusionBreeder extends TileEntityMachineBase implements IF
 
 	@Override public boolean canExtractItem(int slot, ItemStack itemStack, int side) { return slot == 2; }
 	@Override public int[] getAccessibleSlotsFromSide(int side) { return new int[] {1, 2}; }
-	
+
 	public DirPos[] getConPos() {
 		ForgeDirection dir = ForgeDirection.getOrientation(this.getBlockMetadata() - 10);
 		ForgeDirection rot = dir.getRotation(ForgeDirection.UP);
-		
+
 		return new DirPos[] {
 				new DirPos(xCoord + dir.offsetX * 3, yCoord + 2, zCoord + dir.offsetZ * 3, dir),
 				new DirPos(xCoord + rot.offsetX * 2, yCoord, zCoord + rot.offsetZ * 2, rot),
@@ -215,7 +222,7 @@ public class TileEntityFusionBreeder extends TileEntityMachineBase implements IF
 		super.serialize(buf);
 		buf.writeDouble(neutronEnergySync);
 		buf.writeDouble(progress);
-		
+
 		this.tanks[0].serialize(buf);
 		this.tanks[1].serialize(buf);
 	}
@@ -225,7 +232,7 @@ public class TileEntityFusionBreeder extends TileEntityMachineBase implements IF
 		super.deserialize(buf);
 		this.neutronEnergy = buf.readDouble();
 		this.progress = buf.readDouble();
-		
+
 		this.tanks[0].deserialize(buf);
 		this.tanks[1].deserialize(buf);
 	}
@@ -288,5 +295,112 @@ public class TileEntityFusionBreeder extends TileEntityMachineBase implements IF
 	@SideOnly(Side.CLIENT)
 	public double getMaxRenderDistanceSquared() {
 		return 65536.0D;
+	}
+
+	@Override
+	@Optional.Method(modid = "OpenComputers")
+	public String getComponentName() {
+		return "ntm_fusion_breeder";
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getNeutronEnergy(Context context, Arguments args) {
+		return new Object[] {neutronEnergySync};
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getProgress(Context context, Arguments args) {
+		return new Object[] {progress / capacity};
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getFluid(Context context, Arguments args) {
+		return new Object[] {
+			tanks[0].getFill(), tanks[0].getMaxFill(), tanks[0].getTankType().getUnlocalizedName(),
+			tanks[1].getFill(), tanks[1].getMaxFill(), tanks[1].getTankType().getUnlocalizedName()
+		};
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getCrafting(Context context, Arguments args) {
+		ItemStack input = slots[1];
+		String inputName = "";
+		int inputSize = 0;
+		if (input != null) {
+			inputName = input.getUnlocalizedName();
+			inputSize = input.stackSize;
+		}
+
+		ItemStack output = slots[2];
+		String outputName = "";
+		int outputSize = 0;
+		if (output != null) {
+			outputName = output.getUnlocalizedName();
+			outputSize = output.stackSize;
+		}
+
+		return new Object[] {
+			inputName, inputSize,
+			outputName, outputSize
+		};
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getInfo(Context context, Arguments args) {
+		ItemStack input = slots[1];
+		String inputName = "";
+		int inputSize = 0;
+		if (input != null) {
+			inputName = input.getUnlocalizedName();
+			inputSize = input.stackSize;
+		}
+
+		ItemStack output = slots[2];
+		String outputName = "";
+		int outputSize = 0;
+		if (output != null) {
+			outputName = output.getUnlocalizedName();
+			outputSize = output.stackSize;
+		}
+
+		return new Object[] {
+			neutronEnergySync, progress / capacity,
+
+			tanks[0].getFill(), tanks[0].getMaxFill(), tanks[0].getTankType().getUnlocalizedName(),
+			tanks[1].getFill(), tanks[1].getMaxFill(), tanks[1].getTankType().getUnlocalizedName(),
+
+			inputName, inputSize,
+			outputName, outputSize
+		};
+	}
+
+	@Override
+	@Optional.Method(modid = "OpenComputers")
+	public String[] methods() {
+		return new String[] {
+			"getNeutronEnergy",
+			"getProgress",
+			"getFluid",
+			"getCrafting",
+			"getInfo"
+		};
+	}
+
+	@Override
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] invoke(String method, Context context, Arguments args) throws Exception {
+		switch (method) {
+			case "getNeutronEnergy": return getNeutronEnergy(context, args);
+			case "getProgress": return getProgress(context, args);
+			case "getFluid": return getFluid(context, args);
+			case "getCrafting": return getCrafting(context, args);
+			case "getInfo": return getInfo(context, args);
+		}
+		throw new NoSuchMethodException();
 	}
 }

--- a/src/main/java/com/hbm/tileentity/machine/fusion/TileEntityFusionKlystron.java
+++ b/src/main/java/com/hbm/tileentity/machine/fusion/TileEntityFusionKlystron.java
@@ -2,6 +2,7 @@ package com.hbm.tileentity.machine.fusion;
 
 import java.util.Map.Entry;
 
+import com.hbm.handler.CompatHandler;
 import com.hbm.interfaces.IControlReceiver;
 import com.hbm.inventory.container.ContainerFusionKlystron;
 import com.hbm.inventory.fluid.Fluids;
@@ -21,9 +22,14 @@ import com.hbm.util.fauxpointtwelve.DirPos;
 
 import api.hbm.energymk2.IEnergyReceiverMK2;
 import api.hbm.fluidmk2.IFluidStandardReceiverMK2;
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.SimpleComponent;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
@@ -33,7 +39,8 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class TileEntityFusionKlystron extends TileEntityMachineBase implements IEnergyReceiverMK2, IFluidStandardReceiverMK2, IControlReceiver, IGUIProvider {
+@Optional.InterfaceList({@Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "OpenComputers")})
+public class TileEntityFusionKlystron extends TileEntityMachineBase implements IEnergyReceiverMK2, IFluidStandardReceiverMK2, IControlReceiver, IGUIProvider, SimpleComponent, CompatHandler.OCComponent {
 
 	protected GenNode klystronNode;
 	public static final long MAX_OUTPUT = 1_000_000;
@@ -42,19 +49,19 @@ public class TileEntityFusionKlystron extends TileEntityMachineBase implements I
 	public long output;
 	public long power;
 	public long maxPower;
-	
+
 	public float fan;
 	public float prevFan;
 	public float fanSpeed;
 	public static final float FAN_ACCELERATION = 0.125F;
-	
+
 	public FluidTank compair;
 
 	private AudioWrapper audio;
 
 	public TileEntityFusionKlystron() {
 		super(1);
-		
+
 		compair = new FluidTank(Fluids.AIR, AIR_CONSUMPTION * 60);
 	}
 
@@ -62,62 +69,62 @@ public class TileEntityFusionKlystron extends TileEntityMachineBase implements I
 	public String getName() {
 		return "container.fusionKlystron";
 	}
-	
+
 	@Override
 	public void updateEntity() {
-		
+
 		if(!worldObj.isRemote) {
-			
+
 			this.maxPower = Math.max(1_000_000L, this.outputTarget * 100L);
-			
+
 			this.power = Library.chargeTEFromItems(slots, 0, power, maxPower);
-			
+
 			for(DirPos pos : getConPos()) {
 				this.trySubscribe(worldObj, pos);
 				this.trySubscribe(compair.getTankType(), worldObj, pos);
 			}
-			
+
 			this.output = 0;
-			
+
 			double powerFactor = TileEntityFusionTorus.getSpeedScaled(maxPower, power);
 			double airFactor = TileEntityFusionTorus.getSpeedScaled(compair.getMaxFill(), compair.getFill());
 			double factor = Math.min(powerFactor, airFactor);
 
 			long powerReq = (long) Math.ceil(outputTarget * factor);
 			int airReq = (int) Math.ceil(AIR_CONSUMPTION * factor);
-			
+
 			if(outputTarget > 0 && power >= powerReq && compair.getFill() >= airReq) {
 				this.output = powerReq;
-				
+
 				this.power -= powerReq;
 				this.compair.setFill(this.compair.getFill() - airReq);
 			}
-			
+
 			if(output < outputTarget / 50) output = 0;
-			
+
 			if(klystronNode == null || klystronNode.expired) {
 				ForgeDirection dir = ForgeDirection.getOrientation(this.getBlockMetadata() - 10).getOpposite();
 				klystronNode = UniNodespace.getNode(worldObj, xCoord + dir.offsetX * 4, yCoord + 2, zCoord + dir.offsetZ * 4, KlystronNetworkProvider.THE_PROVIDER);
-				
+
 				if(klystronNode == null) {
 					klystronNode = new GenNode(KlystronNetworkProvider.THE_PROVIDER,
 							new BlockPos(xCoord + dir.offsetX * 4, yCoord + 2, zCoord + dir.offsetZ * 4))
 							.setConnections(new DirPos(xCoord + dir.offsetX * 5, yCoord + 2, zCoord + dir.offsetZ * 5, dir));
-					
+
 					UniNodespace.createNode(worldObj, klystronNode);
 				}
 			}
-			
+
 			if(klystronNode.net != null) klystronNode.net.addProvider(this);
-			
+
 			if(klystronNode != null && klystronNode.net != null) {
 				KlystronNetwork net = (KlystronNetwork) klystronNode.net;
-				
+
 				for(Object o : net.receiverEntries.entrySet()) {
 					Entry e = (Entry) o;
 					if(e.getKey() instanceof TileEntityFusionTorus) { // replace this with an interface should we ever get more acceptors
 						TileEntityFusionTorus torus = (TileEntityFusionTorus) e.getKey();
-						
+
 						if(torus.isLoaded() && !torus.isInvalid()) { // check against zombie network members
 							torus.klystronEnergy += this.output;
 							break; // we only do one anyway
@@ -125,29 +132,29 @@ public class TileEntityFusionKlystron extends TileEntityMachineBase implements I
 					}
 				}
 			}
-			
+
 			this.networkPackNT(100);
-			
+
 		} else {
-			
+
 			double mult = TileEntityFusionTorus.getSpeedScaled(outputTarget, output);
 			if(this.output > 0) this.fanSpeed += FAN_ACCELERATION * mult;
 			else this.fanSpeed -= FAN_ACCELERATION;
-			
+
 			this.fanSpeed = MathHelper.clamp_float(this.fanSpeed, 0F, 5F * (float) mult);
-			
+
 			this.prevFan = this.fan;
 			this.fan += this.fanSpeed;
-			
+
 			if(this.fan >= 360F) {
 				this.fan -= 360F;
 				this.prevFan -= 360F;
 			}
-			
+
 			if(this.fanSpeed > 0 && MainRegistry.proxy.me().getDistanceSq(xCoord + 0.5, yCoord + 2.5, zCoord + 0.5) < 30 * 30) {
-				
+
 				float speed = this.fanSpeed / 5F;
-				
+
 				if(audio == null) {
 					audio = MainRegistry.proxy.getLoopedSound("hbm:block.fel", xCoord + 0.5F, yCoord + 2.5F, zCoord + 0.5F, getVolume(speed), 15F, speed, 20);
 					audio.startSound();
@@ -156,9 +163,9 @@ public class TileEntityFusionKlystron extends TileEntityMachineBase implements I
 					audio.updatePitch(speed);
 					audio.keepAlive();
 				}
-				
+
 			} else {
-				
+
 				if(audio != null) {
 					if(audio.isPlaying()) audio.stopSound();
 					audio = null;
@@ -166,11 +173,11 @@ public class TileEntityFusionKlystron extends TileEntityMachineBase implements I
 			}
 		}
 	}
-	
+
 	public DirPos[] getConPos() {
 		ForgeDirection dir = ForgeDirection.getOrientation(this.getBlockMetadata() - 10);
 		ForgeDirection rot = dir.getRotation(ForgeDirection.UP);
-		
+
 		return new DirPos[] {
 				new DirPos(xCoord + dir.offsetX * 4, yCoord + 2, zCoord + dir.offsetZ * 4, dir),
 				new DirPos(xCoord + rot.offsetX * 3, yCoord, zCoord + rot.offsetZ * 3, rot),
@@ -221,7 +228,7 @@ public class TileEntityFusionKlystron extends TileEntityMachineBase implements I
 		this.output = buf.readLong();
 		this.compair.deserialize(buf);
 	}
-	
+
 	@Override
 	public void readFromNBT(NBTTagCompound nbt) {
 		super.readFromNBT(nbt);
@@ -229,18 +236,18 @@ public class TileEntityFusionKlystron extends TileEntityMachineBase implements I
 		this.power = nbt.getLong("power");
 		this.maxPower = nbt.getLong("maxPower");
 		this.outputTarget = nbt.getLong("outputTarget");
-		
+
 		this.compair.readFromNBT(nbt, "t");
 	}
-	
+
 	@Override
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
-		
+
 		nbt.setLong("power", power);
 		nbt.setLong("maxPower", maxPower);
 		nbt.setLong("outputTarget", outputTarget);
-		
+
 		this.compair.writeToNBT(nbt, "t");
 	}
 
@@ -299,11 +306,77 @@ public class TileEntityFusionKlystron extends TileEntityMachineBase implements I
 
 	@Override
 	public void receiveControl(NBTTagCompound data) {
-		
+
 		if(data.hasKey("amount")) {
 			this.outputTarget = data.getLong("amount");
 			if(this.outputTarget < 0) this.outputTarget = 0;
 			if(this.outputTarget > MAX_OUTPUT) this.outputTarget = MAX_OUTPUT;
 		}
+	}
+
+	@Override
+	@Optional.Method(modid = "OpenComputers")
+	public String getComponentName() {
+		return "ntm_fusion_klystron";
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getEnergyInfo(Context context, Arguments args) {
+		return new Object[] {getPower(), getMaxPower()};
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getAir(Context context, Arguments args) {
+		return new Object[] {compair.getFill(), compair.getMaxFill()};
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getOutput(Context context, Arguments args) {
+		return new Object[] {output, outputTarget};
+	}
+
+	@Callback(direct = true, limit = 4)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] setOutput(Context context, Arguments args) {
+		outputTarget = (long) MathHelper.clamp_double(args.checkDouble(0), 0.0, MAX_OUTPUT);
+		return new Object[] {};
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getInfo(Context context, Arguments args) {
+		return new Object[] {
+			getPower(), getMaxPower(),
+			compair.getFill(), compair.getMaxFill(),
+			output, outputTarget
+		};
+	}
+
+	@Override
+	@Optional.Method(modid = "OpenComputers")
+	public String[] methods() {
+		return new String[] {
+			"getEnergyInfo",
+			"getAir",
+			"getOutput",
+			"setOutput",
+			"getInfo"
+		};
+	}
+
+	@Override
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] invoke(String method, Context context, Arguments args) throws Exception {
+		switch (method) {
+			case "getEnergyInfo": return getEnergyInfo(context, args);
+			case "getAir": return getAir(context, args);
+			case "getOutput": return getOutput(context, args);
+			case "setOutput": return setOutput(context, args);
+			case "getInfo": return getInfo(context, args);
+		}
+		throw new NoSuchMethodException();
 	}
 }


### PR DESCRIPTION
changeeeeees:
- The new fusion reactor has OC compat
  - ``ntm_fusion_torus``, ``ntm_fusion_mhdt``, ``ntm_fusion_klystron``, ``ntm_fusion_boiler`` and ``ntm_fusion_breeder``
- Particle accelerator has more OC compat too
  - ``ntm_pa_dipole`` was modified to have ``getEnergyInfo``, ``getCoolant``, and ``getInfo``
  - otherwise ``ntm_pa_source``, ``ntm_pa_rfc``, ``ntm_pa_quad`` and ``ntm_pa_detector`` now have compat