### PR TITLE
DFC explosion radius bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,8 @@ dependencies {
 }
 
 processResources {
+	duplicatesStrategy = DuplicatesStrategy.INCLUDE
+
 	// this will ensure that this task is redone when the versions change.
 	inputs.property "version", project.version
 	inputs.property "mcversion", project.minecraft.version
@@ -133,8 +135,8 @@ processResources {
 		filesMatching('mcmod.info') {
 			// replace version, mcversion and credits
 			expand([
-					version: version_name,
-					credits: project.credits
+				version: version_name,
+				credits: project.credits
 			])
 		}
 	}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip

--- a/src/main/java/com/hbm/inventory/gui/GUIToolBox.java
+++ b/src/main/java/com/hbm/inventory/gui/GUIToolBox.java
@@ -35,8 +35,8 @@ public class GUIToolBox extends GuiContainer {
 
 		// if the open box has changed or disappeared, close the inventory
 		} else if(this.mc.thePlayer.getHeldItem() != firstHeld) {
-			//this.mc.thePlayer.closeScreen();
-			//return;
+			this.mc.thePlayer.closeScreen();
+			return;
 		}
 
 		super.drawScreen(x, y, interp);

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityCore.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityCore.java
@@ -36,7 +36,7 @@ import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
 public class TileEntityCore extends TileEntityMachineBase implements IGUIProvider, IInfoProviderEC {
-	
+
 	public int field;
 	public int heat;
 	public int color;
@@ -60,31 +60,34 @@ public class TileEntityCore extends TileEntityMachineBase implements IGUIProvide
 
 	@Override
 	public void updateEntity() {
-		
+
 		if(!worldObj.isRemote) {
-			
+
 			this.prevConsumption = this.consumption;
 			this.consumption = 0;
-			
+
 			int chunkX = xCoord >> 4;
 			int chunkZ = zCoord >> 4;
-			
+
 			meltdownTick = false;
-			
+
 			lastTickValid = worldObj.getChunkProvider().chunkExists(chunkX, chunkZ) &&
 					worldObj.getChunkProvider().chunkExists(chunkX + 1, chunkZ + 1) &&
 					worldObj.getChunkProvider().chunkExists(chunkX + 1, chunkZ - 1) &&
 					worldObj.getChunkProvider().chunkExists(chunkX - 1, chunkZ + 1) &&
 					worldObj.getChunkProvider().chunkExists(chunkX - 1, chunkZ - 1);
-			
+
 			if(lastTickValid && heat > 0 && heat >= field) {
-				
+
 				int fill = tanks[0].getFill() + tanks[1].getFill();
 				int max = tanks[0].getMaxFill() + tanks[1].getMaxFill();
 				int mod = heat * 10;
-				
-				int size = Math.max(Math.min(fill * mod / max, 1000), 50);
-				
+
+				// fill * mod can create a value higher than 2^31 (max integer value)
+				// where at that point radius would go negative
+				long radius = (long) fill * mod / max;
+				int size = Math.max(Math.min((int) radius, 1000), 50);
+
 				boolean canExplode = true;
 				Iterator<Entry<ATEntry, Long>> it = EntityNukeExplosionMK3.at.entrySet().iterator();
 				while(it.hasNext()) {
@@ -101,9 +104,9 @@ public class TileEntityCore extends TileEntityMachineBase implements IGUIProvide
 						break;
 					}
 				}
-				
+
 				if(canExplode) {
-					
+
 					EntityNukeExplosionMK3 ex = new EntityNukeExplosionMK3(worldObj);
 					ex.posX = xCoord + 0.5;
 					ex.posY = yCoord + 0.5;
@@ -113,21 +116,21 @@ public class TileEntityCore extends TileEntityMachineBase implements IGUIProvide
 					ex.coefficient = 1.0F;
 					ex.waste = false;
 					worldObj.spawnEntityInWorld(ex);
-					
+
 					worldObj.playSoundEffect(xCoord, yCoord, zCoord, "random.explode", 100000.0F, 1.0F);
-					
+
 					EntityCloudFleijaRainbow cloud = new EntityCloudFleijaRainbow(worldObj, size);
 					cloud.posX = xCoord;
 					cloud.posY = yCoord;
 					cloud.posZ = zCoord;
 					worldObj.spawnEntityInWorld(cloud);
-					
+
 				} else {
 					meltdownTick = true;
 					ChunkRadiationManager.proxy.incrementRad(worldObj, xCoord, yCoord, zCoord, 100);
 				}
 			}
-			
+
 			if(slots[0] != null && slots[2] != null && slots[0].getItem() instanceof ItemCatalyst && slots[2].getItem() instanceof ItemCatalyst)
 				color = calcAvgHex(
 						((ItemCatalyst)slots[0].getItem()).getColor(),
@@ -135,24 +138,24 @@ public class TileEntityCore extends TileEntityMachineBase implements IGUIProvide
 				);
 			else
 				color = 0;
-			
+
 			if(heat > 0)
 				radiation();
 
 			networkPackNT(250);
-			
+
 			heat = 0;
-			
+
 			if(lastTickValid && field > 0) {
 				field -= 1;
 			}
-			
+
 			this.markDirty();
 		} else {
-			
+
 			//TODO: sick particle effects
 		}
-		
+
 	}
 
 	@Override
@@ -178,14 +181,14 @@ public class TileEntityCore extends TileEntityMachineBase implements IGUIProvide
 		this.color = buf.readInt();
 		this.meltdownTick = buf.readBoolean();
 	}
