### PR TITLE
Fix satellite miner cargo stack sizes

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineSatDock.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineSatDock.java
@@ -218,7 +218,7 @@ public class TileEntityMachineSatDock extends TileEntity implements ISidedInvent
 
 		for(int i = 0; i < 15; i++) {
 			if(slots[i] == null) {
-				slots[i] = new ItemStack(stack.getItem(), 1, stack.getItemDamage());
+				slots[i] = new ItemStack(stack.getItem(), stack.stackSize, stack.getItemDamage());
 				return;
 			}
 		}


### PR DESCRIPTION
Fixes asteroid and lunar mining satellite cargo losing items when inserting into an empty cargo dock slot.
