### PR TITLE
made strand caster work better

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineStrandCaster.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineStrandCaster.java
@@ -75,12 +75,12 @@ public class TileEntityMachineStrandCaster extends TileEntityFoundryCastingBase 
 			this.updateConnections();
 
 			int moldsToCast = maxProcessable();
-		
+
 			// Makes it flush the buffers after 10 seconds of inactivity, or when they're full
-			if (moldsToCast > 0 && (moldsToCast >= 9 || worldObj.getWorldTime() >= lastProgressTick + 200)) {
+			if (moldsToCast > 0 && (moldsToCast >= 1 || worldObj.getWorldTime() >= lastProgressTick + 200)) {
 
 				ItemMold.Mold mold = this.getInstalledMold();
-				
+
 				this.amount -= moldsToCast * mold.getCost();
 
 				ItemStack out = mold.getOutput(type);


### PR DESCRIPTION
strand caster now casts its contents as soon as it is able to cast

i literally just changed the number of molds to cast from 9 to 1
it was a single number

i didnt bother completely removing the feature because 
1. high chance to break the thing (common theme regarding the strand caster)
2. strand caster will be reworked in the near future anyway so its just little fix until that day comes

accept if you want, it would make life a lot eaier and would stop strand caster clogging in big factories (primarily ntm:space bedrock ores)

pleaseeeee :3 :3 :3 