### PR TITLE
Better electric FSB hud bars

### DIFF
--- a/src/main/java/com/hbm/main/ModEventHandlerClient.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerClient.java
@@ -59,12 +59,15 @@ import com.hbm.tileentity.bomb.TileEntityNukeCustom;
 import com.hbm.tileentity.bomb.TileEntityNukeCustom.CustomNukeEntry;
 import com.hbm.tileentity.bomb.TileEntityNukeCustom.EnumEntryType;
 import com.hbm.util.*;
+import com.hbm.util.Tuple;
 import com.hbm.util.ArmorRegistry.HazardClass;
 import com.hbm.util.i18n.I18nUtil;
 import com.hbm.wiaj.GuiWorldInAJar;
 import com.hbm.wiaj.cannery.CanneryBase;
 import com.hbm.wiaj.cannery.Jars;
 import com.mojang.authlib.minecraft.MinecraftProfileTexture.Type;
+
+import api.hbm.fluidmk2.IFillableItem;
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
@@ -230,7 +233,7 @@ public class ModEventHandlerClient {
 						((ILookOverlay) entity).printHook(event, world, 0, 0, 0);
 					}
 				}
-				
+
 				GL11.glColor4f(1F, 1F, 1F, 1F);
 			}
 
@@ -395,6 +398,24 @@ public class ModEventHandlerClient {
 		}
 	}
 
