### PR TITLE
Prevent TileEntityPedestal from being accessed before it is initialised

### DIFF
--- a/src/main/java/com/hbm/blocks/generic/BlockKeyhole.java
+++ b/src/main/java/com/hbm/blocks/generic/BlockKeyhole.java
@@ -229,6 +229,12 @@ public class BlockKeyhole extends BlockStone {
 	public static void spawnPedestalItem(World world, int x, int y, int z) {
 		world.setBlock(x, y, z, ModBlocks.pedestal);
 		TileEntityPedestal pedestal = (TileEntityPedestal) world.getTileEntity(x, y, z);
+		
+		if(pedestal == null) {
+			pedestal = new TileEntityPedestal();
+			world.setTileEntity(x, y, z, pedestal);
+		}
+		
 		WeightedRandomChestContent content = (WeightedRandomChestContent) WeightedRandom.getRandomItem(world.rand, ItemPool.getPool(ItemPoolsRedRoom.POOL_RED_PEDESTAL));
 		pedestal.item = content.theItemId.copy();
 	}

--- a/src/main/java/com/hbm/blocks/generic/BlockRedBrickKeyhole.java
+++ b/src/main/java/com/hbm/blocks/generic/BlockRedBrickKeyhole.java
@@ -156,6 +156,12 @@ public class BlockRedBrickKeyhole extends Block {
 	public static void spawnPedestalItem(World world, int x, int y, int z, WeightedRandomChestContent[] pool) {
 		world.setBlock(x, y, z, ModBlocks.pedestal);
 		TileEntityPedestal pedestal = (TileEntityPedestal) world.getTileEntity(x, y, z);
+		
+		if(pedestal == null) {
+			pedestal = new TileEntityPedestal();
+			world.setTileEntity(x, y, z, pedestal);
+		}
+		
 		pedestal.item = ItemPool.getStack(pool, world.rand).copy();
 	}
 }


### PR DESCRIPTION
This is to fix errors on busier servers like

```
java.lang.NullPointerException: Cannot invoke "com.hbm.blocks.generic.BlockLoot$TileEntityLoot.addItem(net.minecraft.item.ItemStack, double, double, double)" because "loot" is null
    at Launch//com.hbm.blocks.generic.BlockKeyhole.generateRoom(BlockKeyhole.java:215) ~[BlockKeyhole.class:?]
    at Launch//com.hbm.blocks.generic.BlockKeyhole.func_149727_a(BlockKeyhole.java:61) ~[BlockKeyhole.class:?]
    at Launch//sorazodia.survival.mechanics.PlayerActionEvent.itemRightClick(PlayerActionEvent.java:130) ~[PlayerActionEvent.class:?]
    at cpw.mods.fml.common.eventhandler.ASMEventHandler_743_PlayerActionEvent_itemRightClick_PlayerInteractEvent.invoke(.dynamic) ~[?:?]
    at Launch//cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) ~[ASMEventHandler.class:?]
    at Launch//cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) ~[EventBus.class:?]
    at Launch//net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(ForgeEventFactory.java:100) ~[ForgeEventFactory.class:?]
    at Launch//net.minecraft.server.management.ItemInWorldManager.func_73078_a(ItemInWorldManager.java:353) ~[mx.class:?]
    at Launch//net.minecraft.network.NetHandlerPlayServer.func_147346_a(NetHandlerPlayServer.java:556) ~[nh.class:?]
    at Launch//net.minecraft.network.play.client.C08PacketPlayerBlockPlacement.func_148833_a(SourceFile:60) ~[jo.class:?]
    at Launch//net.minecraft.network.play.client.C08PacketPlayerBlockPlacement.func_148833_a(SourceFile:9) ~[jo.class:?]
    at Launch//net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:212) ~[ej.class:?]
    at Launch//net.minecraft.network.NetworkSystem.func_151269_c(NetworkSystem.java:165) [nc.class:?]
    at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:659) [MinecraftServer.class:?]
    at Launch//net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334) [lt.class:?]
    at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547) [MinecraftServer.class:?]
    at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427) [MinecraftServer.class:?]
    at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685) [li.class:?]
```
How to get the above internal server warning on the client:
<details><summary>Warning, Game Spoilers!</summary>when you use a red key/cracked key on strange stones</details>


I suspect it's to do with some sort of race condition somewhere. This patch adds a check to make sure the loot is ready before it's accessed. 