### PR TITLE
Save satellite state after SatLink commands

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineSatLink.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineSatLink.java
@@ -210,6 +210,7 @@ public class TileEntityMachineSatLink extends TileEntityTickingBase implements I
 			String[] cmd = String.join(IRORInteractive.PARAM_SEPARATOR, params).split(" ");
 			if(sat != null) {
 				sat.onCommand(worldObj, cmd);
+				dat.markDirty();
 			}
 			SatelliteRayScan.reportEvent(worldObj, xCoord, yCoord, zCoord, RayEvent.INFO_RADIO, 300);
 			this.markChanged();


### PR DESCRIPTION
Fixes satellite state changes made through SatLink commands not being saved to disk.