### PR TITLE
add fluiditemstorage classs

### DIFF
--- a/src/main/java/com/hbm/inventory/fluid/tank/FluidItemStorage.java
+++ b/src/main/java/com/hbm/inventory/fluid/tank/FluidItemStorage.java
@@ -1,0 +1,30 @@
+package com.hbm.inventory.fluid.tank;
+
+import com.hbm.inventory.fluid.FluidType;
+import com.hbm.inventory.fluid.Fluids;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+// This is a class for items that use pipette like behaviors (rn its used for the pipette and autodrip)
+public class FluidItemStorage {
+	public static void initNBT(ItemStack stack) {
+		stack.stackTagCompound = new NBTTagCompound();
+		stack.stackTagCompound.setShort("type", (short) Fluids.NONE.getID());
+		stack.stackTagCompound.setShort("fill", (short) 0);
+	}
+
+	public static FluidType getType(ItemStack stack) {
+		if(!stack.hasTagCompound()) initNBT(stack);
+		return Fluids.fromID(stack.stackTagCompound.getShort("type"));
+	}
+	public static short getFill(ItemStack stack) {
+		if(!stack.hasTagCompound()) initNBT(stack);
+		return stack.stackTagCompound.getShort("fill");
+	}
+
+	public static void setFill(ItemStack stack, FluidType type, short fill) {
+		if(!stack.hasTagCompound()) initNBT(stack);
+		stack.stackTagCompound.setShort("type", (short) type.getID());
+		stack.stackTagCompound.setShort("fill", fill);
+	}
+}

--- a/src/main/java/com/hbm/items/tool/ItemPipette.java
+++ b/src/main/java/com/hbm/items/tool/ItemPipette.java
@@ -2,6 +2,7 @@ package com.hbm.items.tool;
 
 import com.hbm.inventory.fluid.FluidType;
 import com.hbm.inventory.fluid.Fluids;
+import com.hbm.inventory.fluid.tank.FluidItemStorage;
 import com.hbm.items.ModItems;
 import com.hbm.util.i18n.I18nUtil;
 
@@ -38,42 +39,26 @@ public class ItemPipette extends Item implements IFillableItem {
 
 	public void initNBT(ItemStack stack) {
 		stack.stackTagCompound = new NBTTagCompound();
-		this.setFill(stack, Fluids.NONE, (short) 0); // sets "type" and "fill" NBT
-		stack.stackTagCompound.setShort("capacity", this.getMaxFill()); // set "capacity"
+		FluidItemStorage.setFill(stack, Fluids.NONE, (short) 0);
+		stack.stackTagCompound.setShort("capacity", this.getMaxFill());
 	}
 
 	public FluidType getType(ItemStack stack) {
-		if(!stack.hasTagCompound()) {
-			initNBT(stack);
-		}
-
-		return Fluids.fromID(stack.stackTagCompound.getShort("type"));
+		return FluidItemStorage.getType(stack);
 	}
 
 	public short getCapacity(ItemStack stack) {
-		if(!stack.hasTagCompound()) {
-			initNBT(stack);
-		}
-
+		if(!stack.hasTagCompound()) initNBT(stack);
 		return stack.stackTagCompound.getShort("capacity");
 	}
 
 	public void setFill(ItemStack stack, FluidType type, short fill) {
-		if(!stack.hasTagCompound()) {
-			initNBT(stack);
-		}
-
-		stack.stackTagCompound.setShort("type", (short) type.getID());
-		stack.stackTagCompound.setShort("fill", fill);
+		FluidItemStorage.setFill(stack, type, fill);
 	}
 
 	@Override
 	public int getFill(ItemStack stack) {
-		if(!stack.hasTagCompound()) {
-			initNBT(stack);
-		}
-
-		return stack.stackTagCompound.getShort("fill");
+		return FluidItemStorage.getFill(stack);
 	}
 
 	@Override


### PR DESCRIPTION
this is for something I was planning to do in the future
this class just extracts the nbt access stuff from the pipette class, and re-implements them in a separate class so it can be used easier by other items (one which i was planning!) and makes the base pipette use it.

It will be useful for future items i think.