### PR TITLE
Fix incorrect OreDictionary key for NaquadahEnriched

### DIFF
--- a/src/main/java/com/hbm/crafting/RodRecipes.java
+++ b/src/main/java/com/hbm/crafting/RodRecipes.java
@@ -158,28 +158,28 @@ public class RodRecipes {
 
 		CraftingManager.addRecipeAuto(new ItemStack(ModItems.icf_pellet_empty), new Object[] { "ZLZ", "L L", "ZLZ", 'Z', ZR.wireFine(), 'L', PB.wireFine() });
 	}
-	
+
 	public static void registerInit() {
 		/* GT6 */
-		if(OreDictionary.doesOreNameExist("ingotNaquadah-Enriched"))	addPellet(new DictFrame("Naquadah-Enriched"),	EnumWatzType.NQD);
+		if(OreDictionary.doesOreNameExist("ingotNaquadahEnriched"))		addPellet(new DictFrame("NaquadahEnriched"),	EnumWatzType.NQD);
 		if(OreDictionary.doesOreNameExist("ingotNaquadria"))			addPellet(new DictFrame("Naquadria"),			EnumWatzType.NQR);
 	}
-	
+
 	//Fill rods with one billet. For fuels only, therefore no unloading or ore dict
 	public static void addFuelRodBillet(Item billet, Item out) {
 		CraftingManager.addShapelessAuto(new ItemStack(out), new Object[] { ModItems.rod_empty, billet });
 	}
-	
+
 	//Fill rods with two billets
 	public static void addDualFuelRodBillet(Item billet, Item out) {
 		CraftingManager.addShapelessAuto(new ItemStack(out), new Object[] { ModItems.rod_dual_empty, billet, billet });
 	}
-	
+
 	//Fill rods with three billets
 	public static void addQuadFuelRodBillet(Item billet, Item out) {
 		CraftingManager.addShapelessAuto(new ItemStack(out), new Object[] { ModItems.rod_quad_empty, billet, billet, billet, billet });
 	}
-	
+
 	//Fill rods with one billet + unload
 	public static void addRodBilletUnload(Item billet, Item out) {
 		CraftingManager.addShapelessAuto(new ItemStack(out), new Object[] { ModItems.rod_empty, billet });


### PR DESCRIPTION
Fixes incorrect OreDictionary key "ingotNaquadah-Enriched".
The correct key should be "ingotNaquadahEnriched".
For GT6.