### PR TITLE
RBMK Crane OpenComputers: getRodInfo()

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
@@ -437,7 +437,7 @@ public class TileEntityCraneConsole extends TileEntityLoadedBase implements Simp
 
 	@Callback(direct = true)
 	@Optional.Method(modid = "OpenComputers")
-	public Object[] getFuelInfo(Context context, Arguments args) {
+	public Object[] getRodInfo(Context context, Arguments args) {
 		java.util.LinkedHashMap<String, Object> map = new java.util.LinkedHashMap<>();
 		if(loadedItem != null && loadedItem.getItem() instanceof ItemRBMKRod) {
 			map.put("coreSkinTemp", ItemRBMKRod.getHullHeat(loadedItem));
@@ -446,7 +446,7 @@ public class TileEntityCraneConsole extends TileEntityLoadedBase implements Simp
 			map.put("xenon", ItemRBMKRod.getPoisonLevel(loadedItem));
 			map.put("rodName", loadedItem.getItem().getUnlocalizedName());
 		} else {
-			return new Object[] {false, "No fuel loaded"};
+			return new Object[] {false, "No rod loaded"};
 		}
 		return new Object[] {map};
 	}

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
@@ -452,6 +452,24 @@ public class TileEntityCraneConsole extends TileEntityLoadedBase implements Simp
 	}
 
 	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getDepletion(Context context, Arguments args) {
+		if(loadedItem != null && loadedItem.getItem() instanceof ItemRBMKRod) {
+			return new Object[] {ItemRBMKRod.getEnrichment(loadedItem)};
+		}
+		return new Object[] {"N/A"};
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "OpenComputers")
+	public Object[] getXenonPoison(Context context, Arguments args) {
+		if(loadedItem != null && loadedItem.getItem() instanceof ItemRBMKRod) {
+			return new Object[] {ItemRBMKRod.getPoison(loadedItem)};
+		}
+		return new Object[] {"N/A"};
+	}
+
+	@Callback(direct = true)
 	@Optional.Method(modid = "OpenComputers") //if this doesnt work im going to die
 	public Object[] getCranePos(Context context, Arguments args) {
 		ForgeDirection dir = ForgeDirection.getOrientation(this.getBlockMetadata() - BlockDummyable.offset);

--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityCraneConsole.java
@@ -437,20 +437,18 @@ public class TileEntityCraneConsole extends TileEntityLoadedBase implements Simp
 
 	@Callback(direct = true)
 	@Optional.Method(modid = "OpenComputers")
-	public Object[] getDepletion(Context context, Arguments args) {
+	public Object[] getFuelInfo(Context context, Arguments args) {
+		java.util.LinkedHashMap<String, Object> map = new java.util.LinkedHashMap<>();
 		if(loadedItem != null && loadedItem.getItem() instanceof ItemRBMKRod) {
-			return new Object[] {ItemRBMKRod.getEnrichment(loadedItem)};
+			map.put("coreSkinTemp", ItemRBMKRod.getHullHeat(loadedItem));
+			map.put("coreTemp", ItemRBMKRod.getCoreHeat(loadedItem));
+			map.put("enrichment", ItemRBMKRod.getEnrichment(loadedItem));
+			map.put("xenon", ItemRBMKRod.getPoisonLevel(loadedItem));
+			map.put("rodName", loadedItem.getItem().getUnlocalizedName());
+		} else {
+			return new Object[] {false, "No fuel loaded"};
 		}
-		return new Object[] {"N/A"};
-	}
-
-	@Callback(direct = true)
-	@Optional.Method(modid = "OpenComputers")
-	public Object[] getXenonPoison(Context context, Arguments args) {
-		if(loadedItem != null && loadedItem.getItem() instanceof ItemRBMKRod) {
-			return new Object[] {ItemRBMKRod.getPoison(loadedItem)};
-		}
-		return new Object[] {"N/A"};
+		return new Object[] {map};
 	}
 
 	@Callback(direct = true)


### PR DESCRIPTION
A simple OpenComputers method to get information about the rod currently loaded if one is loaded.