### PR TITLE
Fix radio crash

### DIFF
--- a/src/main/java/com/hbm/tileentity/network/RTTYSystem.java
+++ b/src/main/java/com/hbm/tileentity/network/RTTYSystem.java
@@ -2,6 +2,7 @@ package com.hbm.tileentity.network;
 
 import java.util.HashMap;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.math.NumberUtils;
 
@@ -18,10 +19,10 @@ import net.minecraft.world.World;
 public class RTTYSystem {
 
 	/** Public frequency band for reading purposes, delayed by one tick */
-	public static HashMap<Pair<World, String>, RTTYChannel> broadcast = new HashMap();
+	public static ConcurrentHashMap<Pair<World, String>, RTTYChannel> broadcast = new ConcurrentHashMap();
 	/** New message queue for writing, gets written into readable Map later on */
-	public static HashMap<Pair<World, String>, Object> newMessages = new HashMap();
-	
+	public static ConcurrentHashMap<Pair<World, String>, Object> newMessages = new ConcurrentHashMap();
+
 	/** Pushes a new signal to be used next tick. Only the last signal pushed will be used. */
 	public static void broadcast(World world, String channelName, Object signal) {
 		Pair identifier = new Pair(world, channelName);


### PR DESCRIPTION
Likely due to a race condition. A bit difficult to reproduce, but this *seems* to have fixed it


```
---- Minecraft Crash Report ----
// Don't be sad, have a hug! <3

Time: 8/8/26, 7:40 PM
Description: Exception in server tick loop

java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1605)
	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1638)
	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1636)
	at Launch//com.hbm.tileentity.network.RTTYSystem.updateBroadcastQueue(RTTYSystem.java:53)
	at Launch//com.hbm.main.ModEventHandler.onServerTick(ModEventHandler.java:1552)
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_189_ModEventHandler_onServerTick_ServerTickEvent.invoke(.dynamic)
	at Launch//cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
	at Launch//cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
	at Launch//cpw.mods.fml.common.FMLCommonHandler.onPreServerTick(FMLCommonHandler.java:260)
	at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:536)
	at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
	at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)
```