### PR TITLE
Modern API for Opencomputers 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,10 +97,6 @@ repositories {
 		name = "CurseMaven"
 		url = "https://cursemaven.com"
 	}
-	maven {
-        name = "OpenComputers"
-        url = "https://maven.cil.li/"
-    }
 }
 
 dependencies {
@@ -115,7 +111,7 @@ dependencies {
 
 	compileOnly("inventorytweaks:InventoryTweaks:1.59-dev:deobf") { transitive = false }
 
-	compileOnly("li.cil.oc:OpenComputers:MC1.7.10-1.5.+:api") { transitive = false }
+	compileOnly("com.github.MightyPirates:OpenComputers:1.7.10-forge~1.8.9:api") { transitive = false }
 
 	compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta.56-GTNH:dev") { transitive = false }
 }


### PR DESCRIPTION
CoC:
  - Changed the buildscript to fetch a much more modern version of the OpenComputers API (v1.8.9).
    - Already stored on the proxy (thanks Martin!!!), so no need to worry about the official maven
    - Allows the usage of the latest OC version (v1.8.9/v1.8.9a) in the development environment (no more crashing on placing OC blocks), so testing with modern features like Lua 5.3/5.4 is possible in it
      - Since NTM only interacts with the public API (and that api has been **remarkably** stable) this should not affect compatibility in any way.

As always, `./gradlew eclipse` will fetch new dependencies (removing the old jar from the build path manually should work, not sure about `./gradlew clean` > setupDecompWorkspace > eclipse).
