### PR TITLE
Fix relay satellite payload

### DIFF
--- a/src/main/java/com/hbm/saveddata/satellites/SatelliteRelay.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatelliteRelay.java
@@ -58,8 +58,8 @@ public class SatelliteRelay extends SatelliteBase {
 			if(targetWorld != null) {
 				
 				StringBuilder signal = new StringBuilder();
-				for(int i = 1; i < cmd.length; i++) {
-					if(i > 1) signal.append(" ");
+				for(int i = 3; i < cmd.length; i++) {
+					if(i > 3) signal.append(" ");
 					signal.append(cmd[i]);
 				}
 				


### PR DESCRIPTION
Fixes relay satellites including the target dimension and channel in forwarded RoR signals. The relay satellite currently includes the target dimension and channel in the forwarded RoR signal. This change skips those routing arguments so receivers get only the intended payload.