### PR TITLE
lock n load or smth

### DIFF
--- a/src/main/java/com/hbm/items/tool/ItemAmmoBag.java
+++ b/src/main/java/com/hbm/items/tool/ItemAmmoBag.java
@@ -144,6 +144,11 @@ public class ItemAmmoBag extends Item implements IGUIProvider {
 		@Override public boolean isUseableByPlayer(EntityPlayer player) { return true; }
 		@Override public void openInventory() { }
 		@Override public void closeInventory() { }
-		@Override public boolean isItemValidForSlot(int slot, ItemStack stack) { return !stack.hasTagCompound(); }
+		@Override public boolean isItemValidForSlot(int slot, ItemStack stack) {
+			return !stack.hasTagCompound() && (
+				stack.getItem() == ModItems.ammo_standard || 
+				stack.getItem() == ModItems.ammo_secret
+			);
+		}
 	}
 }


### PR DESCRIPTION
fixed ammo bag being able to store anything but items with NBT data

thanks to github.com/TheDogOfChaos for finding this :3

PS: ammo bags made so radioactive items were completely ignored when stored in, making it effectively an anti-rad container