### PR TITLE
Fix satellite miner ready status and cargo pod collisions

### DIFF
--- a/src/main/java/com/hbm/entity/missile/EntitySatellitePod.java
+++ b/src/main/java/com/hbm/entity/missile/EntitySatellitePod.java
@@ -243,13 +243,11 @@ public class EntitySatellitePod extends EntityThrowableInterp implements IRadarD
 		
 		if(mop.typeOfHit == mop.typeOfHit.BLOCK) {
 			this.setPosition(mop.hitVec.xCoord, mop.hitVec.yCoord, mop.hitVec.zCoord);
-			
-			if(!this.isLanding() || this.worldObj.getBlock(mop.blockX, mop.blockY, mop.blockZ) != ModBlocks.sat_dock) {
-				this.attackEntityFrom(DamageSource.generic, 10F);
-				return;
-			}
-
 			this.onGround = true;
+			
+			if(this.speed < -0.02) {
+				this.attackEntityFrom(DamageSource.generic, 10F);
+			}
 		}
 	}
 	

--- a/src/main/java/com/hbm/entity/missile/EntitySatellitePod.java
+++ b/src/main/java/com/hbm/entity/missile/EntitySatellitePod.java
@@ -243,11 +243,13 @@ public class EntitySatellitePod extends EntityThrowableInterp implements IRadarD
 		
 		if(mop.typeOfHit == mop.typeOfHit.BLOCK) {
 			this.setPosition(mop.hitVec.xCoord, mop.hitVec.yCoord, mop.hitVec.zCoord);
-			this.onGround = true;
 			
-			if(this.speed < -0.02) {
+			if(!this.isLanding() || this.worldObj.getBlock(mop.blockX, mop.blockY, mop.blockZ) != ModBlocks.sat_dock) {
 				this.attackEntityFrom(DamageSource.generic, 10F);
+				return;
 			}
+
+			this.onGround = true;
 		}
 	}
 	

--- a/src/main/java/com/hbm/saveddata/satellites/SatelliteLunarMiner.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatelliteLunarMiner.java
@@ -20,7 +20,7 @@ public class SatelliteLunarMiner extends SatelliteMiner {
 		
 		return new IChatComponent[] {
 				new ChatComponentTranslation(ModItems.satellite.getUnlocalizedName(new ItemStack(ModItems.satellite, 1, EnumSatType.MINER_LUNAR.ordinal())) + ".name"),
-				new ChatComponentTranslation("satellite.minerprogress", progress + "%")
+				this.requestableSlots.length > 0 ? new ChatComponentTranslation("satellite.ready") : new ChatComponentTranslation("satellite.minerprogress", progress + "%")
 		};
 	}
 	

--- a/src/main/java/com/hbm/saveddata/satellites/SatelliteMiner.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatelliteMiner.java
@@ -35,7 +35,7 @@ public class SatelliteMiner extends SatelliteBase {
 		
 		return new IChatComponent[] {
 				new ChatComponentTranslation(ModItems.satellite.getUnlocalizedName(new ItemStack(ModItems.satellite, 1, EnumSatType.MINER_ASTRO.ordinal())) + ".name"),
-				new ChatComponentTranslation("satellite.minerprogress", progress + "%")
+				this.requestableSlots.length > 0 ? new ChatComponentTranslation("satellite.ready") : new ChatComponentTranslation("satellite.minerprogress", progress + "%")
 		};
 	}
 


### PR DESCRIPTION
Shows READY when asteroid or lunar miner cargo is waiting for delivery. Cargo pods now explode when colliding with blocks other than a Cargo Landing Pad instead of treating obstacles as valid landing surfaces.

Fixes #3242