### PR TITLE
improved pneumatics throughput

### DIFF
--- a/src/main/java/com/hbm/uninos/networkproviders/PneumaticNetwork.java
+++ b/src/main/java/com/hbm/uninos/networkproviders/PneumaticNetwork.java
@@ -2,6 +2,7 @@ package com.hbm.uninos.networkproviders;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -34,11 +35,11 @@ public class PneumaticNetwork extends NodeNet {
 
 	protected static final int timeout = 1_000;
 	public static final int ITEMS_PER_TRANSFER = 64;
-	
+
 	// while the system has parts that expects IInventires to be TileEntities to work properly (mostly range checks),
 	// it can actually handle non-TileEntities just fine.
 	public HashMap<IInventory, Triplet<ForgeDirection, Long, TileEntityPneumoTube>> receivers = new HashMap();
-	
+
 	public void addReceiver(IInventory inventory, ForgeDirection pipeDir, TileEntityPneumoTube endpoint) {
 		receivers.put(inventory, new Triplet(pipeDir, System.currentTimeMillis(), endpoint));
 	}
@@ -51,7 +52,7 @@ public class PneumaticNetwork extends NodeNet {
 		long timestamp = System.currentTimeMillis();
 		receivers.entrySet().removeIf(x -> { return (timestamp - x.getValue().getY() > timeout) || NodeNet.isBadLink(x.getKey()); });
 	}
-	
+
 	public boolean send(IInventory source, TileEntityPneumoTube tube, ForgeDirection accessDir, int sendOrder, int receiveOrder, int maxRange, int nextReceiver) {
 
 		// turns out there may be a short time window where the cleanup hasn't happened yet, but chunkloading has already caused tiles to go invalid
@@ -67,114 +68,144 @@ public class PneumaticNetwork extends NodeNet {
 		if(sendOrder == SEND_LAST) BobMathUtil.reverseIntArray(sourceSlotAccess);
 		if(sendOrder == SEND_RANDOM) BobMathUtil.shuffleIntArray(sourceSlotAccess);
 
+		ISidedInventory sidedSource = source instanceof ISidedInventory ? (ISidedInventory) source : null;
+		boolean hasItem = false;
+
+		for(int i : sourceSlotAccess) {
+			ItemStack stack = source.getStackInSlot(i);
+			if(stack != null) {
+				if(sidedSource != null && !sidedSource.canExtractItem(i, stack, sourceSide)) continue;
+				boolean match = tube.matchesFilter(stack);
+				if((match && !tube.whitelist) || (!match && tube.whitelist)) continue;
+				hasItem = true;
+				break;
+			}
+		}
+
+		// return early if there arent any items in the source inventory, saves on some cpu usage for idle networks
+		if(!hasItem) return false;
+
 		// for round robin, receivers are ordered by proximity to the source
 		ReceiverComparator comparator = new ReceiverComparator(tube);
 		List<Entry<IInventory, Triplet<ForgeDirection, Long, TileEntityPneumoTube>>> receiverList = new ArrayList(receivers.size());
 		receiverList.addAll(receivers.entrySet());
-		receiverList.sort(comparator);
-		
-		int index = nextReceiver % receivers.size();
-		Entry<IInventory, Triplet<ForgeDirection, Long, TileEntityPneumoTube>> chosenReceiverEntry = null;
 
-		if(receiveOrder == RECEIVE_ROBIN) chosenReceiverEntry = receiverList.get(index);
-		if(receiveOrder == RECEIVE_RANDOM) chosenReceiverEntry = receiverList.get(rand.nextInt(receiverList.size()));
-		
-		if(chosenReceiverEntry == null) return false;
-		
-		IInventory dest = chosenReceiverEntry.getKey();
-		TileEntityPneumoTube endpointTile = chosenReceiverEntry.getValue().getZ();
-		ISidedInventory sidedDest = dest instanceof ISidedInventory ? (ISidedInventory) dest : null;
-		ISidedInventory sidedSource = source instanceof ISidedInventory ? (ISidedInventory) source : null;
-		
+		if(receiveOrder == RECEIVE_ROBIN) receiverList.sort(comparator);
+		if(receiveOrder == RECEIVE_RANDOM) Collections.shuffle(receiverList);
+
 		TileEntity tile1 = source instanceof TileEntity ? (TileEntity) source : null;
-		TileEntity tile2 = dest instanceof TileEntity ? (TileEntity) dest : null;
-		
-		// range check for our compression level, skip if either source or dest aren't tile entities
-		if(tile1 != null && tile2 != null) {
-			int sq = (tile1.xCoord - tile2.xCoord) * (tile1.xCoord - tile2.xCoord) + (tile1.yCoord - tile2.yCoord) * (tile1.yCoord - tile2.yCoord) + (tile1.zCoord - tile2.zCoord) * (tile1.zCoord - tile2.zCoord);
-			if(sq > maxRange * maxRange) {
-				return false;
-			}
-		}
-		
-		int destSide = chosenReceiverEntry.getValue().getX().getOpposite().ordinal();
-		int[] destSlotAccess = getSlotAccess(dest, destSide);
-		int itemsLeftToSend = ITEMS_PER_TRANSFER; // not actually individual items, but rather the total "mass", based on max stack size
-		int itemHardCap = dest instanceof TileEntityMachineAutocrafter ? 1 : ITEMS_PER_TRANSFER;
-		boolean didSomething = false;
-		
-		for(int sourceIndex : sourceSlotAccess) {
-			ItemStack sourceStack = source.getStackInSlot(sourceIndex);
-			if(sourceStack == null) continue;
-			if(sidedSource != null && !sidedSource.canExtractItem(sourceIndex, sourceStack, sourceSide)) continue;
-			// filter of the source
-			boolean match = tube.matchesFilter(sourceStack);
-			if((match && !tube.whitelist) || (!match && tube.whitelist)) continue;
-			// filter of the receiver, only if the sender and receiver aren't the same block
-			if(endpointTile != null && endpointTile != tube) {
-				match = endpointTile.matchesFilter(sourceStack);
-				if((match && !endpointTile.whitelist) || (!match && endpointTile.whitelist)) continue;
-			}
-			// the "mass" of an item. something that only stacks to 4 has a "mass" of 16. max transfer mass is 64, i.e. one standard stack, or one single unstackable item
-			int proportionalValue = MathHelper.clamp_int(64 / sourceStack.getMaxStackSize(), 1, 64);
-			
-			// try to fill partial stacks first
-			for(int destIndex : destSlotAccess) {
-				ItemStack destStack = dest.getStackInSlot(destIndex);
-				if(destStack == null) continue;
-				if(!ItemStackUtil.areStacksCompatible(sourceStack, destStack)) continue;
-				int toMove = BobMathUtil.min(sourceStack.stackSize, destStack.getMaxStackSize() - destStack.stackSize, dest.getInventoryStackLimit() - destStack.stackSize, itemsLeftToSend / proportionalValue, itemHardCap);
-				if(toMove <= 0) continue;
-				
-				ItemStack checkStack = destStack.copy();
-				checkStack.stackSize += toMove;
-				if(!dest.isItemValidForSlot(destIndex, checkStack)) continue;
-				if(sidedDest != null && !sidedDest.canInsertItem(destIndex, checkStack, destSide)) continue;
-				
-				sourceStack.stackSize -= toMove;
-				if(sourceStack.stackSize <= 0) source.setInventorySlotContents(sourceIndex, null);
-				destStack.stackSize += toMove;
-				itemsLeftToSend -= toMove * proportionalValue;
-				didSomething = true;
-				if(itemsLeftToSend <= 0) break;
-			}
-			
-			// if there's stuff left to send, occupy empty slots
-			if(itemsLeftToSend > 0 && sourceStack.stackSize > 0) for(int destIndex : destSlotAccess) {
-				if(dest.getStackInSlot(destIndex) != null) continue;
-				int toMove = BobMathUtil.min(sourceStack.stackSize, dest.getInventoryStackLimit(), itemsLeftToSend / proportionalValue, itemHardCap);
-				if(toMove <= 0) continue;
-				
-				ItemStack checkStack = sourceStack.copy();
-				checkStack.stackSize = toMove;
-				if(!dest.isItemValidForSlot(destIndex, checkStack)) continue;
-				if(sidedDest != null && !sidedDest.canInsertItem(destIndex, checkStack, destSide)) continue;
 
-				ItemStack newStack = sourceStack.copy();
-				newStack.stackSize = toMove;
-				sourceStack.stackSize -= toMove;
-				if(sourceStack.stackSize <= 0) source.setInventorySlotContents(sourceIndex, null);
-				dest.setInventorySlotContents(destIndex, newStack);
-				itemsLeftToSend -= toMove * proportionalValue;
-				didSomething = true;
+		int attempts = 0;
+		int maxAttempts = receiverList.size();
+
+		// try all receivers for both modes, in an attempts based system.
+		// instead of bailing out of trying after the first failure (which means you have to wait 0.25 seconds), we just try the next one.
+		while(attempts < maxAttempts) {
+			int index = (receiveOrder == RECEIVE_ROBIN) ? (nextReceiver + attempts) % receiverList.size() : attempts;
+
+			Entry<IInventory, Triplet<ForgeDirection, Long, TileEntityPneumoTube>> candidate = receiverList.get(index);
+
+			if(NodeNet.isBadLink(candidate.getKey())) {
+				receivers.remove(candidate.getKey());
+				attempts++;
+				continue;
+			}
+
+			IInventory dest = candidate.getKey();
+			TileEntityPneumoTube endpointTile = candidate.getValue().getZ();
+			TileEntity tile2 = dest instanceof TileEntity ? (TileEntity) dest : null;
+
+			// range check for our compression level, skip if either source or dest aren't tile entities
+			if(tile1 != null && tile2 != null) {
+				int sq = (tile1.xCoord - tile2.xCoord) * (tile1.xCoord - tile2.xCoord) + (tile1.yCoord - tile2.yCoord) * (tile1.yCoord - tile2.yCoord) + (tile1.zCoord - tile2.zCoord) * (tile1.zCoord - tile2.zCoord);
+				if(sq > maxRange * maxRange) {
+					attempts++;
+					continue;
+				}
+			}
+
+			ISidedInventory sidedDest = dest instanceof ISidedInventory ? (ISidedInventory) dest : null;
+			int destSide = candidate.getValue().getX().getOpposite().ordinal();
+			int[] destSlotAccess = getSlotAccess(dest, destSide);
+			int itemsLeftToSend = ITEMS_PER_TRANSFER; // not actually individual items, but rather the total "mass", based on max stack size
+			int itemHardCap = dest instanceof TileEntityMachineAutocrafter ? 1 : ITEMS_PER_TRANSFER;
+			boolean didSomething = false;
+
+			for(int sourceIndex : sourceSlotAccess) {
+				ItemStack sourceStack = source.getStackInSlot(sourceIndex);
+				if(sourceStack == null) continue;
+				if(sidedSource != null && !sidedSource.canExtractItem(sourceIndex, sourceStack, sourceSide)) continue;
+				// filter of the source
+				boolean match = tube.matchesFilter(sourceStack);
+				if((match && !tube.whitelist) || (!match && tube.whitelist)) continue;
+				// filter of the receiver, only if the sender and receiver aren't the same block
+				if(endpointTile != null && endpointTile != tube) {
+					match = endpointTile.matchesFilter(sourceStack);
+					if((match && !endpointTile.whitelist) || (!match && endpointTile.whitelist)) continue;
+				}
+				// the "mass" of an item. something that only stacks to 4 has a "mass" of 16. max transfer mass is 64, i.e. one standard stack, or one single unstackable item
+				int proportionalValue = MathHelper.clamp_int(64 / sourceStack.getMaxStackSize(), 1, 64);
+
+				// try to fill partial stacks first
+				for(int destIndex : destSlotAccess) {
+					ItemStack destStack = dest.getStackInSlot(destIndex);
+					if(destStack == null) continue;
+					if(!ItemStackUtil.areStacksCompatible(sourceStack, destStack)) continue;
+					int toMove = BobMathUtil.min(sourceStack.stackSize, destStack.getMaxStackSize() - destStack.stackSize, dest.getInventoryStackLimit() - destStack.stackSize, itemsLeftToSend / proportionalValue, itemHardCap);
+					if(toMove <= 0) continue;
+
+					ItemStack checkStack = destStack.copy();
+					checkStack.stackSize += toMove;
+					if(!dest.isItemValidForSlot(destIndex, checkStack)) continue;
+					if(sidedDest != null && !sidedDest.canInsertItem(destIndex, checkStack, destSide)) continue;
+
+					sourceStack.stackSize -= toMove;
+					if(sourceStack.stackSize <= 0) source.setInventorySlotContents(sourceIndex, null);
+					destStack.stackSize += toMove;
+					itemsLeftToSend -= toMove * proportionalValue;
+					didSomething = true;
+					if(itemsLeftToSend <= 0) break;
+				}
+
+				// if there's stuff left to send, occupy empty slots
+				if(itemsLeftToSend > 0 && sourceStack.stackSize > 0) for(int destIndex : destSlotAccess) {
+					if(dest.getStackInSlot(destIndex) != null) continue;
+					int toMove = BobMathUtil.min(sourceStack.stackSize, dest.getInventoryStackLimit(), itemsLeftToSend / proportionalValue, itemHardCap);
+					if(toMove <= 0) continue;
+
+					ItemStack checkStack = sourceStack.copy();
+					checkStack.stackSize = toMove;
+					if(!dest.isItemValidForSlot(destIndex, checkStack)) continue;
+					if(sidedDest != null && !sidedDest.canInsertItem(destIndex, checkStack, destSide)) continue;
+
+					ItemStack newStack = sourceStack.copy();
+					newStack.stackSize = toMove;
+					sourceStack.stackSize -= toMove;
+					if(sourceStack.stackSize <= 0) source.setInventorySlotContents(sourceIndex, null);
+					dest.setInventorySlotContents(destIndex, newStack);
+					itemsLeftToSend -= toMove * proportionalValue;
+					didSomething = true;
+					if(itemsLeftToSend <= 0) break;
+				}
+
 				if(itemsLeftToSend <= 0) break;
 			}
-			
-			if(itemsLeftToSend <= 0) break;
+
+			// make sure both parties are saved to disk and increment the counter for round robin
+			if(didSomething) {
+				source.markDirty();
+				dest.markDirty();
+				return true;
+			}
+
+			attempts++;
 		}
-		
-		// make sure both parties are saved to disk and increment the counter for round robin
-		if(didSomething) {
-			source.markDirty();
-			dest.markDirty();
-		}
-		
-		return didSomething;
+		return false;
 	}
-	
+
 	/** Returns an array of accessible slots from the given side of an IInventory. If it's an ISidedInventory, uses the sided restrictions instead. */
 	public static int[] getSlotAccess(IInventory inventory, int dir) {
-		
+
 		if(inventory instanceof ISidedInventory) {
 			int[] slotAccess = ((ISidedInventory) inventory).getAccessibleSlotsFromSide(dir);
 			return Arrays.copyOf(slotAccess, slotAccess.length); //we mess with the order, so better not use the original array
@@ -184,12 +215,12 @@ public class PneumaticNetwork extends NodeNet {
 			return slotAccess;
 		}
 	}
-	
+
 	/** Compares IInventory by distance, going off the assumption that they are TileEntities. Uses positional data for tie-breaking if the distance is the same. */
 	public static class ReceiverComparator implements Comparator<Entry<IInventory, Triplet<ForgeDirection, Long, TileEntityPneumoTube>>> {
-		
+
 		private TileEntityPneumoTube origin;
-		
+
 		public ReceiverComparator(TileEntityPneumoTube origin) {
 			this.origin = origin;
 		}
@@ -204,11 +235,11 @@ public class PneumaticNetwork extends NodeNet {
 			if(tile1 == null && tile2 != null) return 1;
 			if(tile1 != null && tile2 == null) return -1;
 			if(tile1 == null && tile2 == null) return 0;
-			
+
 			// calculate distances from origin
 			int dist1 = (tile1.xCoord - origin.xCoord) * (tile1.xCoord - origin.xCoord) + (tile1.yCoord - origin.yCoord) * (tile1.yCoord - origin.yCoord) + (tile1.zCoord - origin.zCoord) * (tile1.zCoord - origin.zCoord);
 			int dist2 = (tile2.xCoord - origin.xCoord) * (tile2.xCoord - origin.xCoord) + (tile2.yCoord - origin.yCoord) * (tile2.yCoord - origin.yCoord) + (tile2.zCoord - origin.zCoord) * (tile2.zCoord - origin.zCoord);
-			
+
 			// tier-breaker: use hash value instead
 			if(dist1 == dist2) {
 				return TileEntityPneumoTube.getIdentifier(tile1.xCoord, tile1.yCoord, tile1.zCoord) - TileEntityPneumoTube.getIdentifier(tile2.xCoord, tile2.yCoord, tile2.zCoord);


### PR DESCRIPTION
pneumatic systems are notoriously slow when there are a lot of outputs. i did a lot of rework to the pneumatic network code which involved these changes:

- round robin now iterates through receivers until a successful transfer occurs (will bail out if we end up failed on all receivers)
- random now doesn't sort based on distance, as it doesn't need to, and shuffles the receiver list, and does the same attempts based system to ensure that each send operation tries all possible outcomes.

those initial changes made the most difference for throughput. it brought it down from multiple seconds per stack sent (in the event of 16 receivers from 1 crate), to the full speed throughput of 4 stacks a second.

some other changes i made:

- the send operation will only begin to send if the source inventory actually contains items that can be sent, which reduces CPU usage on idle networks
- validating receivers on every send call seemed redundant to me, which removed an O(N) loop. this should be done whenever update is called which im "assuming" is periodically
- invalid links are handled on the fly if that ever happens.

these changes would make pneumatic actually able to withstand complex network sizes, in the case where its not simply A-B.

https://github.com/user-attachments/assets/353d515a-216d-4335-9c7a-b06744c988e5