-	
+
 	private void radiation() {
-		
+
 		double scale = this.meltdownTick ? 5 : 3;
 		double range = this.meltdownTick ? 50 : 10;
-		
+
 		List<Entity> list = worldObj.getEntitiesWithinAABBExcludingEntity(null, AxisAlignedBB.getBoundingBox(xCoord + 0.5, yCoord + 0.5, zCoord + 0.5, xCoord + 0.5, yCoord + 0.5, zCoord + 0.5).expand(range, range, range));
-		
+
 		for(Entity e : list) {
 			if(!(e instanceof EntityPlayer && ArmorUtil.checkForHazmat((EntityPlayer)e)))
 				if(!Library.isObstructed(worldObj, xCoord + 0.5, yCoord + 0.5 + 6, zCoord + 0.5, e.posX, e.posY + e.getEyeHeight(), e.posZ)) {
@@ -195,61 +198,61 @@ public class TileEntityCore extends TileEntityMachineBase implements IGUIProvide
 		}
 
 		List<Entity> list2 =worldObj.getEntitiesWithinAABBExcludingEntity(null, AxisAlignedBB.getBoundingBox(xCoord + 0.5, yCoord + 0.5, zCoord + 0.5, xCoord + 0.5, yCoord + 0.5, zCoord + 0.5).expand(scale, scale, scale));
-		
+
 		for(Entity e : list2) {
 			if(!(e instanceof EntityPlayer && ArmorUtil.checkForHaz2((EntityPlayer)e)))
 					e.attackEntityFrom(ModDamageSource.amsCore, 10000);
 		}
 	}
-	
+
 	public int getFieldScaled(int i) {
 		return (field * i) / 100;
 	}
-	
+
 	public int getHeatScaled(int i) {
 		return (heat * i) / 100;
 	}
-	
+
 	public boolean isReady() {
-		
+
 		if(!lastTickValid)
 			return false;
-		
+
 		if(getCore() == 0)
 			return false;
-		
+
 		if(color == 0)
 			return false;
-		
+
 		if(getFuelEfficiency(tanks[0].getTankType()) <= 0 || getFuelEfficiency(tanks[1].getTankType()) <= 0)
 			return false;
-		
+
 		return true;
 	}
-	
+
 	//100 emitter watt = 10000 joules = 1 heat = 10mB burned
 	public long burn(long joules) {
-		
+
 		//check if a reaction can take place
 		if(!isReady())
 			return joules;
-		
+
 		int demand = (int)Math.ceil((double)joules / 1000D);
-		
+
 		//check if the reaction has enough valid fuel
 		if(tanks[0].getFill() < demand || tanks[1].getFill() < demand)
 			return joules;
-		
+
 		this.consumption += demand;
-		
+
 		heat += (int)Math.ceil((double)joules / 10000D);
 
 		tanks[0].setFill(tanks[0].getFill() - demand);
 		tanks[1].setFill(tanks[1].getFill() - demand);
-		
+
 		return (long) (joules * getCore() * getFuelEfficiency(tanks[0].getTankType()) * getFuelEfficiency(tanks[1].getTankType()));
 	}
-	
+
 	public float getFuelEfficiency(FluidType type) {
 		if(type == Fluids.HYDROGEN)
 			return 1.0F;
@@ -273,35 +276,35 @@ public class TileEntityCore extends TileEntityMachineBase implements IGUIProvide
 			return 2.7F;
 		return 0;
 	}
-	
+
 	//TODO: move stats to the AMSCORE class
 	public int getCore() {
-		
+
 		if(slots[1] == null) {
 			return 0;
 		}
-		
+
 		if(slots[1].getItem() == ModItems.ams_core_sing)
 			return 500;
-		
+
 		if(slots[1].getItem() == ModItems.ams_core_wormhole)
 			return 650;
-		
+
 		if(slots[1].getItem() == ModItems.ams_core_eyeofharmony)
 			return 800;
-		
+
 		if(slots[1].getItem() == ModItems.ams_core_thingy)
 			return 2500;
-		
+
 		return 0;
 	}
-	
+
 	private int calcAvgHex(int h1, int h2) {
 
 		int r1 = ((h1 & 0xFF0000) >> 16);
 		int g1 = ((h1 & 0x00FF00) >> 8);
 		int b1 = ((h1 & 0x0000FF) >> 0);
-		
+
 		int r2 = ((h2 & 0xFF0000) >> 16);
 		int g2 = ((h2 & 0x00FF00) >> 8);
 		int b2 = ((h2 & 0x0000FF) >> 0);
@@ -309,19 +312,19 @@ public class TileEntityCore extends TileEntityMachineBase implements IGUIProvide
 		int r = (((r1 + r2) / 2) << 16);
 		int g = (((g1 + g2) / 2) << 8);
 		int b = (((b1 + b2) / 2) << 0);
-		
+
 		return r | g | b;
 	}
-	
+
 	@Override
 	public void readFromNBT(NBTTagCompound nbt) {
 		super.readFromNBT(nbt);
-		
+
 		tanks[0].readFromNBT(nbt, "fuel1");
 		tanks[1].readFromNBT(nbt, "fuel2");
 		this.field = nbt.getInteger("field");
 	}
-	
+
 	@Override
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
@@ -330,12 +333,12 @@ public class TileEntityCore extends TileEntityMachineBase implements IGUIProvide
 		tanks[1].writeToNBT(nbt, "fuel2");
 		nbt.setInteger("field", this.field);
 	}
