### PR TITLE
Make placing crates in the world require shift

### DIFF
--- a/src/main/java/com/hbm/items/block/ItemBlockStorageCrate.java
+++ b/src/main/java/com/hbm/items/block/ItemBlockStorageCrate.java
@@ -37,6 +37,16 @@ public class ItemBlockStorageCrate extends ItemBlockBase implements IGUIProvider
 	}
 
 	@Override
+	public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ) {
+		// If crates can be opened from hand, prioritize this and require sneaking to place them
+		if (ServerConfig.CRATE_OPEN_HELD.get() && !player.isSneaking()) {
+			return false;
+		}
+
+		return super.onItemUse(stack, player, world, x, y, z, side, hitX, hitY, hitZ);
+	}
+
+	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
 		if(!ServerConfig.CRATE_OPEN_HELD.get()) return stack;
 

--- a/src/main/java/com/hbm/items/block/ItemBlockStorageCrate.java
+++ b/src/main/java/com/hbm/items/block/ItemBlockStorageCrate.java
@@ -39,7 +39,7 @@ public class ItemBlockStorageCrate extends ItemBlockBase implements IGUIProvider
 	@Override
 	public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ) {
 		// If crates can be opened from hand, prioritize this and require sneaking to place them
-		if (ServerConfig.CRATE_OPEN_HELD.get() && !player.isSneaking()) {
+		if (ServerConfig.CRATE_OPEN_HELD.get() && !player.isSneaking() && Block.getBlockFromItem(stack.getItem()) != ModBlocks.mass_storage) {
 			return false;
 		}
 


### PR DESCRIPTION
A QoL improvement. Essentially makes crate opening from hand take priority over placing, if it is enabled at all. Previously you'd have to look at your feet or up in the air to open a crate, which was a bit inconvenient. Not the other way round (shift forces opening, regular click places) because that would make it improssible to place a crate on an interactable block