+	private List<Tuple.Pair<Float, Integer>> getBars(ItemStack stack, EntityPlayer player) {
+
+		List<Tuple.Pair<Float, Integer>> bars = new ArrayList<>();
+
+		if(stack.getItem() instanceof ArmorFSBPowered && ArmorFSBPowered.hasFSBArmorIgnoreCharge(player)) {
+			float charge = 1F - (float) ((ArmorFSBPowered) stack.getItem()).getDurabilityForDisplay(stack);
+			bars.add(new Tuple.Pair<Float, Integer>(charge, 0x00FF00));
+		}
+
+		if(stack.getItem() instanceof JetpackFueledBase) {
+			JetpackFueledBase jetpack = (JetpackFueledBase) stack.getItem();
+			float fuel = (float) JetpackFueledBase.getFuel(stack) / jetpack.maxFuel;
+			bars.add(new Tuple.Pair<Float, Integer>(fuel, jetpack.fuel.getColor()));
+		}
+
+		return bars;
+	}
+
 	@SubscribeEvent(receiveCanceled = true, priority = EventPriority.LOW)
 	public void onHUDRenderBar(RenderGameOverlayEvent.Post event) {
 
@@ -404,6 +425,28 @@ public class ModEventHandlerClient {
 		Tessellator tess = Tessellator.instance;
 
 		if(event.type == event.type.ARMOR) {
+			List<List<Tuple.Pair<Float, Integer>>> barsList = new ArrayList<>();
+
+			for (int i = 0; i < 4; i++) {
+				barsList.add(new ArrayList<>());
+				ItemStack stack = player.inventory.armorInventory[i];
+
+				if(stack == null)
+					continue;
+
+				barsList.get(i).addAll(getBars(stack, player));
+
+				if (!(ArmorModHandler.hasMods(stack)))
+					continue;
+
+				for (ItemStack mod : ArmorModHandler.pryMods(stack)) {
+					if (mod == null) continue;
+					barsList.get(i).addAll(getBars(mod, player));
+				}
+			}
+
+			GL11.glDisable(GL11.GL_TEXTURE_2D);
+			tess.startDrawingQuads();
 
 			if(ForgeHooks.getTotalArmorValue(player) == 0) {
 				GuiIngameForge.left_height -= 10;
@@ -413,69 +456,53 @@ public class ModEventHandlerClient {
 			int height = event.resolution.getScaledHeight();
 			int left = width / 2 - 91;
 
-			if(ArmorFSB.hasFSBArmorIgnoreCharge(player)) {
-				ArmorFSB chestplate = (ArmorFSB) player.inventory.armorInventory[2].getItem();
-				boolean noHelmet = chestplate.noHelmet;
+			for (List<Tuple.Pair<Float, Integer>> bars : barsList) {
+				if (bars.isEmpty())
+					continue;
 
-				GL11.glDisable(GL11.GL_TEXTURE_2D);
-				tess.startDrawingQuads();
+				int top = height - GuiIngameForge.left_height + 7;
 
-				for(int i = 0; i < (noHelmet ? 3 : 4); i++) {
+				for (int i = 0; i < bars.size(); i++) {
+					float val = bars.get(i).key;
 
-					int top = height - GuiIngameForge.left_height + 7;
+					int hstart, hend;
 
-					ItemStack stack = player.inventory.armorInventory[i];
+					if (i == 0) {
+						hstart = left;
+						hend = hstart + (bars.size() == 1 ? 81 : 40);
+					} else {
+						int bl = (int) Math.ceil(40F / (bars.size() - 1));
+						// :(
+						hstart = left + 41 + bl * (i - 1);
+						hend = i == bars.size() - 1 ? left + 81 : hstart + bl;
+						if (i != 1) hstart += 1;
+					}
 
-					if(!(stack != null && stack.getItem() instanceof ArmorFSBPowered))
-						break;
-
-					float tot = 1F - (float) ((ArmorFSBPowered) stack.getItem()).getDurabilityForDisplay(stack);
+					int color = bars.get(i).value;
 
 					tess.setColorOpaque_F(0.25F, 0.25F, 0.25F);
-					tess.addVertex(left - 0.5, top - 0.5, 0);
-					tess.addVertex(left - 0.5, top + 1.5, 0);
-					tess.addVertex(left + 81.5, top + 1.5, 0);
-					tess.addVertex(left + 81.5, top - 0.5, 0);
+					tess.addVertex(hstart, top - 1, 0);
+					tess.addVertex(hstart, top + 2, 0);
+					tess.addVertex(hend, top + 2, 0);
+					tess.addVertex(hend, top - 1, 0);
 
-					tess.setColorOpaque_F(1F - tot, tot, 0F);
-					tess.addVertex(left, top, 0);
-					tess.addVertex(left, top + 1, 0);
-					tess.addVertex(left + 81 * tot, top + 1, 0);
-					tess.addVertex(left + 81 * tot, top, 0);
+					float valx = hstart + (hend - hstart - 1) * val;
 
-					GuiIngameForge.left_height += 3;
+					float r = ((color >> 16) & 0xFF) / 255F;
+					float g = ((color >> 8) & 0xFF) / 255F;
+					float b = (color & 0xFF) / 255F;
+
+					tess.setColorOpaque_F(r, g, b);
+					tess.addVertex(hstart+1, top, 0);
+					tess.addVertex(hstart+1, top + 1, 0);
+					tess.addVertex(valx, top + 1, 0);
+					tess.addVertex(valx, top, 0);
 				}
 
-				tess.draw();
-
-				GL11.glEnable(GL11.GL_TEXTURE_2D);
-
-			} else if(player.inventory.armorInventory[2] != null && player.inventory.armorInventory[2].getItem() instanceof JetpackFueledBase) {
-
-				ItemStack stack = player.inventory.armorInventory[2];
-
-				float tot = (float) ((JetpackFueledBase) stack.getItem()).getFuel(stack) / (float) ((JetpackFueledBase) stack.getItem()).getMaxFill(stack);
-
-				int top = height - GuiIngameForge.left_height + 3;
-
-				GL11.glDisable(GL11.GL_TEXTURE_2D);
-				tess.startDrawingQuads();
-				tess.setColorOpaque_F(0.25F, 0.25F, 0.25F);
-				tess.addVertex(left - 0.5, top - 0.5, 0);
-				tess.addVertex(left - 0.5, top + 4.5, 0);
-				tess.addVertex(left + 81.5, top + 4.5, 0);
-				tess.addVertex(left + 81.5, top - 0.5, 0);
-
-				tess.setColorOpaque_F(1F - tot, tot, 0F);
-				tess.addVertex(left, top, 0);
-				tess.addVertex(left, top + 4, 0);
-				tess.addVertex(left + 81 * tot, top + 4, 0);
-				tess.addVertex(left + 81 * tot, top, 0);
-				tess.draw();
-
-				GL11.glEnable(GL11.GL_TEXTURE_2D);
-
+				GuiIngameForge.left_height += 4;
 			}
+			tess.draw();
+			GL11.glEnable(GL11.GL_TEXTURE_2D);
 		}
 	}
 
@@ -955,7 +982,7 @@ public class ModEventHandlerClient {
 					ItemDepletedFuel.class,
 					ItemFluidDuct.class
 				);
-				
+
 				String prefix = "Gun ";
 				//int gunScale = 16;
 				//int defaultScale = 1;
@@ -1069,11 +1096,11 @@ public class ModEventHandlerClient {
 	@SideOnly(Side.CLIENT)
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public void onClientTickLast(ClientTickEvent event) {
-		
+
 		Minecraft mc = Minecraft.getMinecraft();
 		long millis = Clock.get_ms();
 		if(millis == 0) millis = System.currentTimeMillis();
-		
+
 		if(GeneralConfig.enableLoadScreenReplacement && loadingScreenReplacementRetry < 25 && !(mc.loadingScreen instanceof LoadingScreenRendererNT) && millis > lastLoadScreenReplacement + 5_000) {
 			mc.loadingScreen = new LoadingScreenRendererNT(mc);
 			lastLoadScreenReplacement = millis;
@@ -1171,7 +1198,7 @@ public class ModEventHandlerClient {
 	public void onRenderWorldLastEvent(RenderWorldLastEvent event) {
 
 		Clock.update();
-		
+
 		BlockRebar.renderRebar(Minecraft.getMinecraft().theWorld.loadedTileEntityList, event.partialTicks);
 
 		GL11.glPushMatrix();
@@ -1262,7 +1289,7 @@ public class ModEventHandlerClient {
 
 				if(chestplate.thermal) thermalSights = true;
 			}
-			
+
 			if(player.getHeldItem() != null && player.getHeldItem().getItem() instanceof ItemGunBaseNT && ItemGunBaseNT.aimingProgress == 1) {
 				ItemGunBaseNT gun = (ItemGunBaseNT) player.getHeldItem().getItem();
 				for(int i = 0; i < gun.getConfigCount(); i++) if(gun.getConfig(player.getHeldItem(), i).hasThermalSights(player.getHeldItem())) thermalSights = true;

--- a/src/main/java/com/hbm/main/ModEventHandlerClient.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerClient.java
@@ -66,8 +66,6 @@ import com.hbm.wiaj.GuiWorldInAJar;
 import com.hbm.wiaj.cannery.CanneryBase;
 import com.hbm.wiaj.cannery.Jars;
 import com.mojang.authlib.minecraft.MinecraftProfileTexture.Type;
-
-import api.hbm.fluidmk2.IFillableItem;
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
@@ -404,12 +402,14 @@ public class ModEventHandlerClient {
 
 		if(stack.getItem() instanceof ArmorFSBPowered && ArmorFSBPowered.hasFSBArmorIgnoreCharge(player)) {
 			float charge = 1F - (float) ((ArmorFSBPowered) stack.getItem()).getDurabilityForDisplay(stack);
+
 			bars.add(new Tuple.Pair<Float, Integer>(charge, 0x00FF00));
 		}
 
 		if(stack.getItem() instanceof JetpackFueledBase) {
 			JetpackFueledBase jetpack = (JetpackFueledBase) stack.getItem();
 			float fuel = (float) JetpackFueledBase.getFuel(stack) / jetpack.maxFuel;
+
 			bars.add(new Tuple.Pair<Float, Integer>(fuel, jetpack.fuel.getColor()));
 		}
 
@@ -425,10 +425,13 @@ public class ModEventHandlerClient {
 		Tessellator tess = Tessellator.instance;
 
 		if(event.type == event.type.ARMOR) {
+
 			List<List<Tuple.Pair<Float, Integer>>> barsList = new ArrayList<>();
 
 			for (int i = 0; i < 4; i++) {
+
 				barsList.add(new ArrayList<>());
+
 				ItemStack stack = player.inventory.armorInventory[i];
 
 				if(stack == null)
@@ -441,6 +444,7 @@ public class ModEventHandlerClient {
 
 				for (ItemStack mod : ArmorModHandler.pryMods(stack)) {
 					if (mod == null) continue;
+
 					barsList.get(i).addAll(getBars(mod, player));
 				}
 			}
@@ -457,14 +461,15 @@ public class ModEventHandlerClient {
 			int left = width / 2 - 91;
 
 			for (List<Tuple.Pair<Float, Integer>> bars : barsList) {
+
 				if (bars.isEmpty())
 					continue;
 
 				int top = height - GuiIngameForge.left_height + 7;
 
 				for (int i = 0; i < bars.size(); i++) {
-					float val = bars.get(i).key;
 
+					float val = bars.get(i).key;
 					int hstart, hend;
 
 					if (i == 0) {
@@ -475,10 +480,9 @@ public class ModEventHandlerClient {
 						// :(
 						hstart = left + 41 + bl * (i - 1);
 						hend = i == bars.size() - 1 ? left + 81 : hstart + bl;
+
 						if (i != 1) hstart += 1;
 					}
-
-					int color = bars.get(i).value;
 
 					tess.setColorOpaque_F(0.25F, 0.25F, 0.25F);
 					tess.addVertex(hstart, top - 1, 0);
@@ -488,6 +492,7 @@ public class ModEventHandlerClient {
 
 					float valx = hstart + (hend - hstart - 1) * val;
 
+					int color = bars.get(i).value;
 					float r = ((color >> 16) & 0xFF) / 255F;
 					float g = ((color >> 8) & 0xFF) / 255F;
 					float b = (color & 0xFF) / 255F;
@@ -501,6 +506,7 @@ public class ModEventHandlerClient {
 
 				GuiIngameForge.left_height += 4;
 			}
+
 			tess.draw();
 			GL11.glEnable(GL11.GL_TEXTURE_2D);
 		}


### PR DESCRIPTION
makes it possible to have more than one bar per slot, for example if you have a suit with a jetpack module it will display both the suit energy and the jetpack fuel.

if your suit does not have a jetpack module this visually changes almost nothing.

more bars can be added easily by adding to the getBars function.

suit + jetpack module
<img width="677" height="352" alt="image" src="https://github.com/user-attachments/assets/bb37a849-b548-424f-be7b-69bd826929bb" />

only jetpack or incomplete suit with jetpack module
<img width="693" height="306" alt="image" src="https://github.com/user-attachments/assets/16aa2b3a-ddd6-4f2f-936b-9b6d2124f268" />

theoretical >2 bars
<img width="479" height="244" alt="image" src="https://github.com/user-attachments/assets/cb202efd-6e26-4173-bece-2ed993814252" />