-	
+
 	AxisAlignedBB bb = null;
-	
+
 	@Override
 	public AxisAlignedBB getRenderBoundingBox() {
-		
+
 		if(bb == null) {
 			bb = AxisAlignedBB.getBoundingBox(
 					xCoord + 0.5 - 4,
@@ -346,10 +349,10 @@ public class TileEntityCore extends TileEntityMachineBase implements IGUIProvide
 					zCoord + 0.5 + 5
 					);
 		}
-		
+
 		return bb;
 	}
-	
+
 	@Override
 	@SideOnly(Side.CLIENT)
 	public double getMaxRenderDistanceSquared() {


### PR DESCRIPTION
(don't mind the "fuck gradle" commit, this is my first pr)

### only change is in TileEntityCore.java (line 86-89)
On powerful double-core DFC setups (power output > 1PHE/s) it can happen that the product of "fill * mod" gets over the upper integer limit (Integer.MAX_VALUE).
This results in the sign bit being flipped and the product getting negative.
The size clamp in line 89 then gives the minimum radius of 50 blocks even if it should be 1000.

Casting temporary the product of "fill * mod" into a long should fix this because so it shouldn't flip negative at high values.

### result of a custom dfc simulation before the change
Uhh i hope you understand the result of this crap piece of my simulation code. You can test the setup it in Minecraft.
- two cores in a row
- all fuel types set to Oxygen
- both cores have Eye of Harmony
- Emitter power set to 100%
- explosion size results in -5827 without the clamp. In Minecraft it turns into 50 blocks radius
<img width="996" height="769" alt="grafik" src="https://github.com/user-attachments/assets/00b80320-7890-4d7f-8e27-3f6d58c5cf7f" />

because github wont tell me how tf i exclude commits, the (half) dupe fix is also here
