### PR TITLE
Fix satellite cargo delivery and display miner cooldowns

### DIFF
--- a/src/main/java/com/hbm/entity/missile/EntitySatellitePod.java
+++ b/src/main/java/com/hbm/entity/missile/EntitySatellitePod.java
@@ -159,6 +159,7 @@ public class EntitySatellitePod extends EntityThrowableInterp {
 		dataWatcher.updateObject(DW_STATE, nbt.getInteger("state"));
 		timer = nbt.getInteger("timer");
 		speed = nbt.getDouble("speed");
+		callerYPos = nbt.getInteger("callerYPos");
 
 		int itemCount = nbt.getInteger("itemCount");
 		NBTTagList items = nbt.getTagList("items", 10);
@@ -182,6 +183,7 @@ public class EntitySatellitePod extends EntityThrowableInterp {
 		nbt.setInteger("state", dataWatcher.getWatchableObjectInt(DW_STATE));
 		nbt.setInteger("timer", timer);
 		nbt.setDouble("speed", speed);
+		nbt.setInteger("callerYPos", callerYPos);
 
 		nbt.setInteger("itemCount", this.slots.length);
 		NBTTagList items = new NBTTagList();

--- a/src/main/java/com/hbm/saveddata/satellites/SatelliteBase.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatelliteBase.java
@@ -50,24 +50,6 @@ public abstract class SatelliteBase {
 		if(driveInput != null) nbt.setInteger("driveInput", driveInput.ordinal());
 		if(driveOutput != null) nbt.setInteger("driveOutput", driveOutput.ordinal());
 
-		int itemCount = nbt.getInteger("itemCount");
-		NBTTagList items = nbt.getTagList("requestableSlots", 10);
-		this.requestableSlots = new ItemStack[itemCount];
-		for(int i = 0; i < items.tagCount(); i++) {
-			NBTTagCompound itemTag = items.getCompoundTagAt(i);
-			int j = itemTag.getByte("slot") & 255;
-			if(j >= 0 && j < this.requestableSlots.length) this.requestableSlots[j] = ItemStack.loadItemStackFromNBT(itemTag);
-		}
-	}
-	
-	public void readFromNBT(NBTTagCompound nbt) {
-		this.targetX = nbt.getInteger("targetX");
-		this.targetZ = nbt.getInteger("targetZ");
-		this.tx = nbt.getString("tx");
-
-		if(nbt.hasKey("driveInput")) this.driveInput = EnumUtil.grabEnumSafely(EnumDriveType.class, nbt.getInteger("driveInput")); else this.driveInput = null;
-		if(nbt.hasKey("driveOutput")) this.driveOutput = EnumUtil.grabEnumSafely(EnumDriveType.class, nbt.getInteger("driveOutput")); else this.driveOutput = null;
-
 		nbt.setInteger("itemCount", this.requestableSlots.length);
 		NBTTagList items = new NBTTagList();
 		for(int i = 0; i < this.requestableSlots.length; i++) {
@@ -78,6 +60,24 @@ public abstract class SatelliteBase {
 			items.appendTag(itemTag);
 		}
 		nbt.setTag("requestableSlots", items);
+	}
+	
+	public void readFromNBT(NBTTagCompound nbt) {
+		this.targetX = nbt.getInteger("targetX");
+		this.targetZ = nbt.getInteger("targetZ");
+		this.tx = nbt.getString("tx");
+
+		if(nbt.hasKey("driveInput")) this.driveInput = EnumUtil.grabEnumSafely(EnumDriveType.class, nbt.getInteger("driveInput")); else this.driveInput = null;
+		if(nbt.hasKey("driveOutput")) this.driveOutput = EnumUtil.grabEnumSafely(EnumDriveType.class, nbt.getInteger("driveOutput")); else this.driveOutput = null;
+
+		int itemCount = nbt.getInteger("itemCount");
+		NBTTagList items = nbt.getTagList("requestableSlots", 10);
+		this.requestableSlots = new ItemStack[itemCount];
+		for(int i = 0; i < items.tagCount(); i++) {
+			NBTTagCompound itemTag = items.getCompoundTagAt(i);
+			int j = itemTag.getByte("slot") & 255;
+			if(j >= 0 && j < this.requestableSlots.length) this.requestableSlots[j] = ItemStack.loadItemStackFromNBT(itemTag);
+		}
 	}
 	
 	/** The check for if there's data available, may also call produceData if a cooldown has elapsed */
@@ -118,7 +118,7 @@ public abstract class SatelliteBase {
 		
 		EntitySatellitePod pod = new EntitySatellitePod(world).setup(y, requestableSlots);
 		pod.setPosition(x + 0.5, 300, z + 0.5);
-		world.spawnEntityInWorld(pod);
+		if(!world.spawnEntityInWorld(pod)) return false;
 		
 		this.requestableSlots = new ItemStack[0];
 		this.markDirty();

--- a/src/main/java/com/hbm/saveddata/satellites/SatelliteLunarMiner.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatelliteLunarMiner.java
@@ -15,9 +15,9 @@ public class SatelliteLunarMiner extends SatelliteMiner {
 	
 	@Override
 	public IChatComponent[] getInfo(World world) {
-		return new IChatComponent[] {
-				new ChatComponentTranslation(ModItems.satellite.getUnlocalizedName(new ItemStack(ModItems.satellite, 1, EnumSatType.MINER_LUNAR.ordinal())) + ".name")
-		};
+		IChatComponent[] info = super.getInfo(world);
+		info[0] = new ChatComponentTranslation(ModItems.satellite.getUnlocalizedName(new ItemStack(ModItems.satellite, 1, EnumSatType.MINER_LUNAR.ordinal())) + ".name");
+		return info;
 	}
 	
 	static {

--- a/src/main/java/com/hbm/saveddata/satellites/SatelliteMiner.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatelliteMiner.java
@@ -30,8 +30,11 @@ public class SatelliteMiner extends SatelliteBase {
 	
 	@Override
 	public IChatComponent[] getInfo(World world) {
+		int seconds = (int) Math.ceil(Math.max(0D, 1D - this.progress) / SPEED / 20D);
+
 		return new IChatComponent[] {
-				new ChatComponentTranslation(ModItems.satellite.getUnlocalizedName(new ItemStack(ModItems.satellite, 1, EnumSatType.MINER_ASTRO.ordinal())) + ".name")
+				new ChatComponentTranslation(ModItems.satellite.getUnlocalizedName(new ItemStack(ModItems.satellite, 1, EnumSatType.MINER_ASTRO.ordinal())) + ".name"),
+				this.requestableSlots.length > 0 ? new ChatComponentTranslation("satellite.ready") : new ChatComponentTranslation("satellite.cooldown", (seconds / 60) + "m" + (seconds % 60) + "s")
 		};
 	}
 


### PR DESCRIPTION
Preserves pending satellite cargo across world saves and cargo pod braking height across entity reloads. Cargo is now cleared only after the pod spawns successfully, and asteroid and lunar miner cooldowns are displayed through the Satellite Link overlay.

Fixes #3242