### PR TITLE
Add /ntmwikirender command to render screenshots of items and blocks

### DIFF
--- a/src/main/java/com/hbm/commands/CommandWikiRender.java
+++ b/src/main/java/com/hbm/commands/CommandWikiRender.java
@@ -21,6 +21,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraft.client.Minecraft;
 import net.minecraft.command.CommandBase;
 import net.minecraft.item.Item;
@@ -30,7 +31,7 @@ import net.minecraft.init.Blocks;
 // horribly written command so you can render more than fucking guns without having to decompile the JAR
 @SideOnly(Side.CLIENT) // make it clientside so bobcat would not come after me
 public class CommandWikiRender extends CommandBase {
-    @Override
+	@Override
     public String getCommandName() {
         return "ntmwikirender";
     }
@@ -86,5 +87,11 @@ public class CommandWikiRender extends CommandBase {
 			
             Minecraft.getMinecraft().thePlayer.closeScreen();
             FMLCommonHandler.instance().showGuiScreen(new GUIScreenWikiRender(stacks.toArray(new ItemStack[0]), prefix, "wiki-block-renders-256", slotScale));
-        }
-    }
+		}
+
+		public static void register() {
+        	if (FMLCommonHandler.instance().getSide() == Side.CLIENT) {
+            	ClientCommandHandler.instance.registerCommand(new CommandWikiRender());
+        	}
+    	}
+}

--- a/src/main/java/com/hbm/commands/CommandWikiRender.java
+++ b/src/main/java/com/hbm/commands/CommandWikiRender.java
@@ -21,7 +21,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.util.EnumChatFormatting;
-import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraft.client.Minecraft;
 import net.minecraft.command.CommandBase;
 import net.minecraft.item.Item;
@@ -88,10 +87,4 @@ public class CommandWikiRender extends CommandBase {
             Minecraft.getMinecraft().thePlayer.closeScreen();
             FMLCommonHandler.instance().showGuiScreen(new GUIScreenWikiRender(stacks.toArray(new ItemStack[0]), prefix, "wiki-block-renders-256", slotScale));
 		}
-
-		public static void register() {
-        	if (FMLCommonHandler.instance().getSide() == Side.CLIENT) {
-            	ClientCommandHandler.instance.registerCommand(new CommandWikiRender());
-        	}
-    	}
 }

--- a/src/main/java/com/hbm/commands/CommandWikiRender.java
+++ b/src/main/java/com/hbm/commands/CommandWikiRender.java
@@ -1,0 +1,87 @@
+package com.hbm.commands;
+
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.List;
+import java.util.Arrays;
+
+import com.hbm.inventory.gui.GUIScreenWikiRender;
+import com.hbm.items.ModItems;
+import com.hbm.items.machine.ItemDepletedFuel;
+import com.hbm.items.machine.ItemFluidDuct;
+import com.hbm.items.machine.ItemRBMKPellet;
+import com.hbm.main.MainRegistry;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.command.PlayerNotFoundException;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.command.CommandBase;
+import net.minecraft.item.Item;
+import net.minecraft.init.Items;
+import net.minecraft.init.Blocks;
+
+// horribly written command so you can render more than fucking guns without having to decompile the JAR
+public class CommandWikiRender extends CommandBase {
+    @Override
+    public String getCommandName() {
+        return "ntmwikirender";
+    }
+    
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return String.format(Locale.US,
+			"%s/%s <name> %s- Render screenshots of a selected item type (e.g ItemGunBaseNT). Intended for developers and wiki editors only.",
+			EnumChatFormatting.GREEN, getCommandName(), EnumChatFormatting.LIGHT_PURPLE
+		);
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        if(!(sender instanceof EntityPlayer)) {
+            throw new PlayerNotFoundException();
+        }
+        
+        if(args.length == 0) {
+			throw new WrongUsageException(getCommandUsage(sender), new Object[0]);
+        }
+
+        MainRegistry.logger.info("Taking a screenshot of " + args[0]);
+             
+		List<Item> ignoredItems = Arrays.asList( 
+			ModItems.achievement_icon,
+			Items.spawn_egg,
+			Item.getItemFromBlock(Blocks.mob_spawner)
+		);
+
+		List<Class<? extends Item>> collapsedClasses = Arrays.asList(
+			ItemRBMKPellet.class,
+			ItemDepletedFuel.class,
+			ItemFluidDuct.class
+		);
+
+        String prefix = args[0];
+		int slotScale = 16;
+		boolean ignoreNonNTM = true;
+
+		List<ItemStack> stacks = new ArrayList<ItemStack>();
+		for (Object reg : Item.itemRegistry) {
+			Item item = (Item) reg;
+			if(ignoreNonNTM && !Item.itemRegistry.getNameForObject(item).startsWith("hbm:")) continue;
+			if(ignoredItems.contains(item)) continue;
+			if(!item.getClass().getSimpleName().equalsIgnoreCase(args[0]) && (net.minecraft.block.Block.getBlockFromItem(item) == null || !net.minecraft.block.Block.getBlockFromItem(item).getClass().getSimpleName().equalsIgnoreCase(args[0]))) continue;
+			if(collapsedClasses.contains(item.getClass())) {
+				stacks.add(new ItemStack(item));
+			} else {
+				item.getSubItems(item, null, stacks);
+				}
+			}
+			
+            Minecraft.getMinecraft().thePlayer.closeScreen();
+            FMLCommonHandler.instance().showGuiScreen(new GUIScreenWikiRender(stacks.toArray(new ItemStack[0]), prefix, "wiki-block-renders-256", slotScale));
+        }
+    }

