### PR TITLE
QMAW Update I vague posted about (on accident)

### DIFF
--- a/src/main/java/com/hbm/qmaw/GuiQMAW.java
+++ b/src/main/java/com/hbm/qmaw/GuiQMAW.java
@@ -14,6 +14,7 @@ import com.hbm.qmaw.components.*;
 import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
+import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.resources.LanguageManager;
@@ -149,6 +150,28 @@ public class GuiQMAW extends GuiScreen {
 				continue;
 			}
 
+			if(toParse.startsWith("<ct>")) {
+				int end = toParse.indexOf("</ct>");
+				if(end != -1) {
+					String text = toParse.substring(4, end);
+					toParse = toParse.substring(end + 5);
+
+					QComponentText textComponent = new QComponentText(text);
+					int textWidth = (maxLineLength - textComponent.getWidth()) / 8;
+					//I did not know this existed until I googled it lol
+					String margin = String.format("%" + textWidth + "s", "");
+					textComponent = new QComponentText(margin + text);
+					int centerWidth = textComponent.getWidth();
+					currentLine = new ArrayList();
+					this.lines.add(currentLine);
+					currentLine.add(textComponent);
+					currentLineWidth = centerWidth;
+
+					prevToParse = "" + toParse;
+					continue;
+				}
+			}
+
 			// handle links
 			if(toParse.startsWith("[[")) {
 				int end = toParse.indexOf("]]");
@@ -198,7 +221,8 @@ public class GuiQMAW extends GuiScreen {
 			if(tbIndex != -1) delimit = Math.min(delimit, tbIndex);
 			int btIndex = toParse.indexOf("<bt>");
 			if(btIndex != -1) delimit = Math.min(delimit, btIndex);
-
+			int ctIndex = toParse.indexOf("<ct>");
+			if(ctIndex != -1) delimit = Math.min(delimit, ctIndex);
 			if(delimit > 0) {
 				QComponentText textComponent = new QComponentText(toParse.substring(0, delimit) + (spaceIndex == delimit ? " " : ""));
 				toParse = toParse.substring(delimit);

--- a/src/main/java/com/hbm/qmaw/GuiQMAW.java
+++ b/src/main/java/com/hbm/qmaw/GuiQMAW.java
@@ -115,6 +115,40 @@ public class GuiQMAW extends GuiScreen {
 				continue;
 			}
 
+			if(toParse.startsWith("<tb>")) {
+				toParse = toParse.substring(4);
+				QComponentText qText = new QComponentText("    ");
+				int width = qText.getWidth();
+				if(width + currentLineWidth <= maxLineLength) {
+					currentLine.add(qText);
+					currentLineWidth += width;
+				// new line
+				} else {
+					currentLine = new ArrayList();
+					this.lines.add(currentLine);
+					currentLine.add(qText);
+					currentLineWidth = width;
+				}
+				continue;
+			}
+
+			if(toParse.startsWith("<bt>")) {
+				toParse = toParse.substring(4);
+				QComponentText qText = new QComponentText("  • ");
+				int width = qText.getWidth();
+				if(width + currentLineWidth <= maxLineLength) {
+					currentLine.add(qText);
+					currentLineWidth += width;
+				// new line
+				} else {
+					currentLine = new ArrayList();
+					this.lines.add(currentLine);
+					currentLine.add(qText);
+					currentLineWidth = width;
+				}
+				continue;
+			}
+
 			// handle links
 			if(toParse.startsWith("[[")) {
 				int end = toParse.indexOf("]]");
@@ -160,6 +194,10 @@ public class GuiQMAW extends GuiScreen {
 			if(linkIndex != -1) delimit = Math.min(delimit, linkIndex);
 			int brIndex = toParse.indexOf("<br>");
 			if(brIndex != -1) delimit = Math.min(delimit, brIndex);
+			int tbIndex = toParse.indexOf("<tb>");
+			if(tbIndex != -1) delimit = Math.min(delimit, tbIndex);
+			int btIndex = toParse.indexOf("<bt>");
+			if(btIndex != -1) delimit = Math.min(delimit, btIndex);
 
 			if(delimit > 0) {
 				QComponentText textComponent = new QComponentText(toParse.substring(0, delimit) + (spaceIndex == delimit ? " " : ""));


### PR DESCRIPTION
This adds:
-Basic tabbing functionality
-Bullet Point
-Centering

example of a file for it
```
{
    "name": "Reformate",
    "icon": ["hbm:item.fluid_icon", 1, 91],
    "trigger": [["hbm:item.fluid_icon", 1, 91]],
    "title": {
        "en_US": "Reformate"
    },
    "content": {
        "en_US": "Reformate can be <ct>obtained</ct><br> by [[vacuum refining|Vacuum Refinery]] [[pressurized|Compressor]] [[crude oil|Crude Oil]]. It has a diverse selection of uses including the production of <br><bt>[[reformate gas|Reformate Gas]] through <br><tb>[[cracking|Catalytic Cracking Tower]] or [[radiolysis|Radiolysis Chamber]]. Another notable use is the production of [[BTX]] through [[fractioning|Fractioning Tower]]. Additionally, it is a key ingredient in both [[high-cetane diesel|High-Cetane Diesel]] and [[high-cetane cracked diesel|High-Cetane Cracked Diesel]].<br><br>{{Template:Oil3}}"
    }
}
```
here is how it renders:

<img width="1023" height="672" alt="image" src="https://github.com/user-attachments/assets/f4bdadd7-8a3f-4b79-88aa-dba32aad9382" />


