### PR TITLE
Blast Furnace Tweaks

### DIFF
--- a/src/main/java/com/hbm/inventory/OreDictManager.java
+++ b/src/main/java/com/hbm/inventory/OreDictManager.java
@@ -440,7 +440,7 @@ public class OreDictManager {
 		VOLCANIC						.gem(gem_volcanic)																				.ore(DictFrame.fromOne(ore_basalt, EnumBasaltOreType.GEM));
 		HEMATITE																														.ore(fromOne(stone_resource, EnumStoneType.HEMATITE));
 		MALACHITE						.ingot(DictFrame.fromOne(chunk_ore, EnumChunkType.MALACHITE))									.ore(fromOne(stone_resource, EnumStoneType.MALACHITE));
-		LIMESTONE				.any(fromOne(stone_resource, EnumStoneType.LIMESTONE), powder_limestone)														.dust(powder_limestone)							.ore(fromOne(stone_resource, EnumStoneType.LIMESTONE));
+		LIMESTONE																		.dust(powder_limestone)							.ore(fromOne(stone_resource, EnumStoneType.LIMESTONE));
 		BAUXITE																															.ore(fromOne(stone_resource, EnumStoneType.BAUXITE));
 		CRYOLITE	.crystal(fromOne(chunk_ore, EnumChunkType.CRYOLITE));
 		SLAG																									.block(block_slag);

--- a/src/main/java/com/hbm/inventory/OreDictManager.java
+++ b/src/main/java/com/hbm/inventory/OreDictManager.java
@@ -440,7 +440,7 @@ public class OreDictManager {
 		VOLCANIC						.gem(gem_volcanic)																				.ore(DictFrame.fromOne(ore_basalt, EnumBasaltOreType.GEM));
 		HEMATITE																														.ore(fromOne(stone_resource, EnumStoneType.HEMATITE));
 		MALACHITE						.ingot(DictFrame.fromOne(chunk_ore, EnumChunkType.MALACHITE))									.ore(fromOne(stone_resource, EnumStoneType.MALACHITE));
-		LIMESTONE																		.dust(powder_limestone)							.ore(fromOne(stone_resource, EnumStoneType.LIMESTONE));
+		LIMESTONE				.any(fromOne(stone_resource, EnumStoneType.LIMESTONE), powder_limestone)														.dust(powder_limestone)							.ore(fromOne(stone_resource, EnumStoneType.LIMESTONE));
 		BAUXITE																															.ore(fromOne(stone_resource, EnumStoneType.BAUXITE));
 		CRYOLITE	.crystal(fromOne(chunk_ore, EnumChunkType.CRYOLITE));
 		SLAG																									.block(block_slag);
@@ -893,12 +893,12 @@ public class OreDictManager {
 			for(Block b : blocks) registerStack(tag, new ItemStack(b));
 			return this;
 		}
-		
+
 		public DictFrame hazIngot() {
 			hazMult = HazardRegistry.ingot;
 			return autoRegHazard(INGOT);
 		}
-		
+
 		// TODO: rethink this. currently, keys are only registered on-demand if the dict frame has a valid entry, even though we can maximize compatibility
 		// by simply registereing all known shapes in the haz reg, whether it exists or not
 		public DictFrame autoRegHazard(MaterialShapes shape) {

--- a/src/main/java/com/hbm/inventory/fluid/Fluids.java
+++ b/src/main/java/com/hbm/inventory/fluid/Fluids.java
@@ -412,7 +412,7 @@ public class Fluids {
 		CONCRETE =				new FluidType("CONCRETE",			0xA2A2A2, 0, 0, 0, EnumSymbol.NONE).addTraits(LIQUID);
 		DHC =					new FluidType("DHC",				0xD2AFFF, 0, 0, 0, EnumSymbol.NONE).addTraits(GASEOUS);
 		AIRBLAST =				new FluidType("AIRBLAST",			0xFFDADA, 0, 3, 0, EnumSymbol.NONE).setTemp(1_200).addTraits(GASEOUS);
-		FLUE =					new FluidType(155, "FLUE",			0x131313, 1, 4, 1, EnumSymbol.NONE).addContainers(new CD_Gastank(0xFF4545, 0xFFE97F)).addTraits(new FT_Flammable(25_000), GASEOUS, new FT_Polluting().burn(PollutionType.SOOT, SOOT_GAS).release(PollutionType.SOOT, SOOT_GAS * 25));
+		FLUE =					new FluidType(155, "FLUE",			0x131313, 1, 4, 1, EnumSymbol.NONE).addContainers(new CD_Gastank(0xFF4545, 0xFFE97F)).addTraits(new FT_Flammable(25_000), GASEOUS, new FT_Polluting().burn(PollutionType.SOOT, SOOT_GAS).release(PollutionType.SOOT, SOOT_GAS * 5));
 
 		// ^ ^ ^ ^ ^ ^ ^ ^
 		//ADD NEW FLUIDS HERE
@@ -617,7 +617,7 @@ public class Fluids {
 				.addEntry(new ToxinEffects(HazardClass.GAS_BLISTERING, true).add(new PotionEffect(Potion.wither.id, 100, 1), new PotionEffect(Potion.confusion.id, 100, 0))));
 		ESTRADIOL.addTraits(new FT_Toxin().addEntry(new ToxinEffects(HazardClass.PARTICLE_FINE, false).add(new PotionEffect(HbmPotion.death.id, 60 * 60 * 20, 0))));
 		REDMUD.addTraits(new FT_Toxin().addEntry(new ToxinEffects(HazardClass.GAS_BLISTERING, false).add(new PotionEffect(Potion.wither.id, 30 * 20, 2))));
-		
+
 		AIR.addTraits(new FT_Heatable().setEff(HeatingType.BOILER, 1.0D).addStep(5, 1, AIRBLAST, 1));
 
 		double eff_steam_boil = 1.0D;
@@ -889,7 +889,7 @@ public class Fluids {
 			ex.printStackTrace();
 		}
 	}
-	
+
 	public static HashMap<String, FluidType> fluidMigration = new HashMap(); // since reloading would create new fluid instances, and those break existing machines
 
 	public static void reloadFluids(){

--- a/src/main/java/com/hbm/inventory/recipes/BlastFurnaceRecipesNT.java
+++ b/src/main/java/com/hbm/inventory/recipes/BlastFurnaceRecipesNT.java
@@ -78,7 +78,7 @@ public class BlastFurnaceRecipesNT extends GenericRecipes<BlastFurnaceRecipe> {
 				.inputItems(new OreDictStack(AL.dust()), new ComparableStack(Items.clay_ball, 7))
 				.outputItems(new ItemStack(ModItems.ingot_firebrick, 8)));
 		this.register((BlastFurnaceRecipe) new BlastFurnaceRecipe("blast.firebrickLimestone").setDuration(800)
-				.inputItems(new OreDictStack(LIMESTONE.any()), new ComparableStack(Items.clay_ball, 6))
+				.inputItems(new OreDictStack(LIMESTONE.dust()), new ComparableStack(Items.clay_ball, 6))
 				.outputItems(new ItemStack(ModItems.ingot_firebrick, 8)));
 	}
 

--- a/src/main/java/com/hbm/inventory/recipes/BlastFurnaceRecipesNT.java
+++ b/src/main/java/com/hbm/inventory/recipes/BlastFurnaceRecipesNT.java
@@ -13,7 +13,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 public class BlastFurnaceRecipesNT extends GenericRecipes<BlastFurnaceRecipe> {
-	
+
 	public static final BlastFurnaceRecipesNT INSTANCE = new BlastFurnaceRecipesNT();
 
 	@Override public int inputItemLimit() { return 2; }
@@ -78,7 +78,7 @@ public class BlastFurnaceRecipesNT extends GenericRecipes<BlastFurnaceRecipe> {
 				.inputItems(new OreDictStack(AL.dust()), new ComparableStack(Items.clay_ball, 7))
 				.outputItems(new ItemStack(ModItems.ingot_firebrick, 8)));
 		this.register((BlastFurnaceRecipe) new BlastFurnaceRecipe("blast.firebrickLimestone").setDuration(800)
-				.inputItems(new OreDictStack(LIMESTONE.ore()), new ComparableStack(Items.clay_ball, 6))
+				.inputItems(new OreDictStack(LIMESTONE.any()), new ComparableStack(Items.clay_ball, 6))
 				.outputItems(new ItemStack(ModItems.ingot_firebrick, 8)));
 	}
 
@@ -86,9 +86,9 @@ public class BlastFurnaceRecipesNT extends GenericRecipes<BlastFurnaceRecipe> {
 	public String getFileName() {
 		return "hbmBlastFurnace.json";
 	}
-	
+
 	public GenericRecipe getRecipe(ItemStack s0, ItemStack s1) {
-		
+
 		for(GenericRecipe recipe : this.recipeOrderedList) {
 			if(recipe.inputItem.length == 1) {
 				if(s0 != null && s1 == null && recipe.inputItem[0].matchesRecipe(s0, false)) return recipe;
@@ -99,7 +99,7 @@ public class BlastFurnaceRecipesNT extends GenericRecipes<BlastFurnaceRecipe> {
 				if(recipe.inputItem[1].matchesRecipe(s0, true) && recipe.inputItem[0].matchesRecipe(s1, false)) return recipe;
 			}
 		}
-		
+
 		return null;
 	}
 }

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineBlastFurnace.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineBlastFurnace.java
@@ -37,7 +37,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 public class TileEntityMachineBlastFurnace extends TileEntityMachineBase implements IFluidStandardTransceiverMK2, IGUIProvider, IFluidCopiable {
-	
+
 	public FluidTank[] tanks;
 
 	public boolean isProgressing;
@@ -47,8 +47,9 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase impleme
 	public static final int FUEL_COAL = 200 * 8;
 	public static final int FUEL_RATE = 200 * 4; // half coal per operation
 	public static final int MAX_FUEL = FUEL_COAL * 24; // 24 pieces of coal, can also fit a bit more than a coal coke block
-	public static final int FLUE_GAS = 100; // per finished operation, not per tick
-	
+	/**8 mb per tick burnt makes for 200tu/t in a fluid heater, giving about the same bonus as a firebox burning coal*/
+	public static final int FLUE_GAS = 8; // per tick
+
 	public ModuleBurnTime burnModule = new ModuleBurnTime()
 			.setWoodHeatMod(0D);
 
@@ -66,15 +67,15 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase impleme
 
 	@Override
 	public void updateEntity() {
-		
+
 		if(!worldObj.isRemote) {
 			this.checkTilt(TiltType.CONFIG, false);
-			
+
 			for(DirPos pos : this.getConPos()) {
 				this.trySubscribe(tanks[0].getTankType(), worldObj, pos);
 				if(this.tanks[1].getFill() > 0) this.tryProvide(tanks[1], worldObj, pos);
 			}
-			
+
 			if(slots[0] != null) {
 				int capacity = MAX_FUEL - fuel;
 				int burnValue = getBurnTime(slots[0]);
@@ -83,50 +84,51 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase impleme
 					this.decrStackSize(0, 1);
 				}
 			}
-			
+
 			this.speed = 0F;
 			GenericRecipe recipe = BlastFurnaceRecipesNT.INSTANCE.getRecipe(slots[1], slots[2]);
-			
+
 			if(!this.tilted && recipe != null && this.fuel >= FUEL_RATE && this.hasQuantities(recipe) && this.canOutput(recipe)) {
-				
-				this.speed = MathHelper.clamp_float(0.5F + this.tanks[0].getFill() * 8F / this.tanks[0].getMaxFill(), 0.5F, 5F);
-				
+
+				this.speed = MathHelper.clamp_float(1F + this.tanks[0].getFill() * 8F / this.tanks[0].getMaxFill(), 1F, 5F);
+
 				this.isProgressing = true;
 				this.progress += speed / recipe.duration;
-				
+
+				this.tanks[1].setFill(tanks[1].getFill() + FLUE_GAS);
+				if(this.tanks[1].getFill() > this.tanks[1].getMaxFill()) {
+					int spill = this.tanks[1].getFill() - this.tanks[1].getMaxFill();
+					this.tanks[1].getTankType().onFluidRelease(worldObj, xCoord, yCoord + 7, zCoord, tanks[1], spill);
+					FluidTrait.onRelease(worldObj, xCoord, yCoord, zCoord, tanks[1].getTankType(), tanks[1], FluidReleaseType.SPILL, spill);
+					this.tanks[1].setFill(this.tanks[1].getMaxFill());
+				}
+
 				if(this.progress >= 1F) {
 					this.process(recipe);
 					this.progress = 0F;
 					this.fuel -= FUEL_RATE;
-					this.tanks[1].setFill(tanks[1].getFill() + FLUE_GAS);
-					if(this.tanks[1].getFill() > this.tanks[1].getMaxFill()) {
-						int spill = this.tanks[1].getFill() - this.tanks[1].getMaxFill();
-						this.tanks[1].getTankType().onFluidRelease(worldObj, xCoord, yCoord + 7, zCoord, tanks[1], spill);
-						FluidTrait.onRelease(worldObj, xCoord, yCoord, zCoord, tanks[1].getTankType(), tanks[1], FluidReleaseType.SPILL, spill);
-						this.tanks[1].setFill(this.tanks[1].getMaxFill());
-					}
 				}
-				
+
 				if(worldObj.rand.nextInt(10) == 0 && !this.muffled) {
 					worldObj.playSoundEffect(xCoord, yCoord, zCoord, NTMSounds.VANILLA_FIRE, 1.0F, 0.5F + worldObj.rand.nextFloat() * 0.25F);
 				}
-				
+
 			} else {
 				this.isProgressing = false;
 				this.progress = 0F;
 			}
-			
+
 			if(this.tanks[0].getFill() > 0) this.tanks[0].setFill((int) (this.tanks[0].getFill() * 0.95));
-			
+
 			this.networkPackNT(100);
 		} else {
-			
+
 			if(worldObj.getBlock(xCoord, yCoord + 7, zCoord).isAir(worldObj, xCoord, yCoord + 7, zCoord)) {
 				if(isProgressing && worldObj.getTotalWorldTime() % 2 == 0) {
 					Random rand = worldObj.rand;
 					this.worldObj.spawnParticle("lava", xCoord + 0.25 + rand.nextDouble() * 0.5, yCoord + 7.25, zCoord + 0.25 + rand.nextDouble() * 0.5, 0, 0, 0);
-					
-					if(tanks[1].getFill() >= 100 && MainRegistry.proxy.me().getDistanceSq(xCoord + 0.5, yCoord + 7, zCoord + 0.5) < 100 * 100) {
+
+					if(tanks[1].getFill() >= 1_000 && MainRegistry.proxy.me().getDistanceSq(xCoord + 0.5, yCoord + 7, zCoord + 0.5) < 100 * 100) {
 						if(worldObj.getTotalWorldTime() % 2 == 0) {
 							NBTTagCompound fx = new NBTTagCompound();
 							fx.setString("type", "tower");
@@ -145,7 +147,7 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase impleme
 			}
 		}
 	}
-	
+
 	public DirPos[] getConPos() {
 		ForgeDirection dir = ForgeDirection.getOrientation(this.getBlockMetadata() - 10);
 		return new DirPos[] {
@@ -157,15 +159,15 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase impleme
 				new DirPos(xCoord, yCoord + 7, zCoord, Library.POS_Y)
 		};
 	}
-	
+
 	public boolean hasQuantities(GenericRecipe recipe) {
 		if(recipe.inputItem[0].matchesRecipe(slots[1], false) && recipe.inputItem[1].matchesRecipe(slots[2], false)) return true;
 		if(recipe.inputItem[0].matchesRecipe(slots[2], false) && recipe.inputItem[1].matchesRecipe(slots[1], false)) return true;
 		return false;
 	}
-	
+
 	public boolean canOutput(GenericRecipe recipe) {
-		
+
 		for(int i = 0; i < recipe.outputItem.length; i++) {
 			ItemStack slot = slots[3 + i];
 			if(slot == null) continue;
@@ -176,23 +178,23 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase impleme
 			if(stack.getItemDamage() != slot.getItemDamage()) return false;
 			if(stack.stackSize + slot.stackSize > stack.getMaxStackSize()) return false;
 		}
-		
+
 		return true;
 	}
-	
+
 	public void process(GenericRecipe recipe) {
-		
+
 		for(int i = 0; i < recipe.outputItem.length; i++) {
 			IOutput out = recipe.outputItem[i];
 			ItemStack stack = out.collapse();
 			if(slots[3 + i] != null) slots[3 + i].stackSize += stack.stackSize;
 			else slots[3 + i] = stack;
 		}
-		
+
 		if(recipe.inputItem.length == 1) {
 			if(recipe.inputItem[0].matchesRecipe(slots[1], false)) this.decrStackSize(1, recipe.inputItem[0].stacksize);
 			else if(recipe.inputItem[0].matchesRecipe(slots[2], false)) this.decrStackSize(2, recipe.inputItem[0].stacksize);
-			
+
 		} else if(recipe.inputItem.length == 2) {
 			if(recipe.inputItem[0].matchesRecipe(slots[1], false) && recipe.inputItem[1].matchesRecipe(slots[2], false)) {
 				this.decrStackSize(1, recipe.inputItem[0].stacksize);
@@ -203,7 +205,7 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase impleme
 			}
 		}
 	}
-	
+
 	public int getBurnTime(ItemStack stack) {
 		if(stack.getItem().hasContainerItem(stack)) return 0;
 		return burnModule.getBurnHeat(burnModule.getBurnTime(stack, 0D), stack, 0D);
@@ -218,23 +220,23 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase impleme
 
 	@Override
 	public boolean canInsertItem(int slot, ItemStack stack, int side) {
-		
+
 		if(slot == 1 || slot == 2) {
 
 			// repetition prevention
 			if(slot == 1 && slots[2] != null && stack.isItemEqual(slots[2])) return false;
 			if(slot == 2 && slots[1] != null && stack.isItemEqual(slots[1])) return false;
-			
+
 			// needs to match at least one recipe
 			for(GenericRecipe recipe : BlastFurnaceRecipesNT.INSTANCE.recipeOrderedList) {
 				for(AStack input : recipe.inputItem) {
 					if(input.matchesRecipe(stack, true)) return true;
 				}
 			}
-			
+
 			return false;
 		}
-		
+
 		return this.isItemValidForSlot(slot, stack);
 	}
 
@@ -251,7 +253,7 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase impleme
 	@Override
 	public void serialize(ByteBuf buf) {
 		super.serialize(buf);
-		
+
 		buf.writeBoolean(isProgressing);
 		buf.writeFloat(progress);
 		buf.writeFloat(speed);
@@ -264,7 +266,7 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase impleme
 	@Override
 	public void deserialize(ByteBuf buf) {
 		super.deserialize(buf);
-		
+
 		this.isProgressing = buf.readBoolean();
 		this.progress = buf.readFloat();
 		this.speed = buf.readFloat();
@@ -293,18 +295,18 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase impleme
 		tanks[0].writeToNBT(nbt, "t0");
 		tanks[1].writeToNBT(nbt, "t1");
 	}
-	
+
 	AxisAlignedBB bb = null;
-	
+
 	@Override
 	public AxisAlignedBB getRenderBoundingBox() {
-		
+
 		if(bb == null) {
 			bb = AxisAlignedBB.getBoundingBox(xCoord - 1, yCoord, zCoord - 1, xCoord + 2, yCoord + 7, zCoord + 2);
 		}
 		return bb;
 	}
-	
+
 	@Override
 	@SideOnly(Side.CLIENT)
 	public double getMaxRenderDistanceSquared() {
@@ -318,10 +320,8 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase impleme
 	@Override public FluidTank[] getSendingTanks() { return new FluidTank[] { tanks[1] }; }
 	@Override public FluidTank[] getAllTanks() { return tanks; }
 
-	@Override public long getProviderSpeed(FluidType type, int pressure) { return Math.max(tanks[1].getFill() * 50 / tanks[1].getMaxFill(), 1); }
-	
 	@Override public FluidTank getTankToPaste() { return null; }
-	
+
 	@Override public int getFloorCount() { return 2 * 2; }
 	@Override public BlockPos getFloorPosFromIndex(int index) { return this.standardFloor3x3(index); }
 }

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineBlastFurnace.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineBlastFurnace.java
@@ -95,18 +95,19 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase impleme
 				this.isProgressing = true;
 				this.progress += speed / recipe.duration;
 
-				this.tanks[1].setFill(tanks[1].getFill() + FLUE_GAS);
-				if(this.tanks[1].getFill() > this.tanks[1].getMaxFill()) {
-					int spill = this.tanks[1].getFill() - this.tanks[1].getMaxFill();
-					this.tanks[1].getTankType().onFluidRelease(worldObj, xCoord, yCoord + 7, zCoord, tanks[1], spill);
-					FluidTrait.onRelease(worldObj, xCoord, yCoord, zCoord, tanks[1].getTankType(), tanks[1], FluidReleaseType.SPILL, spill);
-					this.tanks[1].setFill(this.tanks[1].getMaxFill());
-				}
 
 				if(this.progress >= 1F) {
 					this.process(recipe);
 					this.progress = 0F;
 					this.fuel -= FUEL_RATE;
+
+					this.tanks[1].setFill((int) (tanks[1].getFill() + FLUE_GAS * (recipe.duration/speed)));
+					if(this.tanks[1].getFill() > this.tanks[1].getMaxFill()) {
+						int spill = this.tanks[1].getFill() - this.tanks[1].getMaxFill();
+						this.tanks[1].getTankType().onFluidRelease(worldObj, xCoord, yCoord + 7, zCoord, tanks[1], spill);
+						FluidTrait.onRelease(worldObj, xCoord, yCoord, zCoord, tanks[1].getTankType(), tanks[1], FluidReleaseType.SPILL, spill);
+						this.tanks[1].setFill(this.tanks[1].getMaxFill());
+					}
 				}
 
 				if(worldObj.rand.nextInt(10) == 0 && !this.muffled) {

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineBlastFurnace.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineBlastFurnace.java
@@ -321,6 +321,8 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase impleme
 	@Override public FluidTank[] getSendingTanks() { return new FluidTank[] { tanks[1] }; }
 	@Override public FluidTank[] getAllTanks() { return tanks; }
 
+	@Override public long getProviderSpeed(FluidType type, int pressure) { return Math.max(tanks[1].getFill() * 50 / tanks[1].getMaxFill(), 8); }
+
 	@Override public FluidTank getTankToPaste() { return null; }
 
 	@Override public int getFloorCount() { return 2 * 2; }


### PR DESCRIPTION
Changes:
* Flue production in the blast furnace was changed to be per tick (8 mb/t) as opposed to per recipe completion
   * This makes flue gas recycling for the blast furnace worthwhile by making the bonus similar to a firebox on standard coal
   * Also prevents the issue where flue gas was produced inconsistently, which made the same setup not work across recipes with different recipe times
* Flue buffer increased by 5x to compensate, and pollution multiplier from releasing flue gas decreased to 5x instead of 25x
* Made the blast furnace speed 100% by default, which makes recipes process with the shown times on the recipes and NEI
   * The recipes are all already balanced well for it, nor does the speed boost detract from the massive bonuses hot blast gives
* Changed limestone.ore() to limestone.any() on the blast furnace firebrick recipe, letting crushed limestone be used as well