### PR TITLE
Fix crash when a looped AudioDynamic sound is restarted after silent channel eviction

### DIFF
--- a/src/main/java/com/hbm/sound/AudioDynamic.java
+++ b/src/main/java/com/hbm/sound/AudioDynamic.java
@@ -69,7 +69,14 @@ public class AudioDynamic extends MovingSound {
 	}
 	
 	public void start() {
-		Minecraft.getMinecraft().getSoundHandler().playSound(this);
+		try {
+			Minecraft.getMinecraft().getSoundHandler().playSound(this);
+		} catch(IllegalArgumentException e) {
+			// SoundManager's internal HashBiMap can already hold this instance as a value
+			// (e.g. evicted under channel pressure without notifying us) when isPlaying()
+			// wrongly reported false, making it try to insert the same value twice and crash.
+			// Skip the restart instead of taking the whole game down over one ambient sound.
+		}
 	}
 	
 	public void stop() {


### PR DESCRIPTION
## Problem

Client crashes with:

```
java.lang.IllegalArgumentException: value already present: com.hbm.sound.AudioDynamic@...
    at com.google.common.collect.HashBiMap.put(HashBiMap.java:238)
    at net.minecraft.client.audio.SoundManager.playSound(SoundManager.java:368)
    at com.hbm.sound.AudioDynamic.start(AudioDynamic.java:72)
    at com.hbm.sound.AudioWrapperClient.startSound(AudioWrapperClient.java:71)
    at com.hbm.entity.projectile.EntityMeteor.onUpdate(EntityMeteor.java:158)
```

`EntityMeteor` (and several other entities/tile entities — `EntityC130`, `EntityBomber`, `EntityRideableRocket`, various machine TEs) gate calls to `AudioWrapper#startSound()` behind an `isPlaying()` check each tick:

```java
if(this.audioFly.isPlaying()) {
    // update sound
} else {
    this.audioFly.startSound();
}
```

`isPlaying()` round-trips to vanilla's `SoundManager#isSoundPlaying`. If the sound engine silently evicts/reclaims the channel backing a looped `AudioDynamic` (without notifying us — more likely to happen in busy areas with lots of concurrent entities/sounds), `isPlaying()` can report `false` for a sound that vanilla's `SoundManager` still has tracked internally. The subsequent `startSound()` call then tries to re-insert the *same* `AudioDynamic` instance into `SoundManager`'s internal `HashBiMap` as a value under a new key, which `HashBiMap` rejects since values must be unique — crashing the game over what should be a harmless "sound didn't restart" case.

Reproduced on a pack that raises `SoundSystemConfig`'s channel count via `GeneralConfig.enableSoundExtension` (which increases channel pressure and makes the eviction race more likely), but the underlying issue is in this shared code path, not pack-specific.

## Fix

Wrap the `playSound` call in `AudioDynamic#start()` in a try/catch for `IllegalArgumentException`. Worst case, one ambient looped sound doesn't restart this tick — instead of the whole game crashing.

This is the minimal, shared fix point since many other classes reuse the same `isPlaying()`-then-`startSound()` pattern through `AudioWrapperClient`.

## Testing

Verified the change compiles and applies cleanly against `master`. Since this only guards an exception path that's rare/timing-dependent to reproduce on demand, I haven't been able to force-trigger the original race in a fresh test world, but the fix cannot change behavior in the non-buggy path (the try block is functionally identical to before) and only takes effect when `playSound` throws.