### PR TITLE
PWR bugfix

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityPWRController.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityPWRController.java
@@ -216,6 +216,12 @@ public class TileEntityPWRController extends TileEntityMachineBase implements IG
 					if(this.rodTarget > this.rodLevel) this.rodLevel++;
 					if(this.rodTarget < this.rodLevel) this.rodLevel--;
 
+					double multiplier = 1D;
+
+					if(tanks[0].getTankType().hasTrait(FT_PWRModerator.class)) {
+						multiplier = tanks[0].getTankType().getTrait(FT_PWRModerator.class).getMultiplier();
+					}
+
 					int newFlux = this.sourceCount * 20;
 
 					if(typeLoaded != -1 && amountLoaded > 0) {
@@ -226,6 +232,10 @@ public class TileEntityPWRController extends TileEntityMachineBase implements IG
 						double outputPerRod = fuel.function.effonix(fluxPerRod);
 						double totalOutput = outputPerRod * amountLoaded * usedRods;
 						double totalHeatOutput = totalOutput * fuel.heatEmission;
+
+						if(tanks[0].getFill() > 0) {
+							totalHeatOutput *= multiplier;
+						}
 
 						this.coreHeat += totalHeatOutput;
 						newFlux += totalOutput;
@@ -266,8 +276,8 @@ public class TileEntityPWRController extends TileEntityMachineBase implements IG
 
 					this.flux = newFlux;
 
-					if(tanks[0].getTankType().hasTrait(FT_PWRModerator.class) && tanks[0].getFill() > 0) {
-						this.flux *= tanks[0].getTankType().getTrait(FT_PWRModerator.class).getMultiplier();
+					if(tanks[0].getFill() > 0) {
+						this.flux *= multiplier;
 					}
 
 					if(this.coreHeat > this.coreHeatCapacity) {


### PR DESCRIPTION
PWRs using a moderated coolant produce less power than they should. Consider this reactor:
<img width="525" height="252" alt="image" src="https://github.com/user-attachments/assets/9d8d2756-c404-4496-bf4d-08619bd5321b" />
Using U233 it produces 32,125 flux, meaning it should produce 240,973.5 TU/t. This should correspond to about 600mB/t of hot thorium salt, given that thorium salt has a thermal capacity of 400TU/mB. However, it actually only produces:
<img width="683" height="338" alt="image" src="https://github.com/user-attachments/assets/dfa22d57-54f8-421a-ad38-3ba41f363e1f" />
Curiously enough this is about 2.5 times less than the expected amount. The same thing happens with heavy water, for example, although the effect isn't as egregious since the moderation value is lower.

With the fix:
<img width="702" height="301" alt="image" src="https://github.com/user-attachments/assets/e0fee192-2020-40fe-b3e0-73de4f03da29" />
(the slight difference in hot salt production can be attributed to the reactor not having enough heat exchangers)

obviously merging this will break a lot of people's pwrs, which is not ideal, but a bug is a bug
if this was actually the intended behavior im going to blow up