### PR TITLE
Rewrite autosaw fellTree with 0-1 BFS tree detection

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineAutosaw.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineAutosaw.java
@@ -1,10 +1,14 @@
 package com.hbm.tileentity.machine;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import com.hbm.blocks.ModBlocks;
+import com.hbm.util.fauxpointtwelve.BlockPos;
 import com.hbm.blocks.generic.BlockTallPlant.EnumTallFlower;
 import com.hbm.handler.threading.PacketThreading;
 import com.hbm.inventory.fluid.FluidType;
@@ -38,6 +42,22 @@ import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.common.util.ForgeDirection;
 
 public class TileEntityMachineAutosaw extends TileEntityLoadedBase implements IBufPacketReceiver, IFluidStandardReceiver, IFluidCopiable {
+
+	private static final int MIN_DIST = 2;
+	private static final int MAX_DIST = 9;
+
+	private static final int FELL_HORIZONTAL_RANGE = 10;
+	private static final int FELL_BFS_RADIUS = MAX_DIST + FELL_HORIZONTAL_RANGE;
+	private static final int FELL_VERTICAL_RANGE = 32;
+	private static final int FELL_MAX_BASE_DEPTH = FELL_VERTICAL_RANGE / 2;
+
+	// 18-connectivity: 6 face-adjacent + 12 edge-adjacent (exactly one coord diff is 0)
+	private static final int[][] EIGHTEEN_DIRS = {
+		{1, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, -1, 0}, {0, 0, 1}, {0, 0, -1},
+		{1, 1, 0}, {1, -1, 0}, {-1, 1, 0}, {-1, -1, 0},
+		{1, 0, 1}, {1, 0, -1}, {-1, 0, 1}, {-1, 0, -1},
+		{0, 1, 1}, {0, 1, -1}, {0, -1, 1}, {0, -1, -1}
+	};
 
 	public static final HashSet<FluidType> acceptedFuels = new HashSet();
 
@@ -134,11 +154,11 @@ public class TileEntityMachineAutosaw extends TileEntityLoadedBase implements IB
 						double rotationYawRads = Math.toRadians((rotationYaw + 270) % 360);
 
 						outer:
-						for(int dx = -9; dx <= 9; dx++) {
-							for(int dz = -9; dz <= 9; dz++) {
+						for(int dx = -MAX_DIST; dx <= MAX_DIST; dx++) {
+							for(int dz = -MAX_DIST; dz <= MAX_DIST; dz++) {
 								int sqrDst = dx * dx + dz * dz;
 
-								if(sqrDst <= 4 || sqrDst > 81)
+								if(sqrDst <= MIN_DIST * MIN_DIST || sqrDst > MAX_DIST * MAX_DIST)
 									continue;
 								
 								double angle = Math.atan2(dz, dx);
@@ -316,39 +336,165 @@ public class TileEntityMachineAutosaw extends TileEntityLoadedBase implements IB
 		worldObj.setBlock(x, y, z, replacementBlock, replacementMeta, 3);
 	}
 
-	protected void fellTree(int x, int y, int z) {
+	protected void fellTree(int hitX, int hitY, int hitZ) {
 
-		if(worldObj.getBlock(x, y - 1, z).getMaterial() == Material.wood) {
-			y--;
-			if(worldObj.getBlock(x, y - 2, z).getMaterial() == Material.wood) {
-				y--;
+		int sawY = hitY;
+		BlockPos hitCol = new BlockPos(hitX, -1, hitZ);
+
+		// Step A: Scan working area for trunks (column -> trunk base pos)
+		HashMap<BlockPos, BlockPos> trunks = new HashMap<BlockPos, BlockPos>();
+
+		for(int dx = -MAX_DIST; dx <= MAX_DIST; dx++) {
+			for(int dz = -MAX_DIST; dz <= MAX_DIST; dz++) {
+				if(dx * dx + dz * dz > MAX_DIST * MAX_DIST) {
+					continue;
+				}
+
+				int colX = xCoord + dx;
+				int colZ = zCoord + dz;
+
+				if(worldObj.getBlock(colX, sawY, colZ).getMaterial() != Material.wood) {
+					continue;
+				}
+
+				int baseY = sawY;
+				while(sawY - baseY < FELL_MAX_BASE_DEPTH && worldObj.getBlock(colX, baseY - 1, colZ).getMaterial() == Material.wood) {
+					baseY--;
+				}
+
+				if(!canSupportSapling(worldObj, colX, baseY - 1, colZ)) {
+					continue;
+				}
+
+				trunks.put(new BlockPos(colX, -1, colZ), new BlockPos(colX, baseY, colZ));
 			}
 		}
 
-		int meta = -1;
+		// Always include the hit position's trunk
+		if(!trunks.containsKey(hitCol)) {
+			int baseY = hitY;
+			while(sawY - baseY < FELL_MAX_BASE_DEPTH && worldObj.getBlock(hitX, baseY - 1, hitZ).getMaterial() == Material.wood) {
+				baseY--;
+			}
+			trunks.put(hitCol, new BlockPos(hitX, baseY, hitZ));
+		}
 
-		for(int i = y; i < y + 10; i++) {
+		// Step B: 0-1 BFS from all trunks
+		// Vertical neighbors (same column) have distance 0, horizontal neighbors have distance 1
+		// blockOwner: block pos -> column of owning trunk
+		HashMap<BlockPos, BlockPos> blockOwner = new HashMap<BlockPos, BlockPos>();
+		ArrayDeque<BlockPos[]> deque = new ArrayDeque<BlockPos[]>();
+		int hitColCount = 1;
 
-			int[][] dir = new int[][] {{0, 0}, {1, 0}, {-1, 0}, {0, 1}, {0, -1}};
+		int minY = Math.max(0, sawY - FELL_MAX_BASE_DEPTH);
+		int maxY = Math.min(255, sawY + FELL_VERTICAL_RANGE);
 
-			for(int[] d : dir) {
-				Block b = worldObj.getBlock(x + d[0], i, z + d[1]);
+		for(Map.Entry<BlockPos, BlockPos> trunk : trunks.entrySet()) {
+			deque.addFirst(new BlockPos[] {trunk.getValue(), trunk.getKey()});
+		}
 
-				if(b.getMaterial() == Material.wood) {
-					worldObj.func_147480_a(x + d[0], i, z + d[1], true);
-				} else if(b instanceof BlockLeaves) {
-					meta = worldObj.getBlockMetadata(x + d[0], i, z + d[1]) & 3;
-					if(b == Blocks.leaves2) meta += 4;
-					worldObj.func_147480_a(x + d[0], i, z + d[1], true);
+		while(!deque.isEmpty()) {
+			BlockPos[] pair = deque.pollFirst();
+			BlockPos current = pair[0];
+			BlockPos currentCol = pair[1];
+
+			if(blockOwner.containsKey(current)) {
+				if(currentCol.equals(hitCol)) {
+					hitColCount--;
+					if(hitColCount == 0) {
+						break;
+					}
+				}
+				continue;
+			}
+			blockOwner.put(current, currentCol);
+
+			for(int[] dir : EIGHTEEN_DIRS) {
+				int neighborX = current.getX() + dir[0];
+				int neighborY = current.getY() + dir[1];
+				int neighborZ = current.getZ() + dir[2];
+
+				// Bounds check: radius FELL_BFS_RADIUS horizontal, minY to maxY vertical
+				int neighborDx = neighborX - xCoord;
+				int neighborDz = neighborZ - zCoord;
+				if(neighborDx * neighborDx + neighborDz * neighborDz > FELL_BFS_RADIUS * FELL_BFS_RADIUS) {
+					continue;
+				}
+				if(neighborY < minY || neighborY > maxY) {
+					continue;
+				}
+
+				BlockPos neighborPos = new BlockPos(neighborX, neighborY, neighborZ);
+				if(blockOwner.containsKey(neighborPos)) {
+					continue;
+				}
+
+				Block b = worldObj.getBlock(neighborX, neighborY, neighborZ);
+				Material mat = b.getMaterial();
+				if(mat != Material.wood && mat != Material.leaves && !(b instanceof BlockLeaves)) {
+					continue;
+				}
+
+				boolean hasHorizontal = dir[0] != 0 || dir[2] != 0;
+				BlockPos[] entry = new BlockPos[] {neighborPos, currentCol};
+				if(!hasHorizontal) {
+					deque.addFirst(entry);
+				} else {
+					deque.addLast(entry);
+				}
+				if(currentCol.equals(hitCol)) {
+					hitColCount++;
+				}
+			}
+
+			if(currentCol.equals(hitCol)) {
+				hitColCount--;
+				if(hitColCount == 0) {
+					break; // Early exit: all hit-tree blocks processed
 				}
 			}
 		}
 
-		if(meta >= 0) {
-			if(Blocks.sapling.canPlaceBlockAt(worldObj, x, y, z)) {
-				worldObj.setBlock(x, y, z, Blocks.sapling, meta, 3);
+		// Step C: Cut blocks assigned to the hit trunk
+		for(Map.Entry<BlockPos, BlockPos> entry : blockOwner.entrySet()) {
+			if(!entry.getValue().equals(hitCol)) {
+				continue;
+			}
+
+			BlockPos pos = entry.getKey();
+			int bx = pos.getX();
+			int by = pos.getY();
+			int bz = pos.getZ();
+
+			Block b = worldObj.getBlock(bx, by, bz);
+
+			// Replant sapling at positions within working area
+			if(b.getMaterial() == Material.wood && isWithinWorkingArea(bx, bz) && canSupportSapling(worldObj, bx, by - 1, bz)) {
+				int bmeta = worldObj.getBlockMetadata(bx, by, bz);
+				int sapMeta = 0;
+				if(b == Blocks.log) {
+					sapMeta = bmeta & 3;
+				} else if(b == Blocks.log2) {
+					sapMeta = (bmeta & 3) + 4;
+				}
+				worldObj.func_147480_a(bx, by, bz, true);
+				worldObj.setBlock(bx, by, bz, Blocks.sapling, sapMeta, 3);
+			} else {
+				worldObj.func_147480_a(bx, by, bz, true);
 			}
 		}
+	}
+
+	private boolean isWithinWorkingArea(int x, int z) {
+		int dx = x - xCoord;
+		int dz = z - zCoord;
+		int distSq = dx * dx + dz * dz;
+		return distSq > MIN_DIST * MIN_DIST && distSq <= MAX_DIST * MAX_DIST;
+	}
+
+	private static boolean canSupportSapling(World world, int x, int y, int z) {
+		Block block = world.getBlock(x, y, z);
+		return block.canSustainPlant(world, x, y, z, ForgeDirection.UP, (IPlantable) Blocks.sapling);
 	}
 
 	@Override


### PR DESCRIPTION
Old approach scanned 10-block-high column -- missed branches, couldn't distinguish adjacent trees.

New approach:
- Scan working area for valid tree trunks with plantable ground below
- 0-1 BFS from all trunks using 18-connectivity to assign each wood/leaf block to its nearest trunk
- Only fell blocks owned by the hit tree's column

Funny enough, the most useful tree: Jungle tree is spawning branches often. But now, I can look at the tree farm without worry:

https://github.com/user-attachments/assets/483eaf59-a15e-4b60-a842-597061698d7e


I tried to grow every tree on the border to get `FELL_HORIZONTAL_RANGE` and `FELL_VERTICAL_RANGE` right, it may be still wrong, but it would be quick to fix.

<details>
  <summary>The idea behind it</summary>

If there is only one tree, this is quite simple, let's do bfs/dfs and remove these blocks.
The question what is to do if we have several trees growth together.
Cutting all leaf/wood blocks also a solution, but IMHO saw has too beautiful animation for it to work like that.

So obvious requirements are: 
* Wood block which is touched by saw shall be destroyed.
* If saw trying to break a block which is part of the column it should also be destroyed.
* There should be no flying blocks after cutting. So we shouldn't cut any articulation points within of our search.
* We shouldn't cut parts of other trees.

The trickiest part is how to define trees. My suggestion let's find tree trunks, and cut everything closest to current tree trunk.

In simplest terms something like this:

https://github.com/user-attachments/assets/85598a4e-7bb1-4ced-8b05-ba28cc34661f

So let's find out all valid tree trunks. Block is considered a tree trunk if:
* There is a wood column from it down to plantable ground
* It stands on something where sapling can grow

Or this is the bottom of wood column of a block that we hit. So if we hit block in the air, we will hit that as well.

After we found all tree trunks let's run multi-source 0-1 BFS, so we will find all the blocks closest to our trunk.
And cut them.

All code above is linear and mostly depends on working area + bounding distance. Everything except block breaking should work well below a millisecond.

![happy happy happy](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExeHNtcDJpbWw4OW5tZGYzeDJrbnY5dWs2bTh6ZmFrcnFoOHJyZmExYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/T70hpBP1L0N7U0jtkq/giphy.gif)
</details>

<details>
  <summary>Future improvements</summary>

* We can store a set near the BFS, of a blocks that we added in the end of the queue. It makes no sense to add it to the end of the queue twice, but it shouldn't happen often. I tried to make code not complicated as possible, if it's a good addition, just say it and I will add this.
* We have no re-planting support for modded trees. Cherry from EtFuturum doesn't work for example. I see no easy way how to fix that.
* Instead of spawning lots of entities we can calculate drops, replace blocks with air/remove them, and spawn blocks on the ground. Wasn't implemented before so I didn't add it either.
</details>
