### PR TITLE
Visible third-person muzzle flashes from other players +self, skeleguns

### DIFF
--- a/src/main/java/com/hbm/items/weapon/sedna/ItemGunBaseNT.java
+++ b/src/main/java/com/hbm/items/weapon/sedna/ItemGunBaseNT.java
@@ -274,9 +274,10 @@ public class ItemGunBaseNT extends Item implements IKeybindReceiver, IItemHUD, I
 	public static void playAnimation(EntityPlayer player, ItemStack stack, GunAnimation type, int index) {
 		if(player instanceof EntityPlayerMP) {
 			PacketDispatcher.wrapper.sendTo(new HbmAnimationPacket(type.ordinal(), 0, index), (EntityPlayerMP) player);
-			setLastAnim(stack, index, type);
-			setAnimTimer(stack, index, 0);
 		}
+		
+		setLastAnim(stack, index, type);
+		setAnimTimer(stack, index, 0);
 	}
 
 	@Override

--- a/src/main/java/com/hbm/items/weapon/sedna/factory/Orchestras.java
+++ b/src/main/java/com/hbm/items/weapon/sedna/factory/Orchestras.java
@@ -14,7 +14,9 @@ import com.hbm.items.weapon.sedna.mags.IMagazine;
 import com.hbm.items.weapon.sedna.mods.XWeaponModManager;
 import com.hbm.lib.ModDamageSource;
 import com.hbm.main.MainRegistry;
+import com.hbm.packet.PacketDispatcher;
 import com.hbm.packet.toclient.AuxParticlePacketNT;
+import com.hbm.packet.toclient.MuzzleFlashPacket;
 import com.hbm.particle.SpentCasing;
 import com.hbm.particle.helper.CasingCreator;
 import com.hbm.render.anim.HbmAnimations;
@@ -200,6 +202,7 @@ public class Orchestras {
 			if(timer == 5) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.openLatch", 1F, 1F);
 		}
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 2) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
 				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.55, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.12, 0.01, -7.5F + (float)entity.getRNG().nextGaussian() * 5F, 12F + (float)entity.getRNG().nextGaussian() * 5F, casing.getName());
@@ -752,6 +755,7 @@ public class Orchestras {
 			if(timer == 0) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
 				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.5, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.12, 0.01, (float)entity.getRNG().nextGaussian() * 5F, 12.5F + (float)entity.getRNG().nextFloat() * 5F, casing.getName());
+				PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			}
 		}
 		if(type == GunAnimation.CYCLE_DRY) {

--- a/src/main/java/com/hbm/items/weapon/sedna/factory/Orchestras.java
+++ b/src/main/java/com/hbm/items/weapon/sedna/factory/Orchestras.java
@@ -826,7 +826,7 @@ public class Orchestras {
 				//stop sound due to timeout
 				if(runningAudio != null && runningAudio.isPlaying()) runningAudio.stopSound();
 			}
-			return; //TODO check if this fucks anything
+			return;
 		}
 		if(type == GunAnimation.CYCLE) {
 			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));

--- a/src/main/java/com/hbm/items/weapon/sedna/factory/Orchestras.java
+++ b/src/main/java/com/hbm/items/weapon/sedna/factory/Orchestras.java
@@ -60,6 +60,7 @@ public class Orchestras {
 			}
 		}
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 11) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.revolverCock", 1F, 1F);
 		}
 		if(type == GunAnimation.CYCLE_DRY) {
@@ -83,6 +84,7 @@ public class Orchestras {
 			if(timer == 55) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.revolverSpin", 1F, 1F);
 		}
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 21) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.revolverCock", 1F, 0.6F);
 		}
 		if(type == GunAnimation.CYCLE_DRY) {
@@ -110,6 +112,7 @@ public class Orchestras {
 			if(timer == 44) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.revolverClose", 1F, 1F);
 		}
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 5) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.revolverCock", 1F, 0.9F);
 		}
 		if(type == GunAnimation.CYCLE_DRY) {
@@ -138,6 +141,7 @@ public class Orchestras {
 			if(timer == 44) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.revolverClose", 1F, 1F);
 		}
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 5) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.revolverCock", 1F, 0.9F);
 		}
 		if(type == GunAnimation.CYCLE_DRY) {
@@ -179,6 +183,7 @@ public class Orchestras {
 			if(timer == 44) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.leverCock", 1F, 1F);
 		}
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 14) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
 				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.5, -0.125, aiming ? -0.125 : -0.375D, 0, 0.12, -0.12, 0.01, -7.5F + (float)entity.getRNG().nextGaussian() * 5F, (float)entity.getRNG().nextGaussian() * 1.5F, casing.getName(), true, 60, 0.5D, 20);
@@ -251,6 +256,7 @@ public class Orchestras {
 			if(timer == 29) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.leverCock", 1F, 0.8F);
 		}
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 14) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
 				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, -0.125, aiming ? -0.125 : -0.375D, 0, 0.18, -0.12, 0.01, -10F + (float)entity.getRNG().nextGaussian() * 5F, (float)entity.getRNG().nextGaussian() * 2.5F, casing.getName(), true, 60, 0.5D, 20);
@@ -286,6 +292,7 @@ public class Orchestras {
 			if(timer == 29) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.leverCock", 1F, 0.8F);
 		}
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 14) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
 				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, -0.125, aiming ? -0.125 : -0.375D, 0, -0.08, 0, 0.01, -15F + (float)entity.getRNG().nextGaussian() * 5F, (float)entity.getRNG().nextGaussian() * 2.5F, casing.getName(), true, 60, 0.5D, 20);
@@ -306,6 +313,7 @@ public class Orchestras {
 		boolean aiming = ItemGunBaseNT.getIsAiming(stack);
 
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 14) {
 				int offset = ctx.configIndex == 0 ? -1 : 1;
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
@@ -371,6 +379,7 @@ public class Orchestras {
 			}
 		}
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 11) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.revolverCock", 1F, 1F);
 		}
 		if(type == GunAnimation.CYCLE_DRY) {
@@ -391,6 +400,7 @@ public class Orchestras {
 		boolean aiming = ItemGunBaseNT.getIsAiming(stack);
 
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 1) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
 				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.3125, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.21, -0.06, 0.01, -10F + (float)entity.getRNG().nextGaussian() * 2.5F, 2.5F + (float)entity.getRNG().nextGaussian() * 2F, casing.getName(), true, 60, 0.5D, 20);
