### PR TITLE
Respect player death prevention for radiation

### DIFF
--- a/src/main/java/com/hbm/handler/EntityEffectHandler.java
+++ b/src/main/java/com/hbm/handler/EntityEffectHandler.java
@@ -230,15 +230,15 @@ public class EntityEffectHandler {
 		/// EFFECTS ///
 		if(eRad >= 1000) {
 
-			//entity.attackEntityFrom(ModDamageSource.radiation, 1000F);
+			entity.attackEntityFrom(ModDamageSource.radiation, 1000F);
 			HbmLivingProps.setRadiation(entity, 0);
 
-			if(entity.getHealth() > 0) {
+			if(entity.getHealth() > 0 && !(entity instanceof EntityPlayer)) {
 				entity.setHealth(0);
 				entity.onDeath(ModDamageSource.radiation);
 			}
 
-			if(entity instanceof EntityPlayer) ((EntityPlayer) entity).triggerAchievement(MainRegistry.achRadDeath);
+			if(entity instanceof EntityPlayer && entity.getHealth() <= 0) ((EntityPlayer) entity).triggerAchievement(MainRegistry.achRadDeath);
 
 		} else if(eRad >= 800) {
 			if(world.rand.nextInt(300) == 0) entity.addPotionEffect(new PotionEffect(Potion.confusion.id, 5 * 30, 0));


### PR DESCRIPTION
Prevents lethal radiation from killing players after a death prevention method has already activated.

Fixes #3231