### PR TITLE
make RBMK panels and meters not break instantly

### DIFF
--- a/src/main/java/com/hbm/blocks/machine/rbmk/RBMKMiniPanelBase.java
+++ b/src/main/java/com/hbm/blocks/machine/rbmk/RBMKMiniPanelBase.java
@@ -24,6 +24,8 @@ public class RBMKMiniPanelBase extends BlockContainer implements ISBRHUniversal 
 
 	public RBMKMiniPanelBase() {
 		super(Material.iron);
+		this.setHardness(3F);
+		this.setResistance(30F);
 	}
 
 	@Override


### PR DESCRIPTION
[5% tested]
the meters are cool as fuck, but left clicking them without a pickaxe immediately breaks them without dropping
i hope i did inheritance right and this won't break something else that depends on it being unset

before

https://github.com/user-attachments/assets/281426cd-ed95-45e0-b3d4-b5b7c57aa37d

after

https://github.com/user-attachments/assets/2646771b-a7ff-45ba-8bcc-30e0dc22395e



