### PR TITLE
Fix parameterless RoR command crashes

### DIFF
--- a/src/main/java/com/hbm/saveddata/satellites/SatellitePrecisionLaser.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatellitePrecisionLaser.java
@@ -91,7 +91,7 @@ public class SatellitePrecisionLaser extends SatelliteBase {
 			return;
 		}
 		
-		if(cmd[0].equals(CMD_SETENTITYTARGET)) {
+		if(cmd[0].equals(CMD_SETENTITYTARGET) && cmd.length == 2) {
 			this.targetedEntity = IRORInteractive.parseInt(cmd[1]);
 			return;
 		}

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityHeaterOilburner.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityHeaterOilburner.java
@@ -260,12 +260,12 @@ public class TileEntityHeaterOilburner extends TileEntityMachinePolluting implem
 
 	@Override
 	public String runRORFunction(String name, String[] params) {
-		if((PREFIX_FUNCTION + "setstate").equals(name)) {
+		if((PREFIX_FUNCTION + "setstate").equals(name) && params.length > 0) {
 			this.isOn = params[0].equals("1");
 			this.markChanged();
 			return null;
 		}
-		if((PREFIX_FUNCTION + "setburnrate").equals(name)) {
+		if((PREFIX_FUNCTION + "setburnrate").equals(name) && params.length > 0) {
 			int rate = IRORInteractive.parseInt(params[0], 1, 10);
 			this.setting = rate;
 			this.markChanged();

--- a/src/main/java/com/hbm/tileentity/network/TileEntityFluidCounterValve.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityFluidCounterValve.java
@@ -166,7 +166,7 @@ public class TileEntityFluidCounterValve extends TileEntityPipeBaseNT implements
 		if(name.equals(PREFIX_FUNCTION + "reset")) {
 			counter = 0;
 			markDirty();
-		} else if(name.equals(PREFIX_FUNCTION + "setstate")) {
+		} else if(name.equals(PREFIX_FUNCTION + "setstate") && params.length > 0) {
 			setState(IRORInteractive.parseInt(params[0], 0, 1));
 		}
 		return null;


### PR DESCRIPTION
Fixes parameterless RoR commands crashing fluid counter valves, oil burners, and precision laser satellites.