--- a/src/main/java/com/hbm/commands/CommandWikiRender.java
+++ b/src/main/java/com/hbm/commands/CommandWikiRender.java
@@ -13,6 +13,8 @@ import com.hbm.items.machine.ItemRBMKPellet;
 import com.hbm.main.MainRegistry;
 
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.command.WrongUsageException;
 import net.minecraft.command.PlayerNotFoundException;
 import net.minecraft.entity.player.EntityPlayer;
@@ -26,6 +28,7 @@ import net.minecraft.init.Items;
 import net.minecraft.init.Blocks;
 
 // horribly written command so you can render more than fucking guns without having to decompile the JAR
+@SideOnly(Side.CLIENT) // make it clientside so bobcat would not come after me
 public class CommandWikiRender extends CommandBase {
     @Override
     public String getCommandName() {
@@ -35,7 +38,7 @@ public class CommandWikiRender extends CommandBase {
     @Override
     public String getCommandUsage(ICommandSender sender) {
         return String.format(Locale.US,
-			"%s/%s <name> %s- Render screenshots of a selected item type (e.g ItemGunBaseNT). Intended for developers and wiki editors only.",
+			"%s/%s <type> %s- Render screenshots of a selected item type (e.g ItemGunBaseNT). Intended for developers and wiki editors only.",
 			EnumChatFormatting.GREEN, getCommandName(), EnumChatFormatting.LIGHT_PURPLE
 		);
     }

--- a/src/main/java/com/hbm/main/MainRegistry.java
+++ b/src/main/java/com/hbm/main/MainRegistry.java
@@ -666,6 +666,7 @@ public class MainRegistry {
 		event.registerServerCommand(new CommandPacketInfo());
 		event.registerServerCommand(new CommandReloadServer());
 		event.registerServerCommand(new CommandLocate());
+		event.registerServerCommand(new CommandWikiRender());
 		event.registerServerCommand(new CommandCustomize());
 		event.registerServerCommand(new CommandReapNetworks());
 		ArcFurnaceRecipes.registerFurnaceSmeltables(); // because we have to wait for other mods to take their merry ass time to register recipes

--- a/src/main/java/com/hbm/main/MainRegistry.java
+++ b/src/main/java/com/hbm/main/MainRegistry.java
@@ -666,7 +666,6 @@ public class MainRegistry {
 		event.registerServerCommand(new CommandPacketInfo());
 		event.registerServerCommand(new CommandReloadServer());
 		event.registerServerCommand(new CommandLocate());
-		event.registerServerCommand(new CommandWikiRender());
 		event.registerServerCommand(new CommandCustomize());
 		event.registerServerCommand(new CommandReapNetworks());
 		ArcFurnaceRecipes.registerFurnaceSmeltables(); // because we have to wait for other mods to take their merry ass time to register recipes

--- a/src/main/java/com/hbm/main/MainRegistry.java
+++ b/src/main/java/com/hbm/main/MainRegistry.java
@@ -667,6 +667,7 @@ public class MainRegistry {
 		event.registerServerCommand(new CommandReloadServer());
 		event.registerServerCommand(new CommandLocate());
 		event.registerServerCommand(new CommandCustomize());
+		event.registerServerCommand(new CommandWikiRender()); // TODO: make this shitfuck be clientside
 		event.registerServerCommand(new CommandReapNetworks());
 		ArcFurnaceRecipes.registerFurnaceSmeltables(); // because we have to wait for other mods to take their merry ass time to register recipes
 	}


### PR DESCRIPTION
the command is used like so:
`/ntmwikirender <type>` where `<type>` is the internal type of the item(s) you want to render, such as `MachineIndustrialTurbine` or `ItemGunBaseNT`.
this behaviour means that it will be intended **SOLELY** for wiki editors and developers
the command, however, doesn't support rendering specific ITEMS, only the `Item` type itself

closes #3013 