### PR TITLE
attempted turbine efficiency fix

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineIndustrialTurbine.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineIndustrialTurbine.java
@@ -32,9 +32,11 @@ public class TileEntityMachineIndustrialTurbine extends TileEntityTurbineBase im
 	public float lastRotor;
 	
 	public double spin = 0;
-	public static double ACCELERATION = 1D / 400D;
+	public static double FLYWHEEL_MAX_ENERGY = 0.5e8; //aka flywheel mass
+	public long maxPower = 0;
 	public long lastPowerTarget = 0;
-
+	public long flywheel_energy = 0;
+	
 	private AudioWrapper audio;
 	private float audioDesync;
 
@@ -52,7 +54,7 @@ public class TileEntityMachineIndustrialTurbine extends TileEntityTurbineBase im
 
 	@Override
 	public void writeConfig(JsonWriter writer) throws IOException {
-		writer.name("INFO").value("industrial steam turbine consumes 20% of availible steam per tick");
+		writer.name("INFO").value("industrial steam turbine consumes 20% of available steam per tick");
 		writer.name("I:inputTankSize").value(inputTankSize);
 		writer.name("I:outputTankSize").value(outputTankSize);
 		writer.name("D:efficiency").value(efficiency);
@@ -73,29 +75,17 @@ public class TileEntityMachineIndustrialTurbine extends TileEntityTurbineBase im
 		FT_Coolable trait = tanks[0].getTankType().getTrait(FT_Coolable.class);
 		double eff = trait.getEfficiency(CoolingType.TURBINE) * getEfficiency();
 		int maxOps = (int) Math.ceil((tanks[0].getMaxFill() * consumptionPercent()) / trait.amountReq);
-		this.lastPowerTarget = (long) (maxOps * trait.heatEnergy * eff); // theoretical max output at full blast with this type
-		double fraction = (double) steamConsumed / (double) (trait.amountReq * maxOps); // % of max steam throughput currently achieved
+		this.maxPower = (long) (maxOps * trait.heatEnergy * eff);
 		
-		if(Math.abs(spin - fraction) <= ACCELERATION) {
-			this.spin = fraction;
-		} else if(spin < fraction) {
-			this.spin += ACCELERATION;
-		} else if(spin > fraction) {
-			this.spin -= ACCELERATION;
-		}
+		this.flywheel_energy += power;
 	}
 
 	@Override
 	public void onServerTick() {
-		if(!operational) {
-			this.spin -= ACCELERATION;
-		}
-		
-		if(this.spin <= 0) {
-			this.spin = 0;
-		} else {
-			this.powerBuffer = (long) (this.lastPowerTarget * this.spin);
-		}
+		this.spin = (double) flywheel_energy / FLYWHEEL_MAX_ENERGY; //because dense steams have way lower energy output, turbines running them take a lot longer to spool up
+		this.lastPowerTarget = (long) (this.spin * maxPower);
+		this.flywheel_energy -= this.lastPowerTarget;
+		this.powerBuffer = (long) (this.lastPowerTarget);
 	}
 	
 	@Override


### PR DESCRIPTION
attempt at #2838
makes turbines' power output follow an exponential curve instead of linear when disturbed

https://github.com/user-attachments/assets/f323bab0-d56c-4d15-93e1-943e85241e9f

notes:
-if spin is intended to be RPMs, it could probably be tweaked to satisfy <img width="139" height="28" alt="image" src="https://github.com/user-attachments/assets/1ec36a50-c279-4929-8ebd-9b63ec36d342" />
-industrial turbines are 1:1:1:1, while singleblock and leviathans need 10x the turbines as you go down each steam density tier
-FLYWHEEL_MAX_ENERGY could probably be reduced for dense steam turbines so they don't take years to spool up/down
-no idea how `this.variable` and `variable` are any different
-not familiar enough with java to know if multiplication is faster than branching but i removed some `if`s anyway
-copying code from TileEntityTurbineBase.java hurts my soul but since this is an abomination anyway i'll leave it to you to copy the idea and make it to standard