@@ -427,6 +437,7 @@ public class Orchestras {
 		if(ClientConfig.GUN_ANIMS_LEGACY.get()) {
 			if(type == GunAnimation.CYCLE) {
 				if(timer == 0) {
+					PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 					SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
 					if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.4375, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, -0.06, 0, 0.01, (float)entity.getRNG().nextGaussian() * 10F, (float)entity.getRNG().nextGaussian() * 10F, casing.getName());
 				}
@@ -451,6 +462,7 @@ public class Orchestras {
 		} else {
 			if(type == GunAnimation.CYCLE) {
 				if(timer == 0) {
+					PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 					SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
 					if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.4375, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, -0.06, 0, 0.01, (float)entity.getRNG().nextGaussian() * 10F, (float)entity.getRNG().nextGaussian() * 10F, casing.getName());
 				}
@@ -481,7 +493,10 @@ public class Orchestras {
 		if(entity.worldObj.isRemote) return;
 		GunAnimation type = ItemGunBaseNT.getLastAnim(stack, ctx.configIndex);
 		int timer = ItemGunBaseNT.getAnimTimer(stack, ctx.configIndex);
-
+		
+		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
+		}
 		if(type == GunAnimation.RELOAD) {
 			if(timer == 0) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.revolverCock", 1F, 0.75F);
 			if(timer == 4) {
@@ -527,6 +542,7 @@ public class Orchestras {
 		boolean aiming = ItemGunBaseNT.getIsAiming(stack);
 
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 15) {
 				IMagazine mag = ctx.config.getReceivers(stack)[0].getMagazine(stack);
 				SpentCasing casing = mag.getCasing(stack, ctx.inventory);
@@ -606,6 +622,7 @@ public class Orchestras {
 		boolean aiming = ItemGunBaseNT.getIsAiming(stack);
 
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 1) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
 				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.0625, aiming ? 0 : -0.25D, 0, 0.18, -0.12, 0.01, -10F + (float)entity.getRNG().nextGaussian() * 5F, 10F + entity.getRNG().nextFloat() * 10F, casing.getName());
@@ -639,6 +656,7 @@ public class Orchestras {
 			if(timer == 8) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.openLatch", 1F, 1.25F);
 		}
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 1) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
 				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.125, aiming ? 0 : -0.25D, 0, 0.18, -0.12, 0.01, -2.5F + (float)entity.getRNG().nextGaussian() * 5F, 10F + (float)entity.getRNG().nextFloat() * 15F, casing.getName());
@@ -670,6 +688,7 @@ public class Orchestras {
 			if(timer == 8) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.openLatch", 1F, 1.25F);
 		}
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 1) {
 				int mult = ctx.configIndex == 0 ? -1 : 1;
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
@@ -700,6 +719,7 @@ public class Orchestras {
 		boolean aiming = ItemGunBaseNT.getIsAiming(stack);
 
 		if(type == GunAnimation.CYCLE || type == GunAnimation.ALT_CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 8) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.shotgunCock", 1F, 1F);
 			if(timer == 10) {
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory); //turns out there's a reason why stovepipes look like that
@@ -737,7 +757,9 @@ public class Orchestras {
 		if(entity.worldObj.isRemote) return;
 		GunAnimation type = ItemGunBaseNT.getLastAnim(stack, ctx.configIndex);
 		int timer = ItemGunBaseNT.getAnimTimer(stack, ctx.configIndex);
-
+		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
+		}
 		if(type == GunAnimation.RELOAD) {
 			if(timer == 30) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.insertCanister", 1F, 1F);
 		}
@@ -804,8 +826,11 @@ public class Orchestras {
 				//stop sound due to timeout
 				if(runningAudio != null && runningAudio.isPlaying()) runningAudio.stopSound();
 			}
+			return; //TODO check if this fucks anything
 		}
-
+		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
+		}
 		if(type == GunAnimation.RELOAD) {
 			if(timer == 30) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.insertCanister", 1F, 1F);
 		}
@@ -857,6 +882,7 @@ public class Orchestras {
 		}
 
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 7) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.boltOpen", 0.5F, 1F);
 			if(timer == 16) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.boltClose", 0.5F, 1F);
 			if(timer == 12) {
@@ -907,6 +933,7 @@ public class Orchestras {
 
 		if(type == GunAnimation.CYCLE) {
 			if(timer == 0) {
+				PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
 				if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, 0.375, aiming ? 0 : -0.125, aiming ? 0 : -0.3125D, 0, 0.06, -0.18, 0.01, (float)entity.getRNG().nextGaussian() * 20F, 12.5F + (float)entity.getRNG().nextGaussian() * 7.5F, casing.getName());
 			}
@@ -920,6 +947,7 @@ public class Orchestras {
 		int timer = ItemGunBaseNT.getAnimTimer(stack, ctx.configIndex);
 
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 2) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.fire.shredderCycle", 0.25F, 1.5F);
 		}
 		if(type == GunAnimation.CYCLE_DRY) {
@@ -944,8 +972,11 @@ public class Orchestras {
 		boolean aiming = ItemGunBaseNT.getIsAiming(stack);
 
 		if(type == GunAnimation.CYCLE) {
-			if(timer == 0 && ctx.config.getReceivers(stack)[0].getMagazine(stack).getType(stack, null) == XFactory12ga.g12_equestrian_bj) {
-				ItemGunBaseNT.setTimer(stack, 0, 20);
+			if(timer == 0) {
+				PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
+				if(ctx.config.getReceivers(stack)[0].getMagazine(stack).getType(stack, null) == XFactory12ga.g12_equestrian_bj) {
+					ItemGunBaseNT.setTimer(stack, 0, 20);
+				}
 			}
 
 			if(timer == 2) {
@@ -990,7 +1021,10 @@ public class Orchestras {
 		if(entity.worldObj.isRemote) return;
 		GunAnimation type = ItemGunBaseNT.getLastAnim(stack, ctx.configIndex);
 		int timer = ItemGunBaseNT.getAnimTimer(stack, ctx.configIndex);
-
+		
+		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
+		}
 		if(type == GunAnimation.RELOAD) {
 			if(timer == 30) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.insertCanister", 1F, 1F);
 		}
@@ -1005,6 +1039,7 @@ public class Orchestras {
 
 		if(type == GunAnimation.CYCLE) {
 			if(timer == 0) {
+				PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 				int rounds = XWeaponModManager.hasUpgrade(stack, ctx.configIndex, XWeaponModManager.ID_MINIGUN_SPEED) ? 3 : 1;
 				for(int i = 0; i < rounds; i++) {
 					SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
@@ -1033,6 +1068,7 @@ public class Orchestras {
 
 		if(type == GunAnimation.CYCLE) {
 			if(timer == 0) {
+				PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 				int index = ctx.configIndex == 0 ? -1 : 1;
 				int rounds = XWeaponModManager.hasUpgrade(stack, ctx.configIndex, XWeaponModManager.ID_MINIGUN_SPEED) ? 3 : 1;
 				for(int i = 0; i < rounds; i++) {
@@ -1059,7 +1095,10 @@ public class Orchestras {
 		if(entity.worldObj.isRemote) return;
 		GunAnimation type = ItemGunBaseNT.getLastAnim(stack, ctx.configIndex);
 		int timer = ItemGunBaseNT.getAnimTimer(stack, ctx.configIndex);
-
+		
+		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
+		}
 		if(type == GunAnimation.CYCLE_DRY) {
 			if(timer == 0) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.dryFireClick", 1F, 1.25F);
 		}
@@ -1098,7 +1137,10 @@ public class Orchestras {
 		if(entity.worldObj.isRemote) return;
 		GunAnimation type = ItemGunBaseNT.getLastAnim(stack, ctx.configIndex);
 		int timer = ItemGunBaseNT.getAnimTimer(stack, ctx.configIndex);
-
+		
+		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
+		}
 		if(type == GunAnimation.CYCLE_DRY) {
 			if(timer == 0) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.dryFireClick", 1F, 1.5F);
 		}
@@ -1127,6 +1169,7 @@ public class Orchestras {
 		if(ClientConfig.GUN_ANIMS_LEGACY.get()) {
 			if(type == GunAnimation.CYCLE) {
 				if(timer == 0) {
+					PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 					SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
 					if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, aiming ? 0.125 : 0.125, aiming ? -0.125 : -0.25, aiming ? -0.125 : -0.25D, 0, 0.18, -0.12, 0.01, (float)entity.getRNG().nextGaussian() * 5F, 7.5F + entity.getRNG().nextFloat() * 5F, casing.getName());
 				}
@@ -1153,6 +1196,7 @@ public class Orchestras {
 		} else {
 			if(type == GunAnimation.CYCLE) {
 				if(timer == 0) {
+					PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 					SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
 					if(casing != null) CasingCreator.composeEffect(entity.worldObj, entity, aiming ? 0.125 : 0.25, aiming ? -0.125 : -0.25, aiming ? -0.125 : -0.25D, 0, 0.18, -0.12, 0.01, (float)entity.getRNG().nextGaussian() * 5F, 7.5F + entity.getRNG().nextFloat() * 5F, casing.getName());
 				}
@@ -1273,7 +1317,10 @@ public class Orchestras {
 		if(entity.worldObj.isRemote) return;
 		GunAnimation type = ItemGunBaseNT.getLastAnim(stack, ctx.configIndex);
 		int timer = ItemGunBaseNT.getAnimTimer(stack, ctx.configIndex);
-
+		
+		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
+		}
 		if(type == GunAnimation.CYCLE_DRY) {
 			if(timer == 0) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.dryFireClick", 1F, 1.5F);
 		}
@@ -1303,7 +1350,10 @@ public class Orchestras {
 		if(entity.worldObj.isRemote) return;
 		GunAnimation type = ItemGunBaseNT.getLastAnim(stack, ctx.configIndex);
 		int timer = ItemGunBaseNT.getAnimTimer(stack, ctx.configIndex);
-
+		
+		if(type == GunAnimation.CYCLE && stack.getItem() == ModItems.gun_n_i_4_n_i) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
+		}
 		if(type == GunAnimation.RELOAD) {
 			if(timer == 0) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.coilgunReload", 1F, 1F);
 		}
@@ -1314,7 +1364,10 @@ public class Orchestras {
 		if(entity.worldObj.isRemote) return;
 		GunAnimation type = ItemGunBaseNT.getLastAnim(stack, ctx.configIndex);
 		int timer = ItemGunBaseNT.getAnimTimer(stack, ctx.configIndex);
-
+		
+		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
+		}
 		if(type == GunAnimation.CYCLE_DRY) {
 			if(timer == 0) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.dryFireClick", 1F, 1F);
 		}
@@ -1417,7 +1470,9 @@ public class Orchestras {
 			if(timer == 5) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.revolverCock", 1F, 0.75F);
 			if(timer == 19) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.revolverClose", 1F, 0.8F);
 		}
-
+		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
+		}
 		if(type == GunAnimation.CYCLE_DRY) {
 			if(timer == 2) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.dryFireClick", 1F, 1F);
 		}
@@ -1437,6 +1492,7 @@ public class Orchestras {
 		}
 
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 1) {
 				int cba = (stack.getItem() == ModItems.gun_aberrator_eott && ctx.configIndex == 0) ? -1 : 1;
 				SpentCasing casing = ctx.config.getReceivers(stack)[0].getMagazine(stack).getCasing(stack, ctx.inventory);
@@ -1463,6 +1519,7 @@ public class Orchestras {
 		}
 
 		if(type == GunAnimation.CYCLE) {
+			if(timer == 0) PacketDispatcher.wrapper.sendToAllAround(new MuzzleFlashPacket(entity), new TargetPoint(entity.worldObj.provider.dimensionId, entity.posX, entity.posY, entity.posZ, 100));
 			if(timer == 7) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.boltOpen", 0.5F, 1F);
 			if(timer == 16) entity.worldObj.playSoundAtEntity(entity, "hbm:weapon.reload.boltClose", 0.5F, 1F);
 			if(timer == 12) {

--- a/src/main/java/com/hbm/main/ModEventHandlerClient.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerClient.java
@@ -1425,6 +1425,14 @@ public class ModEventHandlerClient {
 
 		if(event.phase == event.phase.END) {
 			ItemCustomLore.updateSystem();
+			
+			//prune other entities' muzzle flashes
+			long millis = System.currentTimeMillis();
+			if(event.world.getTotalWorldTime() % 30 == 0) {
+				Iterator itr = ItemRenderWeaponBase.flashMap.keySet().iterator();
+				//dead entities may have later insertion order than actively firing ones, so we be safe
+				ItemRenderWeaponBase.flashMap.values().removeIf(entry -> entry.longValue() - millis >= 100);
+			}
 		}
 	}
 

--- a/src/main/java/com/hbm/main/ModEventHandlerClient.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerClient.java
@@ -926,6 +926,14 @@ public class ModEventHandlerClient {
 			if(ArmorUtil.isWearingEmptyMask(mc.thePlayer)) {
 				MainRegistry.proxy.displayTooltip(EnumChatFormatting.RED + "Your mask has no filter!", MainRegistry.proxy.ID_FILTER);
 			}
+			
+			//prune other entities' muzzle flashes
+			if(mc.theWorld.getTotalWorldTime() % 30 == 0) {
+				Iterator itr = ItemRenderWeaponBase.flashMap.keySet().iterator();
+				long millis = System.currentTimeMillis();
+				//dead entities may have later insertion order than actively firing ones, so we be safe
+				ItemRenderWeaponBase.flashMap.values().removeIf(entry -> millis - entry.longValue() >= 100);
+			}
 		}
 
 		if(Keyboard.isKeyDown(HbmKeybinds.qmaw.getKeyCode()) && Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) && Minecraft.getMinecraft().currentScreen != null) {
@@ -1425,14 +1433,6 @@ public class ModEventHandlerClient {
 
 		if(event.phase == event.phase.END) {
 			ItemCustomLore.updateSystem();
-			
-			//prune other entities' muzzle flashes
-			long millis = System.currentTimeMillis();
-			if(event.world.getTotalWorldTime() % 30 == 0) {
-				Iterator itr = ItemRenderWeaponBase.flashMap.keySet().iterator();
-				//dead entities may have later insertion order than actively firing ones, so we be safe
-				ItemRenderWeaponBase.flashMap.values().removeIf(entry -> entry.longValue() - millis >= 100);
-			}
 		}
 	}
 

--- a/src/main/java/com/hbm/main/ModEventHandlerClient.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerClient.java
@@ -932,7 +932,7 @@ public class ModEventHandlerClient {
 				Iterator itr = ItemRenderWeaponBase.flashMap.keySet().iterator();
 				long millis = System.currentTimeMillis();
 				//dead entities may have later insertion order than actively firing ones, so we be safe
-				ItemRenderWeaponBase.flashMap.values().removeIf(entry -> millis - entry.longValue() >= 100);
+				ItemRenderWeaponBase.flashMap.values().removeIf(entry -> millis - entry.longValue() >= 150);
 			}
 		}
 

--- a/src/main/java/com/hbm/main/ModEventHandlerRenderer.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerRenderer.java
@@ -279,10 +279,10 @@ public class ModEventHandlerRenderer {
 				if(renderWeapon.isLeftHanded()) {
 					GL11.glTranslatef(0.1875F, 0F, 0.0F);
 					renderWeapon.setupThirdPerson(held);
-					renderWeapon.renderEquippedAkimbo(held);
+					renderWeapon.renderEquippedAkimbo(held, player);
 				} else {
 					renderWeapon.setupThirdPersonAkimbo(held);
-					renderWeapon.renderEquippedAkimbo(held);
+					renderWeapon.renderEquippedAkimbo(held, player);
 				}
 				GL11.glDisable(GL12.GL_RESCALE_NORMAL);
 				GL11.glPopMatrix();

--- a/src/main/java/com/hbm/packet/PacketDispatcher.java
+++ b/src/main/java/com/hbm/packet/PacketDispatcher.java
@@ -69,6 +69,8 @@ public class PacketDispatcher {
 		wrapper.registerMessage(SerializableRecipePacket.Handler.class, SerializableRecipePacket.class, i++, Side.CLIENT);
 		//Syncing of NBT for guns
 		wrapper.registerMessage(HeldItemNBTPacket.Handler.class, HeldItemNBTPacket.class, i++, Side.CLIENT);
+		//Syncs muzzle flashes of SEDNA guns for clients from other entities/players
+		wrapper.registerMessage(MuzzleFlashPacket.Handler.class, MuzzleFlashPacket.class, i++, Side.CLIENT);
 	}
 
 }

--- a/src/main/java/com/hbm/packet/toclient/MuzzleFlashPacket.java
+++ b/src/main/java/com/hbm/packet/toclient/MuzzleFlashPacket.java
@@ -16,27 +16,27 @@ import net.minecraft.item.ItemStack;
 public class MuzzleFlashPacket implements IMessage {
 	
 	private int entityID;
-	private int gunIndex; //e.g. akimbo
+	//private int gunIndex; //e.g. akimbo
 	
 	public MuzzleFlashPacket() { }
 	
-	public MuzzleFlashPacket(EntityLivingBase entity) { this(entity, 0); }
+	//public MuzzleFlashPacket(EntityLivingBase entity) { this(entity, 0); }
 	
-	public MuzzleFlashPacket(EntityLivingBase entity, int index) {
+	public MuzzleFlashPacket(EntityLivingBase entity) {
 		this.entityID = entity.getEntityId();
-		this.gunIndex = index;
+		//this.gunIndex = index;
 	}
 	
 	@Override
 	public void toBytes(ByteBuf buf) {
 		buf.writeInt(entityID);
-		buf.writeInt(gunIndex);
+		//buf.writeInt(gunIndex);
 	}
 	
 	@Override
 	public void fromBytes(ByteBuf buf) {
 		this.entityID = buf.readInt();
-		this.gunIndex = buf.readInt();
+		//this.gunIndex = buf.readInt();
 	}
 	
 	public static class Handler implements IMessageHandler<MuzzleFlashPacket, IMessage> {
@@ -45,7 +45,7 @@ public class MuzzleFlashPacket implements IMessage {
 		@Override
 		public IMessage onMessage(MuzzleFlashPacket m, MessageContext ctx) {
 			EntityLivingBase entity = (EntityLivingBase) Minecraft.getMinecraft().theWorld.getEntityByID(m.entityID);
-			if(entity == null) return null;
+			if(entity == null || entity == Minecraft.getMinecraft().thePlayer) return null; //packets are sent to the player who fired
 			ItemStack stack = entity.getHeldItem();
 			if(stack == null) return null;
 			

--- a/src/main/java/com/hbm/packet/toclient/MuzzleFlashPacket.java
+++ b/src/main/java/com/hbm/packet/toclient/MuzzleFlashPacket.java
@@ -1,0 +1,62 @@
+package com.hbm.packet.toclient;
+
+import com.hbm.items.weapon.sedna.ItemGunBaseNT;
+import com.hbm.render.item.weapon.sedna.ItemRenderWeaponBase;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+
+public class MuzzleFlashPacket implements IMessage {
+	
+	private int entityID;
+	private int gunIndex; //e.g. akimbo
+	
+	public MuzzleFlashPacket() { }
+	
+	public MuzzleFlashPacket(EntityLivingBase entity) { this(entity, 0); }
+	
+	public MuzzleFlashPacket(EntityLivingBase entity, int index) {
+		this.entityID = entity.getEntityId();
+		this.gunIndex = index;
+	}
+	
+	@Override
+	public void toBytes(ByteBuf buf) {
+		buf.writeInt(entityID);
+		buf.writeInt(gunIndex);
+	}
+	
+	@Override
+	public void fromBytes(ByteBuf buf) {
+		this.entityID = buf.readInt();
+		this.gunIndex = buf.readInt();
+	}
+	
+	public static class Handler implements IMessageHandler<MuzzleFlashPacket, IMessage> {
+		
+		@SideOnly(Side.CLIENT)
+		@Override
+		public IMessage onMessage(MuzzleFlashPacket m, MessageContext ctx) {
+			EntityLivingBase entity = (EntityLivingBase) Minecraft.getMinecraft().theWorld.getEntityByID(m.entityID);
+			if(entity == null) return null;
+			ItemStack stack = entity.getHeldItem();
+			if(stack == null) return null;
+			
+			if(stack.getItem() instanceof ItemGunBaseNT) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				
+				ItemRenderWeaponBase.flashMap.put(entity, System.currentTimeMillis());
+			}
+			
+			return null;
+		}
+		
+	}
+}

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAberrator.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAberrator.java
@@ -194,7 +194,7 @@ public class ItemRenderAberrator extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 
 		GL11.glEnable(GL11.GL_LIGHTING);
 		GL11.glAlphaFunc(GL11.GL_GREATER, 0F);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAberrator.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAberrator.java
@@ -8,6 +8,7 @@ import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
@@ -208,6 +209,34 @@ public class ItemRenderAberrator extends ItemRenderWeaponBase {
 		ResourceManager.aberrator.renderPart("Slide");
 		ResourceManager.aberrator.renderPart("Sight");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 2, 4);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			GL11.glScaled(0.75, 0.75, 0.75);
+			this.renderMuzzleFlash(shot, 75, 7.5);
+			GL11.glPopMatrix();
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 2, -1.5);
+			GL11.glScaled(0.5, 0.5, 0.5);
+			this.renderFireball(shot);
+			GL11.glPopMatrix();
+		}
 	}
 	
 	public static void renderFireball(long lastShot) {
@@ -218,6 +247,7 @@ public class ItemRenderAberrator extends ItemRenderWeaponBase {
 		if(System.currentTimeMillis() - lastShot < flash) {
 			GL11.glEnable(GL11.GL_BLEND);
 			GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
+			GL11.glDisable(GL11.GL_CULL_FACE);
 			GL11.glPushMatrix();
 			
 			double fire = (System.currentTimeMillis() - lastShot) / (double) flash;
@@ -244,6 +274,7 @@ public class ItemRenderAberrator extends ItemRenderWeaponBase {
 			tess.draw();
 			GL11.glPopMatrix();
 			GL11.glDisable(GL11.GL_BLEND);
+			GL11.glEnable(GL11.GL_CULL_FACE);
 		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAm180.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAm180.java
@@ -9,6 +9,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderAm180 extends ItemRenderWeaponBase {
@@ -159,6 +160,30 @@ public class ItemRenderAm180 extends ItemRenderWeaponBase {
 		ResourceManager.am180.renderPart("Mag");
 		ResourceManager.am180.renderPart("MagPlate");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			boolean silenced = this.hasSilencer(stack);
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 1.875, silenced ? 16.75 : 12);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			double flashScale = silenced ? 0.5 : 0.75;
+			GL11.glScaled(flashScale, flashScale, flashScale);
+			this.renderMuzzleFlash(shot, silenced ? 75 : 50, silenced ? 5 : 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 	
 	public boolean hasSilencer(ItemStack stack) {

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAm180.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAm180.java
@@ -147,7 +147,7 @@ public class ItemRenderAm180 extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAmat.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAmat.java
@@ -9,6 +9,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -194,7 +195,9 @@ public class ItemRenderAmat extends ItemRenderWeaponBase {
 		ResourceManager.amat.renderPart("BipodRight");
 		ResourceManager.amat.renderPart("BipodHingeRight");
 		if(isScoped(stack)) ResourceManager.amat.renderPart("Scope");
-		if(isSilenced(stack)) {
+		
+		boolean silenced = isSilenced(stack);
+		if(silenced) {
 			GL11.glTranslated(0, 0.625, -4.3125);
 			GL11.glScaled(1.25, 1.25, 1.25);
 			Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.g3_attachments);
@@ -203,6 +206,25 @@ public class ItemRenderAmat extends ItemRenderWeaponBase {
 			ResourceManager.amat.renderPart("MuzzleBrake");
 		}
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED && !silenced) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0.5, 11);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glScaled(0.75, 0.75, 0.75);
+			this.renderGapFlash(shot);
+			GL11.glPopMatrix();
+		}
 	}
 	
 	public boolean isScoped(ItemStack stack) {

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAmat.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAmat.java
@@ -181,7 +181,7 @@ public class ItemRenderAmat extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAtlas.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAtlas.java
@@ -135,7 +135,7 @@ public class ItemRenderAtlas extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAtlas.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderAtlas.java
@@ -7,6 +7,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -142,5 +143,23 @@ public class ItemRenderAtlas extends ItemRenderWeaponBase {
 		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
 		ResourceManager.bio_revolver.renderAll();
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 1.5, 9.25);
+			GL11.glRotated(90, 0, 1, 0);
+			this.renderMuzzleFlash(shot, 75, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderBolter.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderBolter.java
@@ -114,7 +114,7 @@ public class ItemRenderBolter extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glRotated(180, 0, 1, 0);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderCarbine.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderCarbine.java
@@ -134,7 +134,7 @@ public class ItemRenderCarbine extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderCarbine.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderCarbine.java
@@ -8,6 +8,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderCarbine extends ItemRenderWeaponBase {
@@ -147,6 +148,28 @@ public class ItemRenderCarbine extends ItemRenderWeaponBase {
 			ResourceManager.carbine.renderPart("Bayonet");
 		}
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 1, 8);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			GL11.glScaled(0.5, 0.5, 0.5);
+			this.renderMuzzleFlash(shot, 75, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 	
 	public boolean hasBayonet(ItemStack stack) {

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderChargeThrower.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderChargeThrower.java
@@ -136,7 +136,7 @@ public class ItemRenderChargeThrower extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderChemthrower.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderChemthrower.java
@@ -86,7 +86,7 @@ public class ItemRenderChemthrower extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 
 		GL11.glRotated(90, 0, 1, 0);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderCoilgun.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderCoilgun.java
@@ -83,7 +83,7 @@ public class ItemRenderCoilgun extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glRotated(-90, 0, 1, 0);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderCongoLake.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderCongoLake.java
@@ -13,6 +13,7 @@ import com.hbm.render.anim.AnimationEnums.GunAnimation;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderCongoLake extends ItemRenderWeaponBase {
@@ -175,5 +176,27 @@ public class ItemRenderCongoLake extends ItemRenderWeaponBase {
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.congolake_tex);
 		ResourceManager.congolake.renderAll();
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 1.75, 4.25);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			GL11.glScaled(0.5, 0.5, 0.5);
+			this.renderMuzzleFlash(shot, 150, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderCongoLake.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderCongoLake.java
@@ -168,7 +168,7 @@ public class ItemRenderCongoLake extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderDANI.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderDANI.java
@@ -167,7 +167,7 @@ public class ItemRenderDANI extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderEquipped(ItemStack stack) {
+	public void renderEquipped(ItemStack stack, Object... data) {
 
 		GL11.glShadeModel(GL11.GL_SMOOTH);
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.dani_lunar_tex);
@@ -216,7 +216,7 @@ public class ItemRenderDANI extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 
 		GL11.glShadeModel(GL11.GL_SMOOTH);
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.dani_celestial_tex);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderDANI.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderDANI.java
@@ -7,6 +7,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderDANI extends ItemRenderWeaponBase {
@@ -173,15 +174,48 @@ public class ItemRenderDANI extends ItemRenderWeaponBase {
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.dani_lunar_tex);
 		ResourceManager.bio_revolver.renderAll();
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		//Stopgap: at the moment, the flashMap is gun agnostic and does not care about index.
+		EntityLivingBase ent = (EntityLivingBase) data[1]; //Entity is second obj. passed 
+		long shot;
+		if(ent == Minecraft.getMinecraft().thePlayer) {
+			ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+			shot = gun.lastShot[1];
+		} else {
+			shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+			if(shot < 0) return;
+		}
+		
+		GL11.glPushMatrix();
+		GL11.glTranslated(0, 1.5, 9.25);
+		GL11.glRotated(90, 0, 1, 0);
+		this.renderMuzzleFlash(shot, 75, 7.5);
+		GL11.glPopMatrix();
 	}
 
 	@Override
-	public void renderEquippedAkimbo(ItemStack stack) {
+	public void renderEquippedAkimbo(ItemStack stack, EntityLivingBase ent) {
 
 		GL11.glShadeModel(GL11.GL_SMOOTH);
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.dani_celestial_tex);
 		ResourceManager.bio_revolver.renderAll();
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		//EntityPlayer is first & only object passed
+		long shot;
+		if(ent == Minecraft.getMinecraft().thePlayer) {
+			ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+			shot = gun.lastShot[0];
+		} else {
+			shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+			if(shot < 0) return;
+		}
+		
+		GL11.glPushMatrix();
+		GL11.glTranslated(0, 1.5, 9.25);
+		GL11.glRotated(90, 0, 1, 0);
+		this.renderMuzzleFlash(shot, 75, 7.5);
+		GL11.glPopMatrix();
 	}
 
 	@Override

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderDebug.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderDebug.java
@@ -120,7 +120,7 @@ public class ItemRenderDebug extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 
 		GL11.glRotated(90, 0, 1, 0);
 		GL11.glEnable(GL11.GL_LIGHTING);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderDebug.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderDebug.java
@@ -7,6 +7,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderDebug extends ItemRenderWeaponBase {
@@ -136,5 +137,24 @@ public class ItemRenderDebug extends ItemRenderWeaponBase {
 		ResourceManager.lilmac.renderPart("Pivot");
 		ResourceManager.lilmac.renderPart("Hammer");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0.125, 2.5, 0);
+			this.renderGapFlash(shot);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderDoubleBarrel.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderDoubleBarrel.java
@@ -9,6 +9,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -170,6 +171,28 @@ public class ItemRenderDoubleBarrel extends ItemRenderWeaponBase {
 		ResourceManager.double_barrel.renderPart("Lever");
 		ResourceManager.double_barrel.renderPart("Shells");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0, 8);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			GL11.glScaled(2, 2, 2);
+			this.renderMuzzleFlash(shot, 75, 5);
+			GL11.glPopMatrix();
+		}
 	}
 	
 	public boolean isSawedOff(ItemStack stack) {

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderDoubleBarrel.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderDoubleBarrel.java
@@ -158,7 +158,7 @@ public class ItemRenderDoubleBarrel extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderDrill.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderDrill.java
@@ -127,7 +127,7 @@ public class ItemRenderDrill extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderEOTT.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderEOTT.java
@@ -209,7 +209,7 @@ public class ItemRenderEOTT extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderEquipped(ItemStack stack) {
+	public void renderEquipped(ItemStack stack, Object... data) {
 
 		GL11.glShadeModel(GL11.GL_SMOOTH);
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.eott_tex);
@@ -268,7 +268,7 @@ public class ItemRenderEOTT extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 
 		GL11.glEnable(GL11.GL_LIGHTING);
 		GL11.glAlphaFunc(GL11.GL_GREATER, 0F);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderEOTT.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderEOTT.java
@@ -8,6 +8,7 @@ import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderEOTT extends ItemRenderWeaponBase {
@@ -219,10 +220,36 @@ public class ItemRenderEOTT extends ItemRenderWeaponBase {
 		ResourceManager.aberrator.renderPart("Slide");
 		ResourceManager.aberrator.renderPart("Sight");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		EntityLivingBase ent = (EntityLivingBase) data[1];
+		long shot;
+		double shotRand = 0;
+		if(ent == Minecraft.getMinecraft().thePlayer) {
+			ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+			shot = gun.lastShot[1];
+			shotRand = gun.shotRand;
+		} else {
+			shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+			if(shot < 0) return;
+		}
+		
+		GL11.glPushMatrix();
+		GL11.glTranslated(0, 2, 4);
+		GL11.glRotated(90, 0, 1, 0);
+		GL11.glRotated(90 * shotRand, 1, 0, 0);
+		GL11.glScaled(0.75, 0.75, 0.75);
+		this.renderMuzzleFlash(shot, 75, 7.5);
+		GL11.glPopMatrix();
+		
+		GL11.glPushMatrix();
+		GL11.glTranslated(0, 2, -1.5);
+		GL11.glScaled(0.5, 0.5, 0.5);
+		this.renderFireball(shot);
+		GL11.glPopMatrix();
 	}
 
 	@Override
-	public void renderEquippedAkimbo(ItemStack stack) {
+	public void renderEquippedAkimbo(ItemStack stack, EntityLivingBase ent) {
 
 		GL11.glShadeModel(GL11.GL_SMOOTH);
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.eott_tex);
@@ -232,6 +259,31 @@ public class ItemRenderEOTT extends ItemRenderWeaponBase {
 		ResourceManager.aberrator.renderPart("Slide");
 		ResourceManager.aberrator.renderPart("Sight");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		long shot;
+		double shotRand = 0;
+		if(ent == Minecraft.getMinecraft().thePlayer) {
+			ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+			shot = gun.lastShot[0];
+			shotRand = gun.shotRand;
+		} else {
+			shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+			if(shot < 0) return;
+		}
+		
+		GL11.glPushMatrix();
+		GL11.glTranslated(0, 2, 4);
+		GL11.glRotated(90, 0, 1, 0);
+		GL11.glRotated(90 * shotRand, 1, 0, 0);
+		GL11.glScaled(0.75, 0.75, 0.75);
+		this.renderMuzzleFlash(shot, 75, 7.5);
+		GL11.glPopMatrix();
+		
+		GL11.glPushMatrix();
+		GL11.glTranslated(0, 2, -1.5);
+		GL11.glScaled(0.5, 0.5, 0.5);
+		this.renderFireball(shot);
+		GL11.glPopMatrix();
 	}
 
 	@Override
@@ -292,6 +344,7 @@ public class ItemRenderEOTT extends ItemRenderWeaponBase {
 		if(System.currentTimeMillis() - lastShot < flash) {
 			GL11.glEnable(GL11.GL_BLEND);
 			GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
+			GL11.glDisable(GL11.GL_CULL_FACE);
 			GL11.glPushMatrix();
 			
 			double fire = (System.currentTimeMillis() - lastShot) / (double) flash;
@@ -318,6 +371,7 @@ public class ItemRenderEOTT extends ItemRenderWeaponBase {
 			tess.draw();
 			GL11.glPopMatrix();
 			GL11.glDisable(GL11.GL_BLEND);
+			GL11.glEnable(GL11.GL_CULL_FACE);
 		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderFatMan.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderFatMan.java
@@ -119,7 +119,7 @@ public class ItemRenderFatMan extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 
 		ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderFlamer.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderFlamer.java
@@ -112,7 +112,7 @@ public class ItemRenderFlamer extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderFlaregun.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderFlaregun.java
@@ -120,7 +120,7 @@ public class ItemRenderFlaregun extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderFolly.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderFolly.java
@@ -202,7 +202,7 @@ public class ItemRenderFolly extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderG3.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderG3.java
@@ -9,6 +9,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -180,7 +181,7 @@ public class ItemRenderG3 extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		boolean silenced = hasSilencer(stack);
@@ -209,6 +210,28 @@ public class ItemRenderG3 extends ItemRenderWeaponBase {
 			if(isScoped) ResourceManager.g3.renderPart("Scope");
 		}
 		GL11.glShadeModel(GL11.GL_FLAT);
+		//third-person muzzle flashes
+		if(type == ItemRenderType.EQUIPPED && !silenced) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0, 12);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(-25 + shotRand * 10, 1, 0, 0);
+			GL11.glScaled(0.75, 0.75, 0.75);
+			this.renderMuzzleFlash(shot, 75, 10);
+			GL11.glPopMatrix();
+		}
 	}
 	
 	public boolean hasStock(ItemStack stack) {

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderGreasegun.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderGreasegun.java
@@ -143,13 +143,25 @@ public class ItemRenderGreasegun extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);
 		Minecraft.getMinecraft().renderEngine.bindTexture(isRefurbished(stack) ? ResourceManager.greasegun_clean_tex : ResourceManager.greasegun_tex);
 		ResourceManager.greasegun.renderAll();
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0, 8);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * gun.shotRand, 1, 0, 0);
+			GL11.glScaled(0.5, 0.5, 0.5);
+			this.renderMuzzleFlash(gun.lastShot[0], 75, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 	
 	public boolean isRefurbished(ItemStack stack) {

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderGreasegun.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderGreasegun.java
@@ -8,6 +8,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderGreasegun extends ItemRenderWeaponBase {
@@ -152,14 +153,24 @@ public class ItemRenderGreasegun extends ItemRenderWeaponBase {
 		GL11.glShadeModel(GL11.GL_FLAT);
 		
 		if(type == ItemRenderType.EQUIPPED) {
-			ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
 			
 			GL11.glPushMatrix();
 			GL11.glTranslated(0, 0, 8);
 			GL11.glRotated(90, 0, 1, 0);
-			GL11.glRotated(90 * gun.shotRand, 1, 0, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
 			GL11.glScaled(0.5, 0.5, 0.5);
-			this.renderMuzzleFlash(gun.lastShot[0], 75, 7.5);
+			this.renderMuzzleFlash(shot, 75, 7.5);
 			GL11.glPopMatrix();
 		}
 	}

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderHangman.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderHangman.java
@@ -7,6 +7,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderHangman extends ItemRenderWeaponBase {
@@ -141,5 +142,27 @@ public class ItemRenderHangman extends ItemRenderWeaponBase {
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.hangman_tex);
 		ResourceManager.hangman.renderAll();
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0, 29);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			GL11.glScaled(2, 2, 2);
+			this.renderMuzzleFlash(shot, 75, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderHangman.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderHangman.java
@@ -134,7 +134,7 @@ public class ItemRenderHangman extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderHeavyRevolver.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderHeavyRevolver.java
@@ -9,6 +9,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -173,6 +174,23 @@ public class ItemRenderHeavyRevolver extends ItemRenderWeaponBase {
 			ResourceManager.lilmac.renderPart("Scope");
 		}
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0.125, 2.5, 0);
+			this.renderGapFlash(shot);
+			GL11.glPopMatrix();
+		}
 	}
 	
 	public boolean isScoped(ItemStack stack) {

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderHeavyRevolver.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderHeavyRevolver.java
@@ -153,7 +153,7 @@ public class ItemRenderHeavyRevolver extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 
 		GL11.glRotated(90, 0, 1, 0);
 		GL11.glEnable(GL11.GL_LIGHTING);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderHenry.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderHenry.java
@@ -7,6 +7,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -167,5 +168,26 @@ public class ItemRenderHenry extends ItemRenderWeaponBase {
 		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
 		ResourceManager.henry.renderAll();
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 1, 8);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			this.renderMuzzleFlash(shot, 75, 5);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderHenry.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderHenry.java
@@ -160,7 +160,7 @@ public class ItemRenderHenry extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLAG.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLAG.java
@@ -135,7 +135,7 @@ public class ItemRenderLAG extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		GL11.glRotated(90, 0, 1, 0);
 		

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLAG.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLAG.java
@@ -7,6 +7,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderLAG extends ItemRenderWeaponBase {
@@ -145,5 +146,25 @@ public class ItemRenderLAG extends ItemRenderWeaponBase {
 		ResourceManager.mike_hawk.renderPart("Slide");
 		ResourceManager.mike_hawk.renderPart("Hammer");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(-10.25, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			this.renderMuzzleFlash(shot, 75, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLaserPistol.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLaserPistol.java
@@ -8,6 +8,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -131,6 +132,26 @@ public class ItemRenderLaserPistol extends ItemRenderWeaponBase {
 		ResourceManager.laser_pistol.renderPart("Latch");
 		if(hasCapacitors(stack)) ResourceManager.laser_pistol.renderPart("Capacitors");
 		if(hasTape(stack)) ResourceManager.laser_pistol.renderPart("Tape");
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 2, 4.75);
+			GL11.glRotated(90, 0, 1, 0);
+			renderLaserFlash(shot, 150, 1.5D, hasEmerald(stack) ? 0x008000 : 0xff0000);
+			GL11.glTranslated(0, 0, -0.25);
+			renderLaserFlash(shot, 150, 0.75D, hasEmerald(stack) ? 0x80ff00 : 0xff8000);
+			GL11.glPopMatrix();
+		}
 		GL11.glShadeModel(GL11.GL_FLAT);
 	}
 	

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLaserPistol.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLaserPistol.java
@@ -122,7 +122,7 @@ public class ItemRenderLaserPistol extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLasrifle.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLasrifle.java
@@ -8,6 +8,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderLasrifle extends ItemRenderWeaponBase {
@@ -134,6 +135,26 @@ public class ItemRenderLasrifle extends ItemRenderWeaponBase {
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.lasrifle_mods_tex);
 		if(hasShotgun(stack)) ResourceManager.lasrifle_mods.renderPart("BarrelShotgun");
 		if(hasCapacitor(stack)) ResourceManager.lasrifle_mods.renderPart("UnderBarrel");
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 1.5, 12);
+			GL11.glRotated(90, 0, 1, 0);
+			renderLaserFlash(shot, 150, 1.5D, 0xff0000);
+			GL11.glTranslated(0, 0, -0.25);
+			renderLaserFlash(shot, 150, 0.75D, 0xff8000);
+			GL11.glPopMatrix();
+		}
 		GL11.glShadeModel(GL11.GL_FLAT);
 	}
 	

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLasrifle.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLasrifle.java
@@ -120,7 +120,7 @@ public class ItemRenderLasrifle extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLiberator.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLiberator.java
@@ -150,7 +150,7 @@ public class ItemRenderLiberator extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLiberator.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderLiberator.java
@@ -8,6 +8,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderLiberator extends ItemRenderWeaponBase {
@@ -157,5 +158,27 @@ public class ItemRenderLiberator extends ItemRenderWeaponBase {
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.liberator_tex);
 		ResourceManager.liberator.renderAll();
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0.5, 8);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			GL11.glScaled(1.5, 1.5, 1.5);
+			this.renderMuzzleFlash(shot, 75, 5);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderM2.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderM2.java
@@ -102,7 +102,7 @@ public class ItemRenderM2 extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 
 		GL11.glRotated(180, 0, 1, 0);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderM2.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderM2.java
@@ -7,6 +7,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderM2 extends ItemRenderWeaponBase {
@@ -104,11 +105,35 @@ public class ItemRenderM2 extends ItemRenderWeaponBase {
 	@Override
 	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
-
+		
+		GL11.glPushMatrix();
 		GL11.glRotated(180, 0, 1, 0);
 		GL11.glShadeModel(GL11.GL_SMOOTH);
 		Minecraft.getMinecraft().getTextureManager().bindTexture(ResourceManager.m2_tex);
 		ResourceManager.m2.renderAll();
+		GL11.glPopMatrix();
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 1.625, 5);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			GL11.glScaled(0.5, 0.5, 0.5);
+			this.renderMuzzleFlash(shot, 75, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMAS36.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMAS36.java
@@ -178,7 +178,7 @@ public class ItemRenderMAS36 extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMAS36.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMAS36.java
@@ -11,6 +11,7 @@ import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GLAllocation;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderMAS36 extends ItemRenderWeaponBase {
@@ -190,6 +191,28 @@ public class ItemRenderMAS36 extends ItemRenderWeaponBase {
 		if(type != ItemRenderType.EQUIPPED) GL11.glTranslated(0, -1, -6);
 		if(hasBayonet(stack)) ResourceManager.mas36.renderPart("Bayonet");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 1, 8);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			GL11.glScaled(0.5, 0.5, 0.5);
+			this.renderMuzzleFlash(shot, 75, 10);
+			GL11.glPopMatrix();
+		}
 	}
 	
 	public boolean isScoped(ItemStack stack) {

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMaresleg.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMaresleg.java
@@ -155,7 +155,7 @@ public class ItemRenderMaresleg extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMaresleg.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMaresleg.java
@@ -9,6 +9,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -163,11 +164,33 @@ public class ItemRenderMaresleg extends ItemRenderWeaponBase {
 		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
 		ResourceManager.maresleg.renderPart("Gun");
 		ResourceManager.maresleg.renderPart("Lever");
-		if(!getShort(stack)) {
+		boolean shortened = getShort(stack);
+		if(!shortened) {
 			ResourceManager.maresleg.renderPart("Stock");
 			ResourceManager.maresleg.renderPart("Barrel");
 		}
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 1, shortened ? 3.75 : 8);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			this.renderMuzzleFlash(shot, 75, 5);
+			GL11.glPopMatrix();
+		}
 	}
 	
 	public boolean getShort(ItemStack stack) {

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMareslegAkimbo.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMareslegAkimbo.java
@@ -204,7 +204,7 @@ public class ItemRenderMareslegAkimbo extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 
 		GL11.glShadeModel(GL11.GL_SMOOTH);
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.maresleg_tex);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMareslegAkimbo.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMareslegAkimbo.java
@@ -7,6 +7,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderMareslegAkimbo extends ItemRenderWeaponBase {
@@ -201,6 +202,53 @@ public class ItemRenderMareslegAkimbo extends ItemRenderWeaponBase {
 		GL11.glPopMatrix();
 		
 		GL11.glShadeModel(GL11.GL_FLAT);
+	}
+	
+	@Override
+	public void renderEquipped(ItemStack stack, Object... data) {
+		renderOther(stack, ItemRenderType.EQUIPPED);
+		//grumble grumble
+		EntityLivingBase ent = (EntityLivingBase) data[1];
+		long shot;
+		double shotRand = 0;
+		if(ent == Minecraft.getMinecraft().thePlayer) {
+			ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+			shot = gun.lastShot[1];
+			shotRand = gun.shotRand;
+		} else {
+			shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+			if(shot < 0) return;
+		}
+		
+		GL11.glPushMatrix();
+		GL11.glTranslated(0, 1, 3.75);
+		GL11.glRotated(90, 0, 1, 0);
+		GL11.glRotated(90 * shotRand, 1, 0, 0);
+		this.renderMuzzleFlash(shot, 75, 5);
+		GL11.glPopMatrix();
+	}
+	
+	@Override
+	public void renderEquippedAkimbo(ItemStack stack, EntityLivingBase ent) {
+		renderOther(stack, ItemRenderType.EQUIPPED);
+		
+		long shot;
+		double shotRand = 0;
+		if(ent == Minecraft.getMinecraft().thePlayer) {
+			ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+			shot = gun.lastShot[0];
+			shotRand = gun.shotRand;
+		} else {
+			shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+			if(shot < 0) return;
+		}
+		
+		GL11.glPushMatrix();
+		GL11.glTranslated(0, 1, 3.75);
+		GL11.glRotated(90, 0, 1, 0);
+		GL11.glRotated(90 * shotRand, 1, 0, 0);
+		this.renderMuzzleFlash(shot, 75, 5);
+		GL11.glPopMatrix();
 	}
 
 	@Override

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMinigun.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMinigun.java
@@ -120,7 +120,7 @@ public class ItemRenderMinigun extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMinigun.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMinigun.java
@@ -8,6 +8,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -129,5 +130,34 @@ public class ItemRenderMinigun extends ItemRenderWeaponBase {
 		ResourceManager.minigun.renderPart("Grip");
 		ResourceManager.minigun.renderPart("Barrels");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0, 12);
+			GL11.glRotated(90, 0, 1, 0);
+			
+			if(stack.getItem() == ModItems.gun_minigun_lacunae) {
+				renderLaserFlash(shot, 50, 1D, 0xff00ff);
+				GL11.glTranslated(0, 0, -0.25);
+				renderLaserFlash(shot, 50, 0.5D, 0xff0080);
+			} else {
+				GL11.glRotated(shotRand * 90, 1, 0, 0);
+				GL11.glScaled(1.5, 1.5, 1.5);
+				this.renderMuzzleFlash(shot, 75, 5);
+			}
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMinigunDual.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMinigunDual.java
@@ -112,7 +112,7 @@ public class ItemRenderMinigunDual extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderEquipped(ItemStack stack) {
+	public void renderEquipped(ItemStack stack, Object... data) {
 
 		GL11.glShadeModel(GL11.GL_SMOOTH);
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.minigun_dual_tex);
@@ -172,7 +172,7 @@ public class ItemRenderMinigunDual extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMinigunDual.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMinigunDual.java
@@ -8,6 +8,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderMinigunDual extends ItemRenderWeaponBase {
@@ -119,16 +120,57 @@ public class ItemRenderMinigunDual extends ItemRenderWeaponBase {
 		ResourceManager.minigun.renderPart("Gun");
 		ResourceManager.minigun.renderPart("Barrels");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		EntityLivingBase ent = (EntityLivingBase) data[1];
+		long shot;
+		double shotRand = 0;
+		if(ent == Minecraft.getMinecraft().thePlayer) {
+			ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+			shot = gun.lastShot[1];
+			shotRand = gun.shotRand;
+		} else {
+			shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+			if(shot < 0) return;
+		}
+		
+		GL11.glPushMatrix();
+		GL11.glTranslated(0, 0, 12);
+		GL11.glRotated(90, 0, 1, 0);
+		
+		GL11.glRotated(shotRand * 90, 1, 0, 0);
+		GL11.glScaled(1.5, 1.5, 1.5);
+		this.renderMuzzleFlash(shot, 75, 5);
+		GL11.glPopMatrix();
 	}
 
 	@Override
-	public void renderEquippedAkimbo(ItemStack stack) {
+	public void renderEquippedAkimbo(ItemStack stack, EntityLivingBase ent) {
 
 		GL11.glShadeModel(GL11.GL_SMOOTH);
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.minigun_dual_tex);
 		ResourceManager.minigun.renderPart("GunDual");
 		ResourceManager.minigun.renderPart("Barrels");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		long shot;
+		double shotRand = 0;
+		if(ent == Minecraft.getMinecraft().thePlayer) {
+			ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+			shot = gun.lastShot[0];
+			shotRand = gun.shotRand;
+		} else {
+			shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+			if(shot < 0) return;
+		}
+		
+		GL11.glPushMatrix();
+		GL11.glTranslated(0, 0, 12);
+		GL11.glRotated(90, 0, 1, 0);
+		
+		GL11.glRotated(shotRand * 90, 1, 0, 0);
+		GL11.glScaled(1.5, 1.5, 1.5);
+		this.renderMuzzleFlash(shot, 75, 5);
+		GL11.glPopMatrix();
 	}
 
 	@Override

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMissileLauncher.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMissileLauncher.java
@@ -11,6 +11,7 @@ import com.hbm.render.anim.HbmAnimations;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
@@ -153,5 +154,26 @@ public class ItemRenderMissileLauncher extends ItemRenderWeaponBase {
 		ResourceManager.missile_launcher.renderPart("Front");
 		if(gun.getConfig(stack, 0).getReceivers(stack)[0].getMagazine(stack).getAmount(stack, null) > 0) ResourceManager.missile_launcher.renderPart("Missile");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 1, 6.75);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(shotRand * 90, 1, 0, 0);
+			GL11.glScaled(0.75, 0.75, 0.75);
+			this.renderMuzzleFlash(shot, 75, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMissileLauncher.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderMissileLauncher.java
@@ -141,7 +141,7 @@ public class ItemRenderMissileLauncher extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.missile_launcher_tex);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderNI4NI.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderNI4NI.java
@@ -10,6 +10,7 @@ import com.hbm.render.tileentity.RenderArcFurnace;
 import com.hbm.util.ColorUtil;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderNI4NI extends ItemRenderWeaponBase {
@@ -185,5 +186,27 @@ public class ItemRenderNI4NI extends ItemRenderWeaponBase {
 		GL11.glEnable(GL11.GL_TEXTURE_2D);
 		RenderArcFurnace.fullbright(false);
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0.75, 4);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			GL11.glScaled(0.125, 0.125, 0.125);
+			this.renderLaserFlash(shot, 75, 7.5, 0xFFFFFF);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderNI4NI.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderNI4NI.java
@@ -144,7 +144,7 @@ public class ItemRenderNI4NI extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 
 		GL11.glEnable(GL11.GL_LIGHTING);
 		GL11.glAlphaFunc(GL11.GL_GREATER, 0F);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderPanzerschreck.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderPanzerschreck.java
@@ -8,6 +8,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderPanzerschreck extends ItemRenderWeaponBase {
@@ -107,6 +108,28 @@ public class ItemRenderPanzerschreck extends ItemRenderWeaponBase {
 		ResourceManager.panzerschreck.renderPart("Tube");
 		if(hasShield(stack)) ResourceManager.panzerschreck.renderPart("Shield");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0, 6.5);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			GL11.glScaled(0.75, 0.75, 0.75);
+			this.renderMuzzleFlash(shot, 150, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 	
 	public boolean hasShield(ItemStack stack) {

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderPanzerschreck.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderPanzerschreck.java
@@ -99,7 +99,7 @@ public class ItemRenderPanzerschreck extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderPepperbox.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderPepperbox.java
@@ -7,6 +7,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderPepperbox extends ItemRenderWeaponBase {
@@ -138,5 +139,29 @@ public class ItemRenderPepperbox extends ItemRenderWeaponBase {
 		ResourceManager.pepperbox.renderPart("Hammer");
 		ResourceManager.pepperbox.renderPart("Trigger");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0.5, 7);
+			GL11.glScaled(0.5, 0.5, 0.5);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			this.renderMuzzleFlash(shot);
+			GL11.glRotated(45, 1, 0, 0);
+			this.renderMuzzleFlash(shot);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderPepperbox.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderPepperbox.java
@@ -127,7 +127,7 @@ public class ItemRenderPepperbox extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 
 		GL11.glEnable(GL11.GL_LIGHTING);
 		

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderQuadro.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderQuadro.java
@@ -11,6 +11,7 @@ import com.hbm.render.anim.HbmAnimations;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
@@ -145,5 +146,27 @@ public class ItemRenderQuadro extends ItemRenderWeaponBase {
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.quadro_tex);
 		ResourceManager.quadro.renderPart("Launcher");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix(); //TODO: adjust in third person, flash is too far forward/ large
+			GL11.glTranslated(0, 0.75, 2);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			GL11.glScaled(0.75, 0.75, 0.75);
+			this.renderMuzzleFlash(shot, 150, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderQuadro.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderQuadro.java
@@ -138,7 +138,7 @@ public class ItemRenderQuadro extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderSPAS12.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderSPAS12.java
@@ -11,6 +11,7 @@ import com.hbm.particle.SpentCasing;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderSPAS12 extends ItemRenderWeaponBase {
@@ -140,5 +141,26 @@ public class ItemRenderSPAS12 extends ItemRenderWeaponBase {
 		ResourceManager.spas_12.renderPart("MainBody");
 		ResourceManager.spas_12.renderPart("PumpGrip");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 1.5, -11);
+			GL11.glRotated(-90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			this.renderMuzzleFlash(shot, 75, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderSPAS12.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderSPAS12.java
@@ -131,7 +131,7 @@ public class ItemRenderSPAS12 extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 
 		GL11.glRotated(180, 0, 1, 0);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderSTG77.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderSTG77.java
@@ -171,7 +171,7 @@ public class ItemRenderSTG77 extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderSTG77.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderSTG77.java
@@ -7,6 +7,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderSTG77 extends ItemRenderWeaponBase {
@@ -184,5 +185,27 @@ public class ItemRenderSTG77 extends ItemRenderWeaponBase {
 		ResourceManager.stg77.renderPart("Handle");
 		ResourceManager.stg77.renderPart("Breech");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0, 7.5);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glScaled(0.25, 0.25, 0.25);
+			GL11.glRotated(-5 + shotRand * 10, 1, 0, 0);
+			this.renderGapFlash(shot);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderSexy.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderSexy.java
@@ -10,6 +10,7 @@ import com.hbm.util.BobMathUtil;
 import com.hbm.util.Vec3NT;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -234,6 +235,27 @@ public class ItemRenderSexy extends ItemRenderWeaponBase {
 		renderShell(p * 17, p * -20, -90, true);
 		
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0, 8);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			this.renderMuzzleFlash(shot, 150, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 	
 	public static void renderShell(double x0, double x1, double y0, double y1, double rot0, double rot1, boolean shell, double interp) {

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderSexy.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderSexy.java
@@ -212,7 +212,7 @@ public class ItemRenderSexy extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderShredder.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderShredder.java
@@ -12,6 +12,7 @@ import com.hbm.render.anim.HbmAnimations;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
@@ -174,5 +175,27 @@ public class ItemRenderShredder extends ItemRenderWeaponBase {
 		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
 		ResourceManager.shredder.renderAll();
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 1, 7.5);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(shotRand * 90, 1, 0, 0);
+			GL11.glScaled(0.75, 0.75, 0.75);
+			this.renderMuzzleFlash(shot, 75, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderShredder.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderShredder.java
@@ -167,7 +167,7 @@ public class ItemRenderShredder extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderStinger.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderStinger.java
@@ -127,7 +127,7 @@ public class ItemRenderStinger extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderStinger.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderStinger.java
@@ -9,6 +9,7 @@ import com.hbm.render.anim.HbmAnimations;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderStinger extends ItemRenderWeaponBase {
@@ -135,5 +136,27 @@ public class ItemRenderStinger extends ItemRenderWeaponBase {
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.stinger_tex);
 		ResourceManager.stinger.renderAll();
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 3.5, -10.3795);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			GL11.glScaled(0.75, 0.75, 0.75);
+			this.renderMuzzleFlash(shot, 150, 10);
+			GL11.glPopMatrix();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderTau.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderTau.java
@@ -88,7 +88,7 @@ public class ItemRenderTau extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderTeslaCannon.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderTeslaCannon.java
@@ -136,7 +136,7 @@ public class ItemRenderTeslaCannon extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 
 		Minecraft.getMinecraft().renderEngine.bindTexture(ResourceManager.tesla_cannon_tex);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderUzi.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderUzi.java
@@ -154,7 +154,7 @@ public class ItemRenderUzi extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		
 		boolean silenced = hasSilencer(stack, 0);

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderUzi.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderUzi.java
@@ -8,6 +8,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderUzi extends ItemRenderWeaponBase {
@@ -174,6 +175,27 @@ public class ItemRenderUzi extends ItemRenderWeaponBase {
 		ResourceManager.uzi.renderPart("Magazine");
 		if(silenced) ResourceManager.uzi.renderPart("Silencer");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(type == ItemRenderType.EQUIPPED && !silenced) {
+			EntityLivingBase ent = (EntityLivingBase) data[1];
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0.75, 8.5);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			this.renderMuzzleFlash(shot, 75, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 	
 	public boolean hasSilencer(ItemStack stack, int cfg) {

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderUziAkimbo.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderUziAkimbo.java
@@ -153,7 +153,7 @@ public class ItemRenderUziAkimbo extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderEquipped(ItemStack stack) {
+	public void renderEquipped(ItemStack stack, Object... data) {
 
 		GL11.glShadeModel(GL11.GL_SMOOTH);
 		Minecraft.getMinecraft().renderEngine.bindTexture(isSaturnite(stack, 1) ? ResourceManager.uzi_saturnite_tex : ResourceManager.uzi_tex);
@@ -234,7 +234,7 @@ public class ItemRenderUziAkimbo extends ItemRenderWeaponBase {
 	}
 
 	@Override
-	public void renderOther(ItemStack stack, ItemRenderType type) {
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) {
 		GL11.glEnable(GL11.GL_LIGHTING);
 		GL11.glShadeModel(GL11.GL_SMOOTH);
 

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderUziAkimbo.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderUziAkimbo.java
@@ -8,6 +8,7 @@ import com.hbm.main.ResourceManager;
 import com.hbm.render.anim.HbmAnimations;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public class ItemRenderUziAkimbo extends ItemRenderWeaponBase {
@@ -162,12 +163,34 @@ public class ItemRenderUziAkimbo extends ItemRenderWeaponBase {
 		ResourceManager.uzi.renderPart("StockFront");
 		ResourceManager.uzi.renderPart("Slide");
 		ResourceManager.uzi.renderPart("Magazine");
-		if(hasSilencer(stack, 1)) ResourceManager.uzi.renderPart("Silencer");
+		boolean silenced = hasSilencer(stack, 1);
+		if(silenced) ResourceManager.uzi.renderPart("Silencer");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(!silenced) {
+			EntityLivingBase ent = (EntityLivingBase) data[1]; //Entity is second obj. passed 
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[1];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0.75, 8.5);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			this.renderMuzzleFlash(shot, 75, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 
 	@Override
-	public void renderEquippedAkimbo(ItemStack stack) {
+	public void renderEquippedAkimbo(ItemStack stack, EntityLivingBase ent) {
 
 		GL11.glShadeModel(GL11.GL_SMOOTH);
 		Minecraft.getMinecraft().renderEngine.bindTexture(isSaturnite(stack, 0) ? ResourceManager.uzi_saturnite_tex : ResourceManager.uzi_tex);
@@ -176,8 +199,29 @@ public class ItemRenderUziAkimbo extends ItemRenderWeaponBase {
 		ResourceManager.uzi.renderPart("StockFront");
 		ResourceManager.uzi.renderPart("Slide");
 		ResourceManager.uzi.renderPart("Magazine");
-		if(hasSilencer(stack, 0)) ResourceManager.uzi.renderPart("Silencer");
+		boolean silenced = hasSilencer(stack, 0);
+		if(silenced) ResourceManager.uzi.renderPart("Silencer");
 		GL11.glShadeModel(GL11.GL_FLAT);
+		
+		if(!silenced) {
+			long shot;
+			double shotRand = 0;
+			if(ent == Minecraft.getMinecraft().thePlayer) {
+				ItemGunBaseNT gun = (ItemGunBaseNT) stack.getItem();
+				shot = gun.lastShot[0];
+				shotRand = gun.shotRand;
+			} else {
+				shot = ItemRenderWeaponBase.flashMap.getOrDefault(ent, (long) -1);
+				if(shot < 0) return;
+			}
+			
+			GL11.glPushMatrix();
+			GL11.glTranslated(0, 0.75, 8.5);
+			GL11.glRotated(90, 0, 1, 0);
+			GL11.glRotated(90 * shotRand, 1, 0, 0);
+			this.renderMuzzleFlash(shot, 75, 7.5);
+			GL11.glPopMatrix();
+		}
 	}
 
 	@Override

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderWeaponBase.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderWeaponBase.java
@@ -1,5 +1,6 @@
 package com.hbm.render.item.weapon.sedna;
 
+import java.util.HashMap;
 import java.util.List;
 
 import org.lwjgl.opengl.GL11;
@@ -33,6 +34,7 @@ public abstract class ItemRenderWeaponBase implements IItemRenderer {
 	public static final ResourceLocation laser_flash = new ResourceLocation(RefStrings.MODID, "textures/models/weapons/laser_flash.png");
 	
 	public static float interp;
+	public static HashMap<EntityLivingBase, Long> flashMap = new HashMap<EntityLivingBase, Long>();
 
 	public boolean isAkimbo() { return false; }
 	public boolean isLeftHanded() { return false; }
@@ -46,7 +48,7 @@ public abstract class ItemRenderWeaponBase implements IItemRenderer {
 	public boolean shouldUseRenderHelper(ItemRenderType type, ItemStack item, ItemRendererHelper helper) {
 		return helper == ItemRendererHelper.ENTITY_BOBBING || helper == ItemRendererHelper.ENTITY_ROTATION;
 	}
-
+	
 	@SuppressWarnings("incomplete-switch") //shut the fuck up
 	@Override
 	public void renderItem(ItemRenderType type, ItemStack item, Object... data) {
@@ -55,14 +57,14 @@ public abstract class ItemRenderWeaponBase implements IItemRenderer {
 		switch(type) {
 		case EQUIPPED_FIRST_PERSON:	setupFirstPerson(item);	renderFirstPerson(item); break;
 		case EQUIPPED:
-		if(isLeftHanded()) break;	setupThirdPerson(item);	renderEquipped(item); break;
+		if(isLeftHanded()) break;	setupThirdPerson(item);	renderEquipped(item, data); break;
 		case INVENTORY:				setupInv(item);			renderInv(item); break;
 		case ENTITY:				setupEntity(item);		renderEntity(item); break;
 		}
 		GL11.glPopMatrix();
 	}
-
-	public void renderEquipped(ItemStack stack) { renderOther(stack, ItemRenderType.EQUIPPED); }
+	//entitylivingbase is second Object passed
+	public void renderEquipped(ItemStack stack, Object... data) { renderOther(stack, ItemRenderType.EQUIPPED, data); }
 	public void renderEquippedAkimbo(ItemStack stack) { renderOther(stack, ItemRenderType.EQUIPPED); }
 	public void renderInv(ItemStack stack) { renderOther(stack, ItemRenderType.INVENTORY); }
 	public void renderEntity(ItemStack stack) { renderOther(stack, ItemRenderType.ENTITY); }
@@ -277,7 +279,7 @@ public abstract class ItemRenderWeaponBase implements IItemRenderer {
 	}
 
 	public abstract void renderFirstPerson(ItemStack stack);
-	public void renderOther(ItemStack stack, ItemRenderType type) { }
+	public void renderOther(ItemStack stack, ItemRenderType type, Object... data) { }
 	
 	public static void standardAimingTransform(ItemStack stack, double sX, double sY, double sZ, double aX, double aY, double aZ) {
 		float aimingProgress = ItemGunBaseNT.prevAimingProgress + (ItemGunBaseNT.aimingProgress - ItemGunBaseNT.prevAimingProgress) * interp;
@@ -347,6 +349,7 @@ public abstract class ItemRenderWeaponBase implements IItemRenderer {
 			GL11.glEnable(GL11.GL_BLEND);
 			GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
 			GL11.glDepthMask(false);
+			GL11.glDisable(GL11.GL_CULL_FACE);
 			GL11.glPushMatrix();
 			
 			double fire = (System.currentTimeMillis() - lastShot) / (double) flash;
@@ -384,6 +387,7 @@ public abstract class ItemRenderWeaponBase implements IItemRenderer {
 			GL11.glPopMatrix();
 			GL11.glDepthMask(true);
 			GL11.glDisable(GL11.GL_BLEND);
+			GL11.glEnable(GL11.GL_CULL_FACE);
 		}
 	}
 	

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderWeaponBase.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderWeaponBase.java
@@ -65,7 +65,7 @@ public abstract class ItemRenderWeaponBase implements IItemRenderer {
 	}
 	//entitylivingbase is second Object passed
 	public void renderEquipped(ItemStack stack, Object... data) { renderOther(stack, ItemRenderType.EQUIPPED, data); }
-	public void renderEquippedAkimbo(ItemStack stack) { renderOther(stack, ItemRenderType.EQUIPPED); }
+	public void renderEquippedAkimbo(ItemStack stack, EntityLivingBase entity) { renderOther(stack, ItemRenderType.EQUIPPED); }
 	public void renderInv(ItemStack stack) { renderOther(stack, ItemRenderType.INVENTORY); }
 	public void renderEntity(ItemStack stack) { renderOther(stack, ItemRenderType.ENTITY); }
 
@@ -399,6 +399,7 @@ public abstract class ItemRenderWeaponBase implements IItemRenderer {
 		if(System.currentTimeMillis() - lastShot < flash) {
 			GL11.glEnable(GL11.GL_BLEND);
 			GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
+			GL11.glDisable(GL11.GL_CULL_FACE);
 			GL11.glPushMatrix();
 			
 			double fire = (System.currentTimeMillis() - lastShot) / (double) flash;
@@ -437,6 +438,7 @@ public abstract class ItemRenderWeaponBase implements IItemRenderer {
 			tess.draw();
 			GL11.glPopMatrix();
 			GL11.glDisable(GL11.GL_BLEND);
+			GL11.glEnable(GL11.GL_CULL_FACE);
 		}
 	}
 	
@@ -447,6 +449,7 @@ public abstract class ItemRenderWeaponBase implements IItemRenderer {
 			GL11.glEnable(GL11.GL_BLEND);
 			GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
 			GL11.glDepthMask(false);
+			GL11.glDisable(GL11.GL_CULL_FACE);
 			GL11.glPushMatrix();
 			
 			double fire = (System.currentTimeMillis() - lastShot) / (double) flash;
@@ -469,6 +472,7 @@ public abstract class ItemRenderWeaponBase implements IItemRenderer {
 			GL11.glPopMatrix();
 			GL11.glDepthMask(true);
 			GL11.glDisable(GL11.GL_BLEND);
+			GL11.glEnable(GL11.GL_CULL_FACE);
 		}
 	}
 }


### PR DESCRIPTION
CoC:
 - Added MuzzleFlashPackets and tweaked ItemRenderWeaponBase + subclasses
   - Now, any player can see the muzzle flashes of any other entity's SEDNA gun
     - Default range of 100 blocks for packets - if needed, specific guns can have a larger range
   - Works for F5 third-person (thanks, GL_CULL_FACE!)
   - Akimbos will technically always "fire" both guns to other players, due to technical limitations (the hashmap uses entities, and is gun-agnostic) but F5 works fine!
 - Support for changing non-player entities' animation states added to ItemGunBaseNT
   - No actual animations, but allows the orchestra system to work
   - Skeleguns will not only show muzzle flashes, but play reload sounds, eject spent casings, etc.
 - Tested on SP, LAN, and dedicated MP for each affected gun + skeleguns with two clients through the IDE with no crashes/errors, so hopefully server-safe!