### PR TITLE
Fix SatLink RoR connected value

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineSatLink.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineSatLink.java
@@ -168,7 +168,7 @@ public class TileEntityMachineSatLink extends TileEntityTickingBase implements I
 	@Override
 	public String provideRORValue(String name) {
 
-		if(name.equals(PREFIX_VALUE + connected)) {
+		if(name.equals(PREFIX_VALUE + "connected")) {
 			return this.connected ? "TRUE" : "FALSE";
 		}
 


### PR DESCRIPTION
Fixes the SatLink RoR connected value always returning null.