### PR TITLE
Added Variable Substitution support to `first` and `last` stmts in AUTOCAL

### DIFF
--- a/src/main/java/com/hbm/module/ParseMSES1Ext1.java
+++ b/src/main/java/com/hbm/module/ParseMSES1Ext1.java
@@ -93,7 +93,7 @@ public class ParseMSES1Ext1 extends ParseMSES1 {
 		if(lower.startsWith("first ")) {
 			if(line.length() <= 6) return EnumStatementReturn.PARAMETER_ERROR;
 			try {
-				int length = Integer.parseInt(line.substring(6));
+				int length = Integer.parseInt(substitute(ctx, line.substring(6), true));
 				int max = ctx.readBuffer().length();
 				if(length > max) length = max;
 				ctx.writeBuffer(ctx.readBuffer().substring(0, length));
@@ -105,7 +105,7 @@ public class ParseMSES1Ext1 extends ParseMSES1 {
 		if(lower.startsWith("last ")) {
 			if(line.length() <= 5) return EnumStatementReturn.PARAMETER_ERROR;
 			try {
-				int length = Integer.parseInt(line.substring(5));
+				int length = Integer.parseInt(substitute(ctx, line.substring(5), true));
 				int max = ctx.readBuffer().length();
 				if(length > max) length = max;
 				ctx.writeBuffer(ctx.readBuffer().substring(max - length, max));


### PR DESCRIPTION
### I've added Variable Substitution support to the `first` and `last` statements in the AUTOCAL
NOTE: Substitute has forceNumber true (which seemed like the correct thing to do, rather than parseInt throwing an error). Thus, if an invalid string is entered, it shall substring with 0.

Example of working code:
<img width="444" height="325" alt="ss_20260727-2" src="https://github.com/user-attachments/assets/8465627d-da05-48ec-b6c4-a2d8b1917138" />

[I can finally make a variable-based stack now, for my language, yayy]