### PR TITLE
Fix RoR fluid counter reset timing

### DIFF
--- a/src/main/java/com/hbm/tileentity/network/TileEntityFluidCounterValve.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityFluidCounterValve.java
@@ -120,6 +120,7 @@ public class TileEntityFluidCounterValve extends TileEntityPipeBaseNT implements
 	@Callback(direct = true)
 	@Optional.Method(modid = "OpenComputers")
 	public Object[] resetCounter(Context context, Arguments args) {
+		updateCounter();
 		counter = 0;
 		markDirty();
 		return new Object[] {};
@@ -164,6 +165,7 @@ public class TileEntityFluidCounterValve extends TileEntityPipeBaseNT implements
 	@Override
 	public String runRORFunction(String name, String[] params) {
 		if(name.equals(PREFIX_FUNCTION + "reset")) {
+			updateCounter();
 			counter = 0;
 			markDirty();
 		} else if(name.equals(PREFIX_FUNCTION + "setstate")) {


### PR DESCRIPTION
Fixes the fluid counter reset result being dependent on tile entity update